### PR TITLE
refactor(sequencer): Add unit tests to module providers/provider.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7892,6 +7892,7 @@ dependencies = [
  "reqwest 0.12.4",
  "serde 1.0.203",
  "serde_json",
+ "tempfile",
  "tokio 1.37.0",
  "tracing",
  "tracing-subscriber",

--- a/apps/sequencer/Cargo.toml
+++ b/apps/sequencer/Cargo.toml
@@ -67,6 +67,7 @@ futures-util = "0.3.30"
 rand = "0.8.5"
 prometheus = "0.13.4"
 paste = "1.0.15"
+tempfile = "3.10.1"
 
 [[bin]]
 name = "sequencer"


### PR DESCRIPTION
- Increases Sequencer test coverage from around 15% to around 25%
- Adds unit tests to module providers/provider.rs
- Removes ignore from basic_test_provider
- Comments out two unused utility functions