### PR TITLE
build(docs.ws): Unplug `next`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "dependenciesMeta": {
     "@openzeppelin/contracts@5.0.2": {
       "unplugged": true
+    },
+    "next@14.2.3": {
+      "unplugged": true
     }
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -484,6 +484,8 @@ __metadata:
   dependenciesMeta:
     "@openzeppelin/contracts@5.0.2":
       unplugged: true
+    next@14.2.3:
+      unplugged: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The `yarn workspace "@blocksense/docs.blocksense.network" build` command began failing unexpectedly. During the `Collecting page data` step of `next build`, we encountered the error: `Collecting page data for <any-of-the-sol-ref-doc-mdx-files> is still timing out after 2 attempts.` Strangely, this issue occurred even on branches where the command previously worked without any problems.

While debugging, we discovered that setting yarn's `nodeLinker` to `node-modules` prevented the issue. This led us to try unplugging `next`, which successfully resolved the problem.