### PR TITLE
[docs.ws]: Show the name of each contract instead of just the first one

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/ContractBaseInfo.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/ContractBaseInfo.tsx
@@ -10,45 +10,48 @@ import {
 } from '@/components/ui/card';
 
 import { NatSpec } from '@/sol-contracts-components/NatSpec';
+import { AnchorLinkTitle } from '@/sol-contracts-components/AnchorLinkTitle';
 
 export const ContractBaseInfo = ({ ...contract }: ContractDocItem) => {
   return (
-    <div className="contract-base-info bg-gray-50 py-3 lg:px-6  mt-6 flex items-start space-y-4">
-      <Card className="contract-base-info__card w-full bg-white shadow-md rounded-lg mt-4 mb-4 py-3 px-3">
-        <CardHeader className="contract-base-info__header">
-          <CardDescription className="contract-base-info__description bg-gray-50 rounded-lg font-bold px-3 py-2 flex items-center">
-            <span className="contract-base-info__kind text-base text-black">
-              Kind: {contract.contractKind}
-            </span>
-            <span className="contract-base-info__abstract__abstract ml-4 text-base text-black">
-              Abstract: {contract.abstract.toString()}
-            </span>
-          </CardDescription>
-        </CardHeader>
-
-        {contract._baseContracts.length > 0 && (
-          <CardContent className="contract-base-info__content">
-            <div className="contract-base-info__base-contracts">
-              <span className="contract-base-info__base-contracts-title text-xl font-semibold text-gray-800 ml-4">
-                Base Contracts
+    <>
+      <AnchorLinkTitle title={contract.name} titleLevel={2} />
+      <div className="contract-base-info bg-gray-50 py-3 lg:px-6  mt-6 flex items-start space-y-4">
+        <Card className="contract-base-info__card w-full bg-white shadow-md rounded-lg mt-4 mb-4 py-3 px-3">
+          <CardHeader className="contract-base-info__header">
+            <CardDescription className="contract-base-info__description bg-gray-50 rounded-lg font-bold px-3 py-2 flex items-center">
+              <span className="contract-base-info__kind text-base text-black">
+                Kind: {contract.contractKind}
               </span>
-              <ul className="contract-base-info__base-contracts-list ml-6 mt-2 list-disc list-inside text-gray-700">
-                {contract._baseContracts.map(baseContract => (
-                  <li
-                    className="contract-base-info__base-contracts-item"
-                    key={baseContract}
-                  >
-                    {baseContract}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </CardContent>
-        )}
-        <CardFooter>
-          <NatSpec natspec={contract.natspec} />
-        </CardFooter>
-      </Card>
-    </div>
+              <span className="contract-base-info__abstract__abstract ml-4 text-base text-black">
+                Abstract: {contract.abstract.toString()}
+              </span>
+            </CardDescription>
+          </CardHeader>
+          {contract._baseContracts.length > 0 && (
+            <CardContent className="contract-base-info__content">
+              <div className="contract-base-info__base-contracts">
+                <span className="contract-base-info__base-contracts-title text-xl font-semibold text-gray-800 ml-4">
+                  Base Contracts
+                </span>
+                <ul className="contract-base-info__base-contracts-list ml-6 mt-2 list-disc list-inside text-gray-700">
+                  {contract._baseContracts.map(baseContract => (
+                    <li
+                      className="contract-base-info__base-contracts-item"
+                      key={baseContract}
+                    >
+                      {baseContract}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </CardContent>
+          )}
+          <CardFooter>
+            <NatSpec natspec={contract.natspec} />
+          </CardFooter>
+        </Card>
+      </div>
+    </>
   );
 };

--- a/apps/docs.blocksense.network/components/sol-contracts/Contracts.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Contracts.tsx
@@ -17,11 +17,7 @@ type ContractsProps = {
 
 export const Contracts = ({ contracts }: ContractsProps) => {
   return (
-    <ContractItemWrapper
-      title={contracts?.[0]?.name ?? ''}
-      titleLevel={2}
-      itemsLength={contracts?.length}
-    >
+    <ContractItemWrapper itemsLength={contracts?.length}>
       {contracts?.map((contract, index) => {
         return (
           <div className="contract-item-wrapper__item" key={index}>


### PR DESCRIPTION
Show each contract name in `ContractBaseInfo` with `AnchorLinkTitle` from one source unit instead of just the first one in `ContractItemWrapper`, so that way we can visualise and see all contract names and not just the first one.
