### PR TITLE
[sol-reflector] Fix missing `functionSelector` field

### DIFF
--- a/libs/sol-reflector/src/types.ts
+++ b/libs/sol-reflector/src/types.ts
@@ -149,14 +149,14 @@ export class EventDocItem {
 export class FunctionDocItem {
   name: string = '';
   kind: FunctionType = 'function';
-  functionSelector?: string;
+  functionSelector: string = '';
   signature?: string;
   visibility: Visibility = 'external';
   stateMutability: StateMutability = 'payable';
   virtual: boolean = true;
   _parameters?: VariableDocItem[];
   _returnParameters?: VariableDocItem[];
-  _modifiers: FunctionModifierDocItem[] = [];
+  _modifiers?: FunctionModifierDocItem[];
   natspec: NatSpec = {};
 }
 


### PR DESCRIPTION
This change is necessary because `FunctionDocItem` is a class, and the constructor needs to know how to handle the `functionSelector` field when it's called. For more details on why this is essential, please refer to the [`extractFields`](https://github.com/blocksense-network/blocksense/blob/main/libs/sol-reflector/src/utils/common.ts#L139) function.

The change of  `_modifiers` follows the same logic but in the opposite direction. It's included in this commit because it's too small a change to live on its own