### PR TITLE
(docs.ws): Constants with large names are exceeding the viewport area and set undesired scroll

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/AnchorLinkTitle.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/AnchorLinkTitle.tsx
@@ -12,7 +12,7 @@ const titleStyles = {
   3: 'text-2xl',
   4: 'text-xl',
   5: 'text-lg',
-  6: 'text-base',
+  6: 'text-xxs sm:text-xs lg:text-base',
 };
 
 const accordionStyles = 'text-gray-900';

--- a/apps/docs.blocksense.network/globals.css
+++ b/apps/docs.blocksense.network/globals.css
@@ -295,6 +295,14 @@ main {
   .token.punctuation {
     color: var(--shiki-token-punctuation);
   }
+
+  .text-xxs {
+    font-size: 0.5rem;
+  }
+
+  .text-xs {
+    font-size: 0.7rem;
+  }
 }
 
 /* This is how we can adjust the Shiki Theme built in Nextra */


### PR DESCRIPTION
The purpose of this task is to avoid exceeding the accordion titles outside of the visible area.
In fact, the mail goal is to add the biggest size in rems that doesn't scroll outside of the visible screen. This should be the default and for **md** screens and above we may use the standart settings for h6.

Other than that it would be great if we may adjust additionally the typography for small screens, medium screens and large screens in a separate task.


Before:
![image](https://github.com/user-attachments/assets/7646712d-1e27-4129-845c-ebb030620f14)

After:
![image](https://github.com/user-attachments/assets/fad280ec-65d3-4ee6-ac28-c8b577419c90)
