### PR TITLE
ci(gh-actions): Change command run by the lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: nix build --impure .#devShells.x86_64-linux.default
 
       - name: Check formatting
-        run: nix develop --impure -c npm run format:write
+        run: nix develop --impure -c npm run format:check
 
   hardhat:
     timeout-minutes: 360


### PR DESCRIPTION
`format:write` won't error in case any files were formatted, unlike `format:check`, which is intended exactly for this purpose.

https://github.com/blocksense-network/blocksense/blob/69afd5417d2b5ec4e2ee6838e5919cf907f37fbe/package.json#L9-L10