### PR TITLE
Add unit tests to await_end_of_current_slot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,7 @@ libs/*/target/
 # Vercel build output
 .vercel
 _vercel-deployment-url
+
+# RustRover
+.idea/
+

--- a/apps/sequencer/src/feeds/feed_slots_manager.rs
+++ b/apps/sequencer/src/feeds/feed_slots_manager.rs
@@ -29,7 +29,9 @@ impl FeedSlotsManager {
                 FeedSlotTimeTracker::new(report_interval_ms, first_report_start_time);
 
             loop {
-                feed_slots_time_tracker.await_end_of_current_slot().await;
+                feed_slots_time_tracker
+                    .await_end_of_current_slot(get_ms_since_epoch)
+                    .await;
 
                 let result_post_to_contract: String;
                 let key_post: u32;


### PR DESCRIPTION
- Refactor await_end_of_current_slot to make it easier to test.
- Add unit tests for the logic

This PR increases the Sequencer code coverage from 10.40% to 14.07%.