### PR TITLE
Fix the misaligned Node Alignment and Custom Titles in graph TD

### DIFF
--- a/apps/docs.blocksense.network/pages/docs/contracts/index.mdx
+++ b/apps/docs.blocksense.network/pages/docs/contracts/index.mdx
@@ -50,10 +50,10 @@ config:
     signalTextColor: "#808080"
 ---
 graph TD
-    classDef clientNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888,width:180px;
-    classDef feedNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888,width:200px;
-    classDef proxyNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888,width:200px;
-    classDef dataNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888,width:300px;
+    classDef clientNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem;
+    classDef feedNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem;
+    classDef proxyNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem;
+    classDef dataNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem;
 
     linkStyle default fill:none,stroke-width:1px,stroke:#1c1917
 


### PR DESCRIPTION
Small change in the global.css file for styling the Mermaid diagram of our Smart Contract Architecture.

We [recently noticed](https://github.com/blocksense-network/blocksense/pull/139#issuecomment-2213488277) that it was broken