### PR TITLE
[CI]: Update PR comment with Vercel deployment URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,14 +225,8 @@ jobs:
           echo "::set-output name=deploymentUrl::${deploymentUrl}"
 
       - name: Comment on the PR
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_NUMBER=$(jq --raw-output .number "$GITHUB_EVENT_PATH")
-          DEPLOYMENT_URL=${{ steps.read-deployment-url.outputs.deploymentUrl }}
-          COMMENT_BODY="Deployed to ${DEPLOYMENT_URL}"
-          curl -s -L \
-            -X POST \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -d "{\"body\": \"${COMMENT_BODY}\"}" \
-            https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments
+        uses: marocchino/sticky-pull-request-comment@v2.9.0
+        with:
+          recreate: true
+          message: |
+            Deployed to ${{ steps.read-deployment-url.outputs.deploymentUrl }} 🌱


### PR DESCRIPTION
#### Summary
This PR refactors the CI workflow to enhance the way deployment information is communicated in pull requests. It implements the `marocchino/sticky-pull-request-comment` action to post and update a single comment with the deployment URL from Vercel.

#### Changes
- **Integrated `marocchino/sticky-pull-request-comment` action**:
  - Posts a comment with the deployment URL to the pull request.
  - Updates the same comment with each subsequent deployment, rather than creating a new comment each time.

- **Benefits**:
  - Keeps the conversation section of the pull request cleaner by reducing comment clutter.
  - Ensures that the latest deployment information is always easily accessible in the updated comment.