### PR TITLE
fix(sol-reflector): Add `;` in the end of signatures. Add signatures to structs & enums

### DIFF
--- a/libs/sol-reflector/src/types.ts
+++ b/libs/sol-reflector/src/types.ts
@@ -187,12 +187,14 @@ export class VariableDocItem {
 
 export class EnumDocItem {
   name: string = '';
+  signature?: string;
   _members: string[] = [];
   natspec: NatSpec = {};
 }
 
 export class StructDocItem {
   name: string = '';
+  signature?: string;
   visibility: Visibility = 'external';
   _members?: VariableDocItem[];
   natspec: NatSpec = {};

--- a/libs/sol-reflector/src/utils/convertors.ts
+++ b/libs/sol-reflector/src/utils/convertors.ts
@@ -190,6 +190,7 @@ function deriveEnums(node: ASTNode): EnumDocItem[] | undefined {
     (n, parsed) => {
       return {
         ...parsed,
+        signature: getSignature(n),
         _members: n.members.map((m: EnumDefinition) => m.name),
       };
     },
@@ -204,6 +205,7 @@ function deriveStructs(node: ASTNode): StructDocItem[] | undefined {
     (n, parsed) => {
       return {
         ...parsed,
+        signature: getSignature(n),
         _members: (
           n.members.filter(isVariableDeclaration) as VariableDeclaration[]
         ).map(e => {
@@ -293,6 +295,12 @@ function getSignature(node: ASTNode): string | undefined {
 
     case 'VariableDeclaration':
       return `${formatVariable(node)};`;
+
+    case 'EnumDefinition':
+      return `enum ${node.name} { ... };`;
+
+    case 'StructDefinition':
+      return `struct ${node.name} { ... };`;
 
     default:
       return undefined;


### PR DESCRIPTION
While working on  `[docs.ws]: Create contract overview` #226 noticed that we do not set `;` at the end of the signatures.
Also noticed that we do not have sugnatures for `structs`& `enums` so added a simple placeholder
```solidity
struct Example { ... };
enum Example { ... };
```

To see the result of the change, one can navigate to `libs/contracts`, run `yarn sol-reflect` and then examine the produced `fine.json` file

Example of a diff in `fine.json`:
Before:
```diff
- "signature": "function setFeed(address base, address quote, address feed) external",
+ "signature": "function setFeed(address base, address quote, address feed) external;",
```