### PR TITLE
LinkButtons are replaced with shadcn/ui Buttons

### DIFF
--- a/apps/docs.blocksense.network/components/common/Footer.tsx
+++ b/apps/docs.blocksense.network/components/common/Footer.tsx
@@ -12,10 +12,10 @@ export const Footer = () => {
     >
       <section className="footer__link-button nx-flex nx-items-center hover:nx-opacity-75 ltr:nx-mr-auto rtl:nx-ml-auto">
         <LinkButton
+          href={config.adoptersTextLink}
+          external
           label="Early Adopters"
-          link={config.adoptersTextLink}
-          target="_blank"
-        />
+        ></LinkButton>
       </section>
       <nav className="footer__social-nav flex items-center nx-justify-end">
         <ul className="footer__social-list flex gap-2 mr-6">

--- a/apps/docs.blocksense.network/components/common/LinkButton.tsx
+++ b/apps/docs.blocksense.network/components/common/LinkButton.tsx
@@ -6,7 +6,7 @@ interface ButtonProps {
   href?: string;
   external?: boolean;
   className?: string;
-  children?: React.ReactNode;
+  label?: string;
   asChild?: true;
 }
 
@@ -14,7 +14,7 @@ export const LinkButton = ({
   href,
   external = false,
   className,
-  children,
+  label,
 }: ButtonProps) => {
   const classes = `link_button me-2 mb-2 font-bold ${className} `;
 
@@ -22,10 +22,10 @@ export const LinkButton = ({
     <Button className={classes} asChild>
       {external ? (
         <a href={href} target="_blank" rel="noopener noreferrer">
-          {children}
+          {label}
         </a>
       ) : (
-        href && <Link href={href}>{children}</Link>
+        href && <Link href={href}>{label}</Link>
       )}
     </Button>
   );

--- a/apps/docs.blocksense.network/components/getting-started/GettingStarted.tsx
+++ b/apps/docs.blocksense.network/components/getting-started/GettingStarted.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { gettingStartedConfig } from '@/config';
-import { LinkButton } from '@/components/common/LinkButton';
 import { FigureBackdrop } from '@/components/common/FigureBackdrop';
+import { LinkButton } from '@/components/common/LinkButton';
 
 export const GettingStarted = () => {
   return (
@@ -17,10 +17,13 @@ export const GettingStarted = () => {
           </p>
           <span className="lg:ml-auto">
             <LinkButton
+              href="/docs/overview/getting-started"
               label="Get Started"
-              link="/docs/overview/getting-started"
-            />
-            <LinkButton label="Roadmap" link="/docs/overview/roadmap" />
+            ></LinkButton>
+            <LinkButton
+              href="/docs/overview/roadmap"
+              label="Roadmap"
+            ></LinkButton>
           </span>
         </article>
         <aside className="getting-started__image hidden lg:mt-0 lg:col-span-3 lg:flex">


### PR DESCRIPTION
We decided to migrate to `shadcn` (from `nextra`), so the next step of the migration are the buttons on the landing page.

Current `LinkButtons` are replaced with `shadcn/ui` `Buttons` from the Getting Started page.
The `LinkButton` component is deleted afterward, as it is no longer needed.