### PR TITLE
(docs.ws): Move `Selector` to accordion title for each item

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/Errors.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Errors.tsx
@@ -65,11 +65,11 @@ export const Errors = ({ errors, isFromSourceUnit }: ErrorsProps) => {
                   title={error.name || `Error ${index + 1}`}
                   titleLevel={isFromSourceUnit ? 5 : 6}
                 />
+                <Selector selector={error.errorSelector} />
               </AccordionTrigger>
               <AccordionContent
                 className={`accordion-content ${accordionStates[id] ? 'expanded' : ''}`}
               >
-                <Selector selector={error.errorSelector} />
                 <Signature signature={error.signature} />
                 <NatSpec natspec={error.natspec} />
                 <Parameters

--- a/apps/docs.blocksense.network/components/sol-contracts/Events.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Events.tsx
@@ -64,11 +64,11 @@ export const Events = ({ events }: EventsProps) => {
                   title={event.name || `Event ${index + 1}`}
                   titleLevel={6}
                 />
+                <Selector selector={event.eventSelector} />
               </AccordionTrigger>
               <AccordionContent
                 className={`accordion-content ${accordionStates[id] ? 'expanded' : ''}`}
               >
-                <Selector selector={event.eventSelector} />
                 <Signature signature={event.signature} />
                 <span className="contract-item-wrapper__event-anonymous">
                   Anonymous: {event.anonymous.toString()}

--- a/apps/docs.blocksense.network/components/sol-contracts/Functions.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Functions.tsx
@@ -67,11 +67,11 @@ export const Functions = ({ functions, isFromSourceUnit }: FunctionsProps) => {
                   title={_function.name || _function.kind}
                   titleLevel={isFromSourceUnit ? 5 : 6}
                 />
+                <Selector selector={_function.functionSelector} />
               </AccordionTrigger>
               <AccordionContent
                 className={`accordion-content ${accordionStates[id] ? 'expanded' : ''}`}
               >
-                <Selector selector={_function.functionSelector} />
                 <Badge className="contract-item-wrapper__function-kind mb-4">
                   <span>Kind: {_function.kind}</span>
                 </Badge>

--- a/apps/docs.blocksense.network/components/sol-contracts/Selector.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Selector.tsx
@@ -11,10 +11,12 @@ export const Selector = ({ selector = '' }: SelectorProps) => {
 
   return (
     selector && (
-      <div className="flex gap-2 items-center">
-        <p className="bg-gray-200 p-1 rounded w-fit">{resultSelector}</p>
+      <aside className="selector-container flex flex-1 items-center justify-end p-2">
+        <p className="selector-container__text hidden 2xl:block bg-slate-100 px-2">
+          {resultSelector}
+        </p>
         <CopyButton textToCopy={resultSelector} />
-      </div>
+      </aside>
     )
   );
 };


### PR DESCRIPTION
The purpose of this item is to move selector to the accordion title wherever it exists. 
Some of the events have pretty long name so, for **xl** screens it's displayed in a normal way. 
For smaller screens is presented with a copy icon, without the exact value of the selector, because the layout will be broken for mobile devices and below.

**Before (xl, lg, md, sm, xs):**
![image](https://github.com/user-attachments/assets/141956cd-5271-4834-932d-0b3ec18b4fd3)

**Now:**
**xl:**
![image](https://github.com/user-attachments/assets/0aab93c4-0f43-4464-9b15-db0e38326f17)
**lg, md, sm, xs:**
![image](https://github.com/user-attachments/assets/6e19e477-0d74-4f62-893b-5badf852dc4c)
 