### PR TITLE
[CI]: Add Vercel deployment steps for prod and preview environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,10 +202,20 @@ jobs:
       - name: Pull Vercel configuration
         run: yarn vercel link --scope blocksense --project docs.blocksense.network --yes --token ${{ secrets.vercel_token }}
 
-      - name: Vercel Build
+      - name: Vercel Build - Prod
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        run: yarn vercel build --prod --yes --token ${{ secrets.vercel_token }}
+
+      - name: Vercel Build - Preview
+        if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
         run: yarn vercel build --yes --token ${{ secrets.vercel_token }}
 
-      - name: Deploy to Vercel
+      - name: Deploy to Vercel - Prod
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        run: yarn vercel deploy --prod --prebuilt --scope blocksense --token ${{ secrets.vercel_token }} > _vercel-deployment-url
+
+      - name: Deploy to Vercel - Preview
+        if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
         run: yarn vercel deploy --prebuilt --scope blocksense --token ${{ secrets.vercel_token }} > _vercel-deployment-url
 
       - name: Read deployment URL


### PR DESCRIPTION
#### Summary
This PR updates the GitHub Actions workflow to include steps for building and deploying to Vercel. The workflow is configured to handle both production and preview deployments based on the branch being pushed. 

Preview is what we had so far; this commit additionally adds Prod

#### Changes
- **Vercel Build Steps:**
  - Build for production if the branch is the default branch - `main`.
  - Build for preview if the branch is not the default branch - `main`.
  
- **Vercel Deployment Steps:**
  - Deploy to production if the branch is the default branch - `main`.
  - Deploy to preview if the branch is not the default branch - `main`.