### PR TITLE
[base-utils/fs] Improve `selectDirectory`

### DIFF
--- a/apps/docs.blocksense.network/src/generate-contracts-mdx.ts
+++ b/apps/docs.blocksense.network/src/generate-contracts-mdx.ts
@@ -32,7 +32,7 @@ import { SourceUnit } from '@/sol-contracts-components/SourceUnit';
   return content;
 }
 
-function generateSolRefDocFiles(): Promise<void[]> {
+function generateSolRefDocFiles(): Promise<string[]> {
   const mdxFiles = solReflection.map(sourceUnit => ({
     name: path.parse(sourceUnit.absolutePath).name,
     content: generateMarkdownContent(sourceUnit),

--- a/libs/base-utils/src/fs.ts
+++ b/libs/base-utils/src/fs.ts
@@ -72,10 +72,14 @@ export function selectDirectory(baseDir: string) {
      * - **args.ext** - The file extension (if any) such as '.html'
      * - **args.name** - The file name without extension (if any) such as 'index'
      * - **args.content** - The content to be written to the file.
-     * @returns A promise that resolves when the file is written.
+     * @returns A promise that resolves with the file path of the written file.
      */
-    write: (args: FileArgs & { content: string }) =>
-      fs.writeFile(path.format({ dir: baseDir, ...args }), args.content),
+    write: (args: FileArgs & { content: string }) => {
+      const filePath = path.format({ dir: baseDir, ...args });
+      return fs.writeFile(filePath, args.content).then(() => {
+        return filePath;
+      });
+    },
 
     /**
      * Writes a JSON object to a file at the specified directory.
@@ -86,13 +90,16 @@ export function selectDirectory(baseDir: string) {
      * - **args.ext** - The file extension (if any) such as '.json'.  Defaults to '.json'.
      * - **args.name** - The file name without extension (if any) such as 'data'
      * - **args.content** - The JSON content to be written to the file.
-     * @returns A promise that resolves when the file is written.
+     * @returns A promise that resolves with the file path of the written file.
      */
-    writeJSON: (args: FileArgs & { content: Record<string, unknown> }) =>
-      fs.writeFile(
-        path.format({ dir: baseDir, ext: '.json', ...args }),
-        JSON.stringify(args.content, null, 2),
-      ),
+    writeJSON: (args: FileArgs & { content: Record<string, unknown> }) => {
+      const filePath = path.format({ dir: baseDir, ext: '.json', ...args });
+      return fs
+        .writeFile(filePath, JSON.stringify(args.content, null, 2))
+        .then(() => {
+          return filePath;
+        });
+    },
 
     /**
      * Reads content from a file at the specified directory.


### PR DESCRIPTION
Improvements:
* `readJSON` and `writeJSON` should default `ext` to `.json` (and allow to be overridden by the user)
*  Make sure the parameters of each of the `{read,write}{,JSON}` functions are displayed in intellisense
* Handle the existence of `baseDir`
* Return path of written files in `selectDirectory`