### PR TITLE
(docs.ws): Add copy-to-clipboard functionality to Signature component 

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/Signature.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Signature.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { codeToHtml } from 'shiki';
+import { CopyButton } from '@/components/common/CopyButton';
 
 type SignatureProps = {
   signature?: string;
@@ -9,18 +10,25 @@ export const Signature = ({ signature = '' }: SignatureProps) => {
   const [html, setHtml] = React.useState('');
 
   React.useEffect(() => {
-    codeToHtml(signature!, {
+    codeToHtml(signature, {
       lang: 'solidity',
       theme: 'material-theme-lighter',
     }).then((htmlString: any) => setHtml(htmlString));
-  }, []);
+  }, [signature]);
 
   return (
     signature && (
-      <div
-        className="signature__content border border-gray-800 mb-2 py-2"
-        dangerouslySetInnerHTML={{ __html: html }}
-      />
+      <section className="signature__container border border-gray-800 mb-2 px-0 py-2 rounded-md bg-slate-100">
+        <div className="signature__content flex justify-between items-start w-full">
+          <div
+            className="signature__code flex-grow mr-2"
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+          <aside className="signature__copy-button flex-shrink-0 mr-6">
+            <CopyButton textToCopy={signature} />
+          </aside>
+        </div>
+      </section>
     )
   );
 };


### PR DESCRIPTION
We need  `copy-to-clipboard` button added to `Signature.tsx` component, so the user will be able to copy and paste it to an editor.
We're reusing right now the `<CopyButton>` we already use for selectors.

As proposed earlier by @RadoslavDimchev it's great to try to reuse the existing snippets look and feel, coming from **nextra**, but they're primary designed to work with Nextra, based on it's needs, so it would be easier for us to reuse what we have in the scope of **docs.ws.** based on ours.

**Before:**
![image](https://github.com/user-attachments/assets/3659ea79-31b6-45b8-aa96-4072ffc5e37d)

**After:**
![image](https://github.com/user-attachments/assets/b94cd702-9204-4c57-bcaf-dabd22e7744f)

