### PR TITLE
Update the sidebar for the Nextra theme to fix all text

### DIFF
--- a/libs/docs-theme/src/components/sidebar.tsx
+++ b/libs/docs-theme/src/components/sidebar.tsx
@@ -413,7 +413,7 @@ export function Sidebar({
           'md:nx-top-16 md:nx-shrink-0 motion-reduce:nx-transform-none',
           'nx-transform-gpu nx-transition-all nx-ease-in-out',
           'print:nx-hidden',
-          showSidebar ? 'md:nx-w-64' : 'md:nx-w-20',
+          showSidebar ? 'md:nx-w-66' : 'md:nx-w-20',
           asPopover ? 'md:nx-hidden' : 'md:nx-sticky md:nx-self-start',
           menu
             ? 'max-md:[transform:translate3d(0,0,0)]'

--- a/libs/docs-theme/src/nx-utilities/nx-dimensions.css
+++ b/libs/docs-theme/src/nx-utilities/nx-dimensions.css
@@ -63,6 +63,9 @@
 .nx-w-64 {
   width: 16rem;
 }
+.nx-w-66 {
+  width: 16.5rem;
+}
 .nx-w-8 {
   width: 2rem;
 }


### PR DESCRIPTION
The current sidebar in the Nextra theme does not adequately accommodate the length of its text, if its too long.

It leads to a sub-optimal UX The sidebar's width should be adjusted to ensure that all text is fully visible without truncation, wrapping or scrolling.