### PR TITLE
refactor(sequencer): Add unit test to admin get_feed_id endpiont

### DIFF
--- a/apps/sequencer/tests/sequencer_config.json
+++ b/apps/sequencer/tests/sequencer_config.json
@@ -1,0 +1,12 @@
+{
+  "max_keys_to_batch": 1,
+  "keys_batch_duration": 500,
+  "providers": {
+  },
+  "feeds" : [
+    {"id": 0, "name": "DOGE/USD", "report_interval_ms": 60000, "first_report_start_time": {"secs_since_epoch":0, "nanos_since_epoch": 0}},
+    {"id": 1, "name": "BTS/USD", "report_interval_ms": 30000, "first_report_start_time": {"secs_since_epoch":0, "nanos_since_epoch": 0}},
+    {"id": 2, "name": "ETH/USD", "report_interval_ms": 60000, "first_report_start_time": {"secs_since_epoch":0, "nanos_since_epoch": 0}},
+    {"id": 3, "name": "SHIB/USD", "report_interval_ms": 20000, "first_report_start_time": {"secs_since_epoch":0, "nanos_since_epoch": 0}}
+  ]
+}


### PR DESCRIPTION
- Add unit test to endpoint /get_feed_report_interval/{feed_id}
- Make logging handler a singleton with lazy initialization so multiple tests can successfully go through that execution path.
- Add a tests sequencer_config.json with no providers.