### PR TITLE
feat(sequencer): Support writing to Event data feeds smart contract

### DIFF
--- a/apps/sequencer/src/feeds/feed_allocator.rs
+++ b/apps/sequencer/src/feeds/feed_allocator.rs
@@ -209,7 +209,7 @@ mod tests {
     #[test]
     fn test_allocation_get_free_index() {
         // setup
-        let allocator: Allocator = Allocator::new((1..=5));
+        let allocator: Allocator = Allocator::new(1..=5);
 
         // run
         let free_index = allocator.get_free_index();
@@ -227,7 +227,7 @@ mod tests {
         let voting_start_timestamp: DateTime<Utc> = Utc::now();
         let ten_seconds: TimeDelta = TimeDelta::new(10, 0).unwrap();
         let voting_end_timestamp: DateTime<Utc> = voting_start_timestamp.add(ten_seconds);
-        let mut allocator: Allocator = Allocator::new((1..=5));
+        let mut allocator: Allocator = Allocator::new(1..=5);
         let allocation1 = allocator.allocate(
             contract_address,
             number_of_slots,
@@ -254,7 +254,7 @@ mod tests {
     #[test]
     fn test_allocation_num_free_and_allocated_indexes() {
         // setup
-        let mut allocator: Allocator = Allocator::new((1..=5));
+        let mut allocator: Allocator = Allocator::new(1..=5);
 
         // assert
         assert_eq!(allocator.space_size(), 5);
@@ -327,7 +327,7 @@ mod tests {
         let voting_start_timestamp: DateTime<Utc> = Utc::now();
         let ten_seconds: TimeDelta = TimeDelta::new(10, 0).unwrap();
         let voting_end_timestamp: DateTime<Utc> = voting_start_timestamp.add(ten_seconds);
-        let mut allocator: Allocator = Allocator::new((1..=5));
+        let mut allocator: Allocator = Allocator::new(1..=5);
 
         // run
         let result = allocator.allocate(
@@ -351,7 +351,7 @@ mod tests {
         // Then allocator correctly returns expired slot.
 
         // setup
-        let mut allocator: Allocator = Allocator::new((1..=5));
+        let mut allocator: Allocator = Allocator::new(1..=5);
 
         // assert
         assert_eq!(allocator.space_size(), 5);

--- a/apps/sequencer/src/feeds/feed_slots_processor.rs
+++ b/apps/sequencer/src/feeds/feed_slots_processor.rs
@@ -159,7 +159,6 @@ mod tests {
     use std::sync::{Arc, RwLock};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
     use tokio::sync::mpsc::unbounded_channel;
-    use tokio::time::error::Elapsed;
 
     #[tokio::test]
     async fn test_feed_slots_processor_loop() {
@@ -223,7 +222,7 @@ mod tests {
 
         match received {
             Ok(Some((key, result))) => {
-                /// assert the received data
+                // assert the received data
                 assert_eq!(
                     key,
                     to_hex_string(feed_id.to_be_bytes().to_vec(), None),
@@ -309,7 +308,7 @@ mod tests {
 
         match received {
             Ok(Some((key, result))) => {
-                /// assert the received data
+                // assert the received data
                 assert_eq!(
                     key,
                     to_hex_string(feed_id.to_be_bytes().to_vec(), None),

--- a/apps/sequencer/src/feeds/feeds_registry.rs
+++ b/apps/sequencer/src/feeds/feeds_registry.rs
@@ -18,7 +18,7 @@ pub struct FeedMetaData {
     feed_type: Box<dyn FeedAggregate>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum Repeatability {
     Periodic, // Has infinite number of voting slots
     Oneshot,  // Has only one voting slot

--- a/apps/sequencer/src/feeds/votes_result_sender.rs
+++ b/apps/sequencer/src/feeds/votes_result_sender.rs
@@ -1,3 +1,4 @@
+use crate::feeds::feeds_registry::Repeatability::Periodic;
 use crate::providers::eth_send_utils::eth_batch_send_to_all_contracts;
 use crate::providers::provider::SharedRpcProviders;
 use actix_web::rt::spawn;
@@ -22,7 +23,9 @@ pub async fn votes_result_sender_loop<
                     info!("sending updates to contract:");
                     let providers_clone = providers.clone();
                     spawn(async move {
-                        match eth_batch_send_to_all_contracts(providers_clone, updates).await {
+                        match eth_batch_send_to_all_contracts(providers_clone, updates, Periodic)
+                            .await
+                        {
                             Ok(res) => info!("Sending updates complete {}.", res),
                             Err(err) => error!("ERROR Sending updates {}", err),
                         };

--- a/apps/sequencer/src/utils/time_utils.rs
+++ b/apps/sequencer/src/utils/time_utils.rs
@@ -54,7 +54,7 @@ impl SlotTimeTracker {
         let current_slot_start_time =
             self.start_time_ms + slot_number * self.slot_interval.as_millis();
         let current_slot_end_time = current_slot_start_time + self.slot_interval.as_millis();
-        let result_ms = (current_slot_end_time as i128 - current_time_as_ms as i128);
+        let result_ms = current_slot_end_time as i128 - current_time_as_ms as i128;
 
         trace!("current_time_as_ms      = {}", current_time_as_ms);
         trace!("slots_count             = {}", slot_number);

--- a/libs/sequencer_config/src/lib.rs
+++ b/libs/sequencer_config/src/lib.rs
@@ -18,6 +18,7 @@ pub struct Provider {
     pub private_key_path: String,
     pub url: String,
     pub contract_address: Option<String>,
+    pub event_contract_address: Option<String>,
     pub transcation_timeout_secs: u32,
 }
 
@@ -74,9 +75,45 @@ pub fn get_test_config_with_single_provider(
                 private_key_path: private_key_path.to_string(),
                 url: url.to_string(),
                 contract_address: None,
+                event_contract_address: None,
                 transcation_timeout_secs: 50,
             },
         )]),
+        feeds: Vec::new(),
+        reporters: Vec::new(),
+    }
+}
+
+pub fn get_test_config_with_multiple_providers(
+    provider_details: Vec<(&str, &str, &str)>,
+) -> SequencerConfig {
+    let mut providers = HashMap::new();
+
+    for (network, private_key_path, url) in provider_details {
+        let mut file = File::create(private_key_path)
+            .expect(format!("Could not create file {}", private_key_path).as_str());
+        file.write_all(b"0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356")
+            .expect(format!("Could not write to file {}", private_key_path).as_str());
+
+        providers.insert(
+            network.to_string(),
+            Provider {
+                private_key_path: private_key_path.to_string(),
+                url: url.to_string(),
+                contract_address: None,
+                event_contract_address: None,
+                transcation_timeout_secs: 50,
+            },
+        );
+    }
+
+    SequencerConfig {
+        main_port: 8877,
+        admin_port: 5556,
+        prometheus_port: 5555,
+        max_keys_to_batch: 1,
+        keys_batch_duration: 500,
+        providers,
         feeds: Vec::new(),
         reporters: Vec::new(),
     }


### PR DESCRIPTION
**Context**

Currently, when the Sequencer is configured and launched we provide the contract address for the smart contract that will receive the voting result. The assumption in the configuration format and the whole codebase is that there is only one smart contract that will receive the votes.

**Problem**

With the introduction of voting for sporting events we will also introduce a separate contract to receive the results for the sporting events while also keeping the original contract for pricing data feeds. This meen the Sequencer should now be able to send a voting result to one of several smart contracts.

**Solution**

We need to support multiple smart contracts in the configuration. 

For each data feed we still write to only one contract but not it will be one of several possible contracts.

