### PR TITLE
Update unplugged `next` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@openzeppelin/contracts@5.0.2": {
       "unplugged": true
     },
-    "next@14.2.3": {
+    "next@14.2.5": {
       "unplugged": true
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -509,7 +509,7 @@ __metadata:
   dependenciesMeta:
     "@openzeppelin/contracts@5.0.2":
       unplugged: true
-    next@14.2.3:
+    next@14.2.5:
       unplugged: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Recently, we updated `next` via @dependabot in [this PR](https://github.com/blocksense-network/blocksense/pull/257). However, @dependabot did not update the unplugged version of `next`, which reintroduced a build issue.

To resolve this, we need to update the unplugged version of `next` to match the version currently used in the project.

For reference, see the related discussion in [this PR](https://github.com/blocksense-network/blocksense/pull/174).