### PR TITLE
[docs.ws]: Rearrange declaration kind order

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/Contracts.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Contracts.tsx
@@ -26,17 +26,17 @@ export const Contracts = ({ contracts }: ContractsProps) => {
         return (
           <div className="contract-item-wrapper__item" key={index}>
             <ContractBaseInfo {...contract} />
-            <Functions functions={contract.functions} />
-            <Errors errors={contract.errors} />
-            <Events events={contract.events} />
-            <Modifiers modifiers={contract.modifiers} />
+            <Enums enums={contract.enums} />
+            <Structs structs={contract.structs} />
             <Variables
               variables={contract.variables}
               title="Variables"
               titleLevel={3}
             />
-            <Enums enums={contract.enums} />
-            <Structs structs={contract.structs} />
+            <Errors errors={contract.errors} />
+            <Events events={contract.events} />
+            <Modifiers modifiers={contract.modifiers} />
+            <Functions functions={contract.functions} />
           </div>
         );
       })}

--- a/apps/docs.blocksense.network/components/sol-contracts/SourceUnit.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/SourceUnit.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { SourceUnitDocItem } from '@blocksense/sol-reflector';
 
@@ -27,16 +27,16 @@ export const SourceUnit = ({
         <License license={sourceUnit.license} />
         <Pragmas pragmas={sourceUnit.pragmas} />
       </section>
-      <Contracts contracts={sourceUnit.contracts} />
       <Enums enums={sourceUnit.enums} isFromSourceUnit />
-      <Errors errors={sourceUnit.errors} isFromSourceUnit />
-      <Functions functions={sourceUnit.functions} isFromSourceUnit />
       <Structs structs={sourceUnit.structs} isFromSourceUnit />
       <Variables
         variables={sourceUnit.variables}
         title="Variables"
         titleLevel={2}
       />
+      <Errors errors={sourceUnit.errors} isFromSourceUnit />
+      <Functions functions={sourceUnit.functions} isFromSourceUnit />
+      <Contracts contracts={sourceUnit.contracts} />
     </section>
   );
 };


### PR DESCRIPTION
Used this structure to rearrange declaration kind order in `SoureUnit` and `Contracts`:

- Enum
- Struct
- Variables
- Errors
- Events
- Modifiers
- Functions