### PR TITLE
Disable GitHub Workflow for build-and-install-plugin.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,8 +142,8 @@ jobs:
       - name: Run Cargo Clippy
         run: cargo clippy
 
-      - name: Build and install oracle trigger plugin
-        run: ./libs/sdk/build-and-install-plugin.sh
+      # - name: Build and install oracle trigger plugin
+      #   run: ./libs/sdk/build-and-install-plugin.sh
 
   rust-nix-build:
     timeout-minutes: 360


### PR DESCRIPTION
This is currently the slowest step in the build workflow at around 30 to 40 percent of the total time and it's related to a component not currently developed. 