### PR TITLE
[docs.ws]: Add additional props to parameters

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/Events.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Events.tsx
@@ -74,7 +74,10 @@ export const Events = ({ events }: EventsProps) => {
                   Anonymous: {event.anonymous.toString()}
                 </span>
                 <NatSpec natspec={event.natspec} />
-                <Parameters parameters={event._parameters} />
+                <Parameters
+                  parameters={event._parameters}
+                  columns={['type', 'name', 'indexed', 'description']}
+                />
               </AccordionContent>
             </AccordionItem>
           );

--- a/apps/docs.blocksense.network/components/sol-contracts/Functions.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Functions.tsx
@@ -89,11 +89,13 @@ export const Functions = ({ functions, isFromSourceUnit }: FunctionsProps) => {
                 <Parameters
                   parameters={_function._parameters}
                   titleLevel={isFromSourceUnit ? 4 : 5}
+                  columns={['type', 'name', 'dataLocation', 'description']}
                 />
                 <Parameters
                   parameters={_function._returnParameters}
                   title="Return Parameters"
                   titleLevel={isFromSourceUnit ? 4 : 5}
+                  columns={['type', 'name', 'dataLocation', 'description']}
                 />
                 <FunctionModifiers functionModifiers={_function._modifiers} />
               </AccordionContent>

--- a/apps/docs.blocksense.network/components/sol-contracts/Parameters.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Parameters.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { VariableDocItem } from '@blocksense/sol-reflector';
+
 import {
   Table,
   TableBody,
@@ -9,19 +10,59 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-
 import { ContractItemWrapper } from '@/sol-contracts-components/ContractItemWrapper';
+
+type Column =
+  | 'type'
+  | 'name'
+  | 'description'
+  | 'indexed'
+  | 'mutability'
+  | 'dataLocation';
 
 type ParametersProps = {
   parameters?: VariableDocItem[];
   title?: string;
   titleLevel?: 4 | 5;
+  columns?: Column[];
+};
+
+const columnNames = {
+  type: 'Type',
+  name: 'Name',
+  indexed: 'Indexed',
+  description: 'Description',
+  mutability: 'Mutability',
+  dataLocation: 'Data Location',
+};
+
+const getParameterValueByColumn = (
+  parameter: VariableDocItem,
+  column: string,
+) => {
+  switch (column) {
+    case 'type':
+      return parameter.typeDescriptions.typeString;
+    case 'name':
+      return parameter.name || parameter._natspecName || 'unnamed';
+    case 'indexed':
+      return parameter.indexed ? 'Yes' : 'No';
+    case 'description':
+      return parameter._natspecDescription || '-';
+    case 'mutability':
+      return parameter.mutability || '-';
+    // case 'dataLocation':
+    //   return parameter.dataLocation || '-';
+    default:
+      return '-';
+  }
 };
 
 export const Parameters = ({
   parameters,
   title = 'Parameters',
   titleLevel = 4,
+  columns = ['type', 'name', 'description'],
 }: ParametersProps) => {
   return (
     <ContractItemWrapper
@@ -32,23 +73,24 @@ export const Parameters = ({
       <Table className="variables__table mt-6 mb-4">
         <TableHeader className="variables__table-header">
           <TableRow className="variables__table-header-row">
-            <TableHead className="variables__table-head">Type</TableHead>
-            <TableHead className="variables__table-head">Name</TableHead>
-            <TableHead className="variables__table-head">Description</TableHead>
+            {columns.map(column => (
+              <TableHead className="variables__table-head" key={column}>
+                {columnNames[column]}
+              </TableHead>
+            ))}
           </TableRow>
         </TableHeader>
         <TableBody className="variables__table-body">
           {parameters?.map((parameter, index) => (
             <TableRow className="variables__table-row" key={index}>
-              <TableCell className="variables__table-cell variables__table-cell--type">
-                {parameter.typeDescriptions.typeString}
-              </TableCell>
-              <TableCell className="variables__table-cell variables__table-cell--name">
-                {parameter.name || parameter._natspecName || 'unnamed'}
-              </TableCell>
-              <TableCell className="variables__table-cell variables__table-cell--description">
-                {parameter._natspecDescription || '-'}
-              </TableCell>
+              {columns.map(column => (
+                <TableCell
+                  className={`variables__table-cell variables__table-cell--${column}`}
+                  key={column}
+                >
+                  {getParameterValueByColumn(parameter, column)}
+                </TableCell>
+              ))}
             </TableRow>
           ))}
         </TableBody>


### PR DESCRIPTION
Add additional property columns to the `Parameters` component which define what columns would be displayed in the table for each AST node kind: 

```
Events: ['type', 'name', 'isIndexed', 'description'] 
Errors: ['type', 'name', 'description'] 
function parameters: ['type', 'name', 'dataLocation', 'description'] 
function return parameters: ['type', 'name', 'dataLocation', 'description']
```