### PR TITLE
Implement function parameters table with natspec desc

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/FunctionParameters.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/FunctionParameters.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import { NatSpec, VariableDocItem } from '@blocksense/sol-reflector';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { ContractItemWrapper } from '@/sol-contracts-components/ContractItemWrapper';
+
+type FunctionParametersProps = {
+  parameters?: VariableDocItem[];
+  title?: string;
+  titleLevel?: 4 | 5;
+  functionNatSpec: NatSpec;
+};
+
+type FunctionNatSpecParam = {
+  name?: string;
+  description: string;
+};
+
+function getFunctionParameterDetails(
+  functionNatSpecParams: FunctionNatSpecParam[],
+  parameterName: string,
+  index: number,
+): FunctionNatSpecParam {
+  if (parameterName) {
+    const parameter = functionNatSpecParams.find(
+      param => param.name === parameterName,
+    );
+    return {
+      name: parameterName,
+      description: parameter ? parameter.description : '-',
+    };
+  } else {
+    return {
+      name: functionNatSpecParams[index]?.name || 'unnamed',
+      description: functionNatSpecParams[index]?.description || '-',
+    };
+  }
+}
+
+function getParamsFromNatspec(paramKind: string, natspec: NatSpec) {
+  return (paramKind === 'Parameters' ? natspec.params : natspec.returns) || [];
+}
+
+export const FunctionParameters = ({
+  parameters,
+  title = '',
+  titleLevel,
+  functionNatSpec,
+}: FunctionParametersProps) => {
+  return (
+    <ContractItemWrapper
+      itemsLength={parameters?.length}
+      title={title}
+      titleLevel={titleLevel}
+    >
+      <Table className="variables__table">
+        <TableHeader className="variables__table-header">
+          <TableRow className="variables__table-header-row">
+            <TableHead className="variables__table-head">Type</TableHead>
+            <TableHead className="variables__table-head">Name</TableHead>
+            <TableHead className="variables__table-head">Description</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody className="variables__table-body">
+          {parameters?.map((parameter, index) => {
+            const functionNatSpecParams = getParamsFromNatspec(
+              title,
+              functionNatSpec,
+            );
+            const { name, description } = getFunctionParameterDetails(
+              functionNatSpecParams,
+              parameter.name,
+              index,
+            );
+
+            return (
+              <TableRow className="variables__table-row" key={index}>
+                <TableCell className="variables__table-cell variables__table-cell--type">
+                  {parameter.typeDescriptions.typeString}
+                </TableCell>
+                <TableCell className="variables__table-cell variables__table-cell--name">
+                  {name}
+                </TableCell>
+                <TableCell className="variables__table-cell variables__table-cell--description">
+                  {description}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </ContractItemWrapper>
+  );
+};

--- a/apps/docs.blocksense.network/components/sol-contracts/Functions.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Functions.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import { Badge } from '@/components/ui/badge';
 
-import { FunctionDocItem, FunctionType } from '@blocksense/sol-reflector';
+import { Badge } from '@/components/ui/badge';
+import { FunctionDocItem } from '@blocksense/sol-reflector';
 
 import { Signature } from '@/sol-contracts-components/Signature';
 import { FunctionModifiers } from '@/sol-contracts-components/FunctionModifiers';
 import { NatSpec } from '@/sol-contracts-components/NatSpec';
 import { ContractItemWrapper } from '@/sol-contracts-components/ContractItemWrapper';
-import { Variables } from '@/sol-contracts-components/Variables';
 import { Selector } from '@/sol-contracts-components/Selector';
-import { AnchorLinkTitle } from './AnchorLinkTitle';
+import { AnchorLinkTitle } from '@/sol-contracts-components/AnchorLinkTitle';
+import { FunctionParameters } from '@/sol-contracts-components/FunctionParameters';
 
 type FunctionsProps = {
   functions?: FunctionDocItem[];
@@ -44,15 +44,17 @@ export const Functions = ({ functions, isFromSourceUnit }: FunctionsProps) => {
           </Badge>
           <Signature signature={_function.signature} />
           <NatSpec natspec={_function.natspec} />
-          <Variables
-            variables={_function._parameters}
+          <FunctionParameters
+            parameters={_function._parameters}
             title="Parameters"
             titleLevel={isFromSourceUnit ? 4 : 5}
+            functionNatSpec={_function.natspec}
           />
-          <Variables
-            variables={_function._returnParameters}
+          <FunctionParameters
+            parameters={_function._returnParameters}
             title="Return Parameters"
             titleLevel={isFromSourceUnit ? 4 : 5}
+            functionNatSpec={_function.natspec}
           />
           <FunctionModifiers functionModifiers={_function._modifiers} />
         </div>


### PR DESCRIPTION
Implement a new component - `FunctionParameters` which is used in `Functions` for parameters and return parameters. It receives parameters and natspec from the function as a props and renders the type, name and description in the table. If there is no parameter, it is mapped with exact index from params array from function natspec, but if there is a name, only a description is retrieved from natspec with find method by name, when there is no name in the cell, "unnamed" is rendered and when the description is empty is "-".

![image](https://github.com/user-attachments/assets/16536ee4-984d-4889-b5e9-c0dc4d2daafe)
