### PR TITLE
feat(base-utils): Init `@blocksense/base-utils` lib

### DIFF
--- a/libs/base-utils/package.json
+++ b/libs/base-utils/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@blocksense/base-utils",
+  "version": "0.0.0",
+  "keywords": [
+    "utils",
+    "helpers"
+  ],
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.ts",
+      "import": "./dist/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "ts": "yarn node --import tsx"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.13",
+    "tsx": "^4.7.1",
+    "typescript": "^5.4.5"
+  }
+}

--- a/libs/base-utils/src/index.ts
+++ b/libs/base-utils/src/index.ts
@@ -1,0 +1,1 @@
+console.log('Hello, @blocksense/base-utils!');

--- a/libs/base-utils/tsconfig.json
+++ b/libs/base-utils/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "strict": true,
+    "noImplicitAny": false,
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -359,6 +359,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@blocksense/base-utils@workspace:libs/base-utils":
+  version: 0.0.0-use.local
+  resolution: "@blocksense/base-utils@workspace:libs/base-utils"
+  dependencies:
+    "@types/node": "npm:^20.12.13"
+    tsx: "npm:^4.7.1"
+    typescript: "npm:^5.4.5"
+  languageName: unknown
+  linkType: soft
+
 "@blocksense/contracts@workspace:*, @blocksense/contracts@workspace:libs/contracts":
   version: 0.0.0-use.local
   resolution: "@blocksense/contracts@workspace:libs/contracts"


### PR DESCRIPTION
This PR introduces the new TypeScript library `@blocksense/base-utils`. This library is designed to host common code that can be shared and reused across different libraries within Blocksense. The main goal of `@blocksense/base-utils` is to provide a centralized repository for utility functions, types, and other common elements that can enhance code maintainability and reduce redundancy.
