### PR TITLE
fix(docs.ws): Fix all nested elements inside code blocks should be inline displayed

### DIFF
--- a/apps/docs.blocksense.network/globals.css
+++ b/apps/docs.blocksense.network/globals.css
@@ -34,3 +34,7 @@ span {
     @apply text-slate-800;
   }
 }
+
+code > span > span {
+  display: inline;
+}


### PR DESCRIPTION
We need to ensure that the `code` snippets will flow inline without breaking the layout. In terms of code examples or inline documentation formatting consistency is crucial.