### PR TITLE
refactor(sequencer): Add unit tests for votes_result_batcher.rs

### DIFF
--- a/apps/sequencer/src/feeds/votes_result_batcher.rs
+++ b/apps/sequencer/src/feeds/votes_result_batcher.rs
@@ -89,3 +89,59 @@ pub async fn votes_result_batcher_loop<
         }
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::env;
+    use std::time::Duration;
+    use tokio::sync::mpsc;
+    use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+    use tokio::time;
+
+    #[actix_web::test]
+    async fn test_votes_result_batcher_loop() {
+        // Setup
+        let batch_size_env = "SEQUENCER_MAX_KEYS_TO_BATCH";
+        env::set_var(batch_size_env, "3");
+
+        let duration_env = "SEQUENCER_KEYS_BATCH_DURATION";
+        env::set_var(duration_env, "100");
+
+        let (vote_send, vote_recv): (
+            UnboundedSender<(&str, &str)>,
+            UnboundedReceiver<(&str, &str)>,
+        ) = mpsc::unbounded_channel();
+        let (batched_votes_send, mut batched_votes_recv): (
+            UnboundedSender<HashMap<&str, &str>>,
+            UnboundedReceiver<HashMap<&str, &str>>,
+        ) = mpsc::unbounded_channel();
+
+        super::votes_result_batcher_loop(vote_recv, batched_votes_send).await;
+
+        // Send test votes
+        let k1 = "test_key_1";
+        let v1 = "test_val_1";
+        vote_send.send((k1, v1)).unwrap();
+        let k2 = "test_key_2";
+        let v2 = "test_val_2";
+        vote_send.send((k2, v2)).unwrap();
+        let k3 = "test_key_3";
+        let v3 = "test_val_3";
+        vote_send.send((k3, v3)).unwrap();
+        let k4 = "test_key_4";
+        let v4 = "test_val_4";
+        vote_send.send((k4, v4)).unwrap();
+
+        // Wait for a while to let the loop process the message
+        time::sleep(Duration::from_millis(1000)).await;
+        assert_eq!(batched_votes_recv.len(), 2);
+
+        // Validate
+        if let Some(batched) = batched_votes_recv.recv().await {
+            assert_eq!(batched.len(), 3);
+        } else {
+            panic!("Batched votes were not received");
+        }
+    }
+}

--- a/nix/shells/pkg-sets/rust.nix
+++ b/nix/shells/pkg-sets/rust.nix
@@ -10,5 +10,6 @@
     ++ (with pkgs; [
       openssl
       pkg-config
+      cargo-tarpaulin
     ]);
 }


### PR DESCRIPTION
Add unit test to module votes_result_batcher.rs.
Increases Sequencer test coverage from 9.53% to 15.88%.