### PR TITLE
docs(readme): Update getting started section w.r.t devenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 2. Install Direnv and [hook it](https://direnv.net/docs/hook.html) with your shell
 3. Manually enter the dev shell to accept the suggested Nix substituters:
    ```
-   nix develop
+   nix develop --impure
    do you want to [..] (y/N)? # answer "y" to all questions like this
    ```
 4. Allow direnv to automatically manage your shell environment


### PR DESCRIPTION
[devenv][0]'s flake module [requires access][2] to environment variables like [`PWD`][1] to determine the current project directory, which are not accessible in pure evaluation mode.

We already [updated][3] the dirnev config (`.envrc`) file and GitHub Actions CI pipeline config to account for that, but we missed the docs - this PR fixes that.

[0]: https://devenv.sh/
[1]: https://github.com/cachix/devenv/blob/v1.0.3/src/modules/top-level.nix#L156
[2]: https://github.com/cachix/devenv/blob/v1.0.3/src/modules/top-level.nix#L212-L219
[3]: https://github.com/blocksense-network/blocksense/pull/10/commits/b536b40b3a1eda94390e72e1b65aaaa0f44ecdc1