### PR TITLE
Update and reuse parameters table

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/Errors.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Errors.tsx
@@ -12,7 +12,7 @@ import { ErrorDocItem } from '@blocksense/sol-reflector';
 import { Signature } from '@/sol-contracts-components/Signature';
 import { NatSpec } from '@/sol-contracts-components/NatSpec';
 import { ContractItemWrapper } from '@/sol-contracts-components/ContractItemWrapper';
-import { Variables } from '@/sol-contracts-components/Variables';
+import { Parameters } from '@/sol-contracts-components/Parameters';
 import { Selector } from '@/sol-contracts-components/Selector';
 import { AnchorLinkTitle } from '@/sol-contracts-components/AnchorLinkTitle';
 import { useExpandCollapse } from '@/hooks/useExpandCollapse';
@@ -72,9 +72,8 @@ export const Errors = ({ errors, isFromSourceUnit }: ErrorsProps) => {
                 <Selector selector={error.errorSelector} />
                 <Signature signature={error.signature} />
                 <NatSpec natspec={error.natspec} />
-                <Variables
-                  variables={error._parameters}
-                  title="Parameters"
+                <Parameters
+                  parameters={error._parameters}
                   titleLevel={isFromSourceUnit ? 4 : 5}
                 />
               </AccordionContent>

--- a/apps/docs.blocksense.network/components/sol-contracts/Events.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Events.tsx
@@ -12,7 +12,7 @@ import { EventDocItem } from '@blocksense/sol-reflector';
 import { Signature } from '@/sol-contracts-components/Signature';
 import { NatSpec } from '@/sol-contracts-components/NatSpec';
 import { ContractItemWrapper } from '@/sol-contracts-components/ContractItemWrapper';
-import { Variables } from '@/sol-contracts-components/Variables';
+import { Parameters } from '@/sol-contracts-components/Parameters';
 import { Selector } from '@/sol-contracts-components/Selector';
 import { AnchorLinkTitle } from '@/sol-contracts-components/AnchorLinkTitle';
 import { useExpandCollapse } from '@/hooks/useExpandCollapse';
@@ -74,11 +74,7 @@ export const Events = ({ events }: EventsProps) => {
                   Anonymous: {event.anonymous.toString()}
                 </span>
                 <NatSpec natspec={event.natspec} />
-                <Variables
-                  variables={event._parameters}
-                  title="Parameters"
-                  titleLevel={4}
-                />
+                <Parameters parameters={event._parameters} />
               </AccordionContent>
             </AccordionItem>
           );

--- a/apps/docs.blocksense.network/components/sol-contracts/Functions.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Functions.tsx
@@ -16,7 +16,7 @@ import { FunctionModifiers } from '@/sol-contracts-components/FunctionModifiers'
 import { NatSpec } from '@/sol-contracts-components/NatSpec';
 import { ContractItemWrapper } from '@/sol-contracts-components/ContractItemWrapper';
 import { AnchorLinkTitle } from '@/sol-contracts-components/AnchorLinkTitle';
-import { FunctionParameters } from '@/sol-contracts-components/FunctionParameters';
+import { Parameters } from '@/sol-contracts-components/Parameters';
 import { useExpandCollapse } from '@/hooks/useExpandCollapse';
 
 type FunctionsProps = {
@@ -86,12 +86,11 @@ export const Functions = ({ functions, isFromSourceUnit }: FunctionsProps) => {
                 </Badge>
                 <Signature signature={_function.signature} />
                 <NatSpec natspec={_function.natspec} />
-                <FunctionParameters
+                <Parameters
                   parameters={_function._parameters}
-                  title="Parameters"
                   titleLevel={isFromSourceUnit ? 4 : 5}
                 />
-                <FunctionParameters
+                <Parameters
                   parameters={_function._returnParameters}
                   title="Return Parameters"
                   titleLevel={isFromSourceUnit ? 4 : 5}

--- a/apps/docs.blocksense.network/components/sol-contracts/Modifiers.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Modifiers.tsx
@@ -12,7 +12,7 @@ import { Signature } from '@/sol-contracts-components/Signature';
 import { ModifierDocItem } from '@blocksense/sol-reflector';
 import { NatSpec } from '@/sol-contracts-components/NatSpec';
 import { ContractItemWrapper } from '@/sol-contracts-components/ContractItemWrapper';
-import { Variables } from '@/sol-contracts-components/Variables';
+import { Parameters } from '@/sol-contracts-components/Parameters';
 import { useExpandCollapse } from '@/hooks/useExpandCollapse';
 import { AnchorLinkTitle } from '@/sol-contracts-components/AnchorLinkTitle';
 
@@ -72,11 +72,7 @@ export const Modifiers = ({ modifiers }: ModifiersProps) => {
                 </span>
                 <Signature signature={modifier.signature} />
                 <NatSpec natspec={modifier.natspec} />
-                <Variables
-                  variables={modifier?._parameters}
-                  title="Parameters"
-                  titleLevel={4}
-                />
+                <Parameters parameters={modifier?._parameters} />
               </AccordionContent>
             </AccordionItem>
           );

--- a/apps/docs.blocksense.network/components/sol-contracts/Parameters.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Parameters.tsx
@@ -12,17 +12,17 @@ import {
 
 import { ContractItemWrapper } from '@/sol-contracts-components/ContractItemWrapper';
 
-type FunctionParametersProps = {
+type ParametersProps = {
   parameters?: VariableDocItem[];
   title?: string;
   titleLevel?: 4 | 5;
 };
 
-export const FunctionParameters = ({
+export const Parameters = ({
   parameters,
-  title = '',
-  titleLevel,
-}: FunctionParametersProps) => {
+  title = 'Parameters',
+  titleLevel = 4,
+}: ParametersProps) => {
   return (
     <ContractItemWrapper
       itemsLength={parameters?.length}

--- a/apps/docs.blocksense.network/components/sol-contracts/Structs.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Structs.tsx
@@ -11,7 +11,7 @@ import { Label } from '@/components/ui/label';
 import { StructDocItem } from '@blocksense/sol-reflector';
 import { NatSpec } from '@/sol-contracts-components/NatSpec';
 import { ContractItemWrapper } from '@/sol-contracts-components/ContractItemWrapper';
-import { Variables } from '@/sol-contracts-components/Variables';
+import { Parameters } from '@/sol-contracts-components/Parameters';
 import { AnchorLinkTitle } from '@/sol-contracts-components/AnchorLinkTitle';
 import { useExpandCollapse } from '@/hooks/useExpandCollapse';
 
@@ -71,8 +71,8 @@ export const Structs = ({ structs, isFromSourceUnit }: StructsProps) => {
                   Visibility: {struct.visibility}
                 </span>
                 <NatSpec natspec={struct.natspec} />
-                <Variables
-                  variables={struct._members}
+                <Parameters
+                  parameters={struct._members}
                   title="Members"
                   titleLevel={isFromSourceUnit ? 4 : 5}
                 />


### PR DESCRIPTION
`FunctionParameters` -> `Parameters`
- shows and used in `function`, `error`, `struct`, `event`, and `modifier` parameters instead only `function`
- add default values

before:
![image](https://github.com/user-attachments/assets/6796c275-0a11-4e37-9a6b-1d682770855f)

after:
![image](https://github.com/user-attachments/assets/aa230323-5e1b-4df7-bec0-3e31cb3af916)
