### PR TITLE
(docs.ws): Update the UI of all Variables to look like functions

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/Variables.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Variables.tsx
@@ -1,26 +1,11 @@
 import * as React from 'react';
-import { Button } from '@/components/ui/button';
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
-  DrawerTrigger,
-} from '@/components/ui/drawer';
+import { Badge } from '@/components/ui/badge';
+
 import { VariableDocItem } from '@blocksense/sol-reflector';
-import {
-  Table,
-  TableBody,
-  TableCaption,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
 import { ContractItemWrapper } from '@/sol-contracts-components/ContractItemWrapper';
+import { Signature } from '@/sol-contracts-components/Signature';
+import { NatSpec } from '@/sol-contracts-components/NatSpec';
+import { AnchorLinkTitle } from './AnchorLinkTitle';
 
 type VariablesProps = {
   variables?: VariableDocItem[];
@@ -35,131 +20,22 @@ export const Variables = ({ variables, title, titleLevel }: VariablesProps) => {
       title={title}
       titleLevel={titleLevel}
     >
-      <Table className="variables__table">
-        <TableCaption className="variables__table-caption">
-          {title}
-        </TableCaption>
-        <TableHeader className="variables__table-header">
-          <TableRow className="variables__table-header-row">
-            <TableHead className="variables__table-head">Name</TableHead>
-            <TableHead className="variables__table-head">Type</TableHead>
-            <TableHead className="variables__table-head">Mutability</TableHead>
-            <TableHead className="variables__table-head">Indexed</TableHead>
-            <TableHead className="variables__table-head">Constant</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody className="variables__table-body">
-          {variables?.map((variable, index) => (
-            <TableRow className="variables__table-row" key={index}>
-              <TableCell className="variables__table-cell variables__table-cell--name">
-                <Drawer>
-                  <DrawerTrigger asChild>
-                    <Button
-                      variant="secondary"
-                      className="variables__button font-bold min-w-[140px]"
-                    >
-                      {variable.name ? variable.name : 'unnamed'}
-                    </Button>
-                  </DrawerTrigger>
-                  <DrawerContent className="variables__drawer-content">
-                    <div className="mx-auto">
-                      <DrawerHeader className="variables__drawer-header">
-                        <DrawerTitle className="variables__drawer-title">
-                          Variable Details
-                        </DrawerTitle>
-                        <DrawerDescription className="variables__drawer-description">
-                          Details of the selected variable.
-                        </DrawerDescription>
-                      </DrawerHeader>
-                      <div className="mt-0 mb-6">
-                        <div className="overflow-x-auto">
-                          <Table className="variables__table min-w-full">
-                            <TableCaption className="variables__table-caption">
-                              {title}
-                            </TableCaption>
-                            <TableHeader className="variables__table-header">
-                              <TableRow className="variables__table-header-row">
-                                <TableHead className="variables__table-head">
-                                  Name
-                                </TableHead>
-                                <TableHead className="variables__table-head">
-                                  Type Identifier
-                                </TableHead>
-                                <TableHead className="variables__table-head">
-                                  Type
-                                </TableHead>
-                                <TableHead className="variables__table-head">
-                                  Mutability
-                                </TableHead>
-                                <TableHead className="variables__table-head">
-                                  Value
-                                </TableHead>
-                                <TableHead className="variables__table-head">
-                                  Indexed
-                                </TableHead>
-                                <TableHead className="variables__table-head">
-                                  Constant
-                                </TableHead>
-                              </TableRow>
-                            </TableHeader>
-                            <TableBody className="variables__table-body">
-                              <TableRow className="variables__table-row">
-                                <TableCell className="variables__table-cell variables__table-cell--name">
-                                  {variable.name ? variable.name : 'unnamed'}
-                                </TableCell>
-                                <TableCell className="variables__table-cell variables__table-cell--type">
-                                  {variable.typeDescriptions.typeIdentifier}
-                                </TableCell>
-                                <TableCell className="variables__table-cell variables__table-cell--type">
-                                  {variable.typeDescriptions.typeString}
-                                </TableCell>
-                                <TableCell className="variables__table-cell variables__table-cell--mutability">
-                                  {variable.mutability}
-                                </TableCell>
-                                <TableCell className="variables__table-cell variables__table-cell--value">
-                                  {variable._value}
-                                </TableCell>
-                                <TableCell className="variables__table-cell variables__table-cell--indexed">
-                                  {variable.indexed.toString()}
-                                </TableCell>
-                                <TableCell className="variables__table-cell variables__table-cell--constant">
-                                  {variable.constant.toString()}
-                                </TableCell>
-                              </TableRow>
-                            </TableBody>
-                          </Table>
-                        </div>
-                      </div>
-                      <DrawerFooter className="variables__drawer-footer hidden">
-                        <DrawerClose asChild>
-                          <Button
-                            variant="outline"
-                            className="variables__button"
-                          >
-                            Close
-                          </Button>
-                        </DrawerClose>
-                      </DrawerFooter>
-                    </div>
-                  </DrawerContent>
-                </Drawer>
-              </TableCell>
-              <TableCell className="variables__table-cell variables__table-cell--type">
-                {variable.typeDescriptions.typeString}
-              </TableCell>
-              <TableCell className="variables__table-cell variables__table-cell--mutability">
-                {variable.mutability}
-              </TableCell>
-              <TableCell className="variables__table-cell variables__table-cell--indexed">
-                {variable.indexed.toString()}
-              </TableCell>
-              <TableCell className="variables__table-cell variables__table-cell--constant">
-                {variable.constant.toString()}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+      {variables?.map((variable, index) => (
+        <section
+          className="contract-item-wrapper__variable space-y-4"
+          key={index}
+        >
+          <AnchorLinkTitle
+            title={variable.name ? variable.name : 'unnamed'}
+            titleLevel={4}
+          />
+          <Badge className="contract-item-wrapper__variable-mutability">
+            <span>Mutability: {variable.mutability}</span>
+          </Badge>
+          <Signature signature={variable.signature} />
+          <NatSpec natspec={variable.natspec} />
+        </section>
+      ))}
     </ContractItemWrapper>
   );
 };


### PR DESCRIPTION
The purpose of this task is to update the layout of `Variables` layout to look like function definitions.
![image](https://github.com/user-attachments/assets/424a8cee-3b37-472e-a053-9c8381235230)
We're updating this layout in this task and if we need another components for this layout, we will implement it in separate task.
**Disclaimer**: With this PR we don't remove completely the drawer from shadcn, because we may evaluate it later in another layout onto the website. 