### PR TITLE
(docs.ws): Add Architecture sidebar section to the Blocksense documentation website

### DIFF
--- a/apps/docs.blocksense.network/pages/docs/_meta.json
+++ b/apps/docs.blocksense.network/pages/docs/_meta.json
@@ -1,5 +1,6 @@
 {
   "overview": "Overview",
+  "architecture": "Architecture",
   "contracts": "Contracts",
   "contribution": "How to Contribute"
 }

--- a/apps/docs.blocksense.network/pages/docs/architecture/_meta.json
+++ b/apps/docs.blocksense.network/pages/docs/architecture/_meta.json
@@ -1,0 +1,6 @@
+{
+  "index": "Overview",
+  "reporter": "Reporter",
+  "sequencer": "Sequencer",
+  "blockchain-integration": "Blockchain integration"
+}

--- a/apps/docs.blocksense.network/pages/docs/architecture/blockchain-integration.mdx
+++ b/apps/docs.blocksense.network/pages/docs/architecture/blockchain-integration.mdx
@@ -1,0 +1,1 @@
+# Blockchain Integration

--- a/apps/docs.blocksense.network/pages/docs/architecture/index.mdx
+++ b/apps/docs.blocksense.network/pages/docs/architecture/index.mdx
@@ -1,0 +1,1 @@
+# Introduction

--- a/apps/docs.blocksense.network/pages/docs/architecture/reporter.mdx
+++ b/apps/docs.blocksense.network/pages/docs/architecture/reporter.mdx
@@ -1,0 +1,1 @@
+# Reporter

--- a/apps/docs.blocksense.network/pages/docs/architecture/sequencer.mdx
+++ b/apps/docs.blocksense.network/pages/docs/architecture/sequencer.mdx
@@ -1,0 +1,1 @@
+# Sequencer


### PR DESCRIPTION
The primary goal of this task is to add `Architecture` page to the sidebar, as part of the Blocksense network documentation website.