### PR TITLE
(docs.ws): Separate FiraCode from SpaceMono explicitly

### DIFF
--- a/apps/docs.blocksense.network/components/common/Header.tsx
+++ b/apps/docs.blocksense.network/components/common/Header.tsx
@@ -4,7 +4,7 @@ import { config } from '@/config';
 export const Header = () => {
   return (
     <header className="header__media flex items-center z-50">
-      <span className="header-media__description font-mono-bold tracking-wide leading-normal text-[22px] text-gray-900">
+      <span className="header-media__description font-mono-space-bold tracking-wide leading-normal text-[22px] text-gray-900">
         {config.blocksenseText}
       </span>
     </header>

--- a/apps/docs.blocksense.network/tailwind.config.ts
+++ b/apps/docs.blocksense.network/tailwind.config.ts
@@ -93,14 +93,11 @@ const config = {
     fontFamily: {
       body: ['Inter', ...fallbackFonts],
       sans: ['Inter', ...fallbackFonts],
-      mono: ['Fira Code', 'Space Mono', ...fallbackFonts],
-      'mono-bold': ['Fira Code Bold', 'Space Mono Bold', ...fallbackFonts],
-      'mono-light': ['Fira Code Light', 'Space Mono Italic', ...fallbackFonts],
-      'mono-semibold': [
-        'Fira Code SemiBold',
-        'Space Mono BoldItalic',
-        ...fallbackFonts,
-      ],
+      mono: ['Fira Code', ...fallbackFonts],
+      'mono-space': ['Space Mono', ...fallbackFonts],
+      'mono-space-bold': ['Space Mono Bold', ...fallbackFonts],
+      'mono-space-italic': ['Space Mono Italic', ...fallbackFonts],
+      'mono-space-bold-italic': ['Space Mono BoldItalic', ...fallbackFonts],
       nerd: ['SpaceMono Nerd', 'Space Mono', ...fallbackFonts],
       'nerd-bold': ['SpaceMono Nerd Bold', 'Space Mono Bold', ...fallbackFonts],
       'nerd-italic': [


### PR DESCRIPTION
In reference to this [PR.](https://github.com/blocksense-network/blocksense/pull/249)
We’ve integrated [FiraCode](https://fonts.google.com/specimen/Fira+Code), as primary mono font, which beats with SpaceMono fonts.

Fonts we’re using right now:

* Inter - global one
* Mono font - [FiraCode](https://fonts.google.com/specimen/Fira+Code)
* Space Mono - `Blocksense` header title
* Space Mono Nerd - icons inside folder structure

We need to separate them more, so they won’t be overriding each other, when they are defined as fallbacks, as it is right now.

**Before** the fix in this PR:
![image](https://github.com/user-attachments/assets/a3b7251a-a269-46cb-8b39-4a4b7c587151)
**After** the fix in this PR:
![image](https://github.com/user-attachments/assets/92814042-daa7-4eed-848e-d305a1c9ccfa)

**Instructions** to test:

1. Inspect Blocksense Header in the browser and check it's font settings. They should be the following:
![image](https://github.com/user-attachments/assets/a0fd2d2e-8410-4465-b863-d3958d7f888b)
2. Inspect Code Snippets. They should be the following:
![image](https://github.com/user-attachments/assets/d3339239-3eb1-4faa-8be2-854b8ff858a8)
3. Everything from the body, should be using the Inter (body/sans), as before. 



