### PR TITLE
[docs.ws]: Enhance `CodeBlock` with `CopyButton` and custom styling options

### DIFF
--- a/apps/docs.blocksense.network/components/common/CodeBlock.tsx
+++ b/apps/docs.blocksense.network/components/common/CodeBlock.tsx
@@ -1,16 +1,21 @@
 import React from 'react';
 import { codeToHtml } from 'shiki';
+import { CopyButton } from './CopyButton';
 
 type CodeBlockProps = {
   code: string;
+  precompiledHtml?: string;
   lang?: string;
   theme?: string;
+  copy?: boolean;
 };
 
-export const CodeBlock = ({
+// "JIT" in this context refers to the fact that the code block is not precompiled.
+const JitCodeBlock = ({
   code = '',
   lang = 'text',
   theme = 'material-theme-lighter',
+  copy = true,
 }: CodeBlockProps) => {
   const [html, setHtml] = React.useState('');
 
@@ -22,9 +27,58 @@ export const CodeBlock = ({
   }, [code]);
 
   return (
-    <div
-      className="signature__code flex-grow mr-2"
-      dangerouslySetInnerHTML={{ __html: html }}
+    <div className="relative">
+      {copy && (
+        <CopyButton
+          textToCopy={code}
+          tooltipPosition="left"
+          copyButtonClasses="absolute top-0 right-0 m-2 nx-z-10"
+        />
+      )}
+      <div
+        className="signature__code flex-grow"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </div>
+  );
+};
+
+const PrecompiledCodeBlock = ({
+  code = '',
+  precompiledHtml = '',
+  copy = true,
+}: CodeBlockProps) => {
+  return (
+    <div className="relative">
+      {copy && (
+        <CopyButton
+          textToCopy={code}
+          tooltipPosition="left"
+          copyButtonClasses="absolute top-0 right-0 m-2 nx-z-10"
+        />
+      )}
+      <div
+        className="signature__code flex-grow"
+        dangerouslySetInnerHTML={{ __html: precompiledHtml }}
+      />
+    </div>
+  );
+};
+
+export const CodeBlock = ({
+  code = '',
+  precompiledHtml = '',
+  lang = 'text',
+  theme = 'material-theme-lighter',
+  copy = true,
+}: CodeBlockProps) => {
+  return precompiledHtml ? (
+    <PrecompiledCodeBlock
+      code={code}
+      precompiledHtml={precompiledHtml}
+      copy={copy}
     />
+  ) : (
+    <JitCodeBlock code={code} lang={lang} theme={theme} copy={copy} />
   );
 };

--- a/apps/docs.blocksense.network/components/common/CopyButton.tsx
+++ b/apps/docs.blocksense.network/components/common/CopyButton.tsx
@@ -4,11 +4,13 @@ import { Tooltip } from '@/components/common/Tooltip';
 type CopyButtonProps = {
   textToCopy: string;
   tooltipPosition?: 'top' | 'right' | 'bottom' | 'left';
+  copyButtonClasses?: string;
 };
 
 export const CopyButton = ({
   textToCopy,
   tooltipPosition = 'bottom',
+  copyButtonClasses = '',
 }: CopyButtonProps) => {
   const [isCopied, setIsCopied] = React.useState(false);
 
@@ -21,7 +23,7 @@ export const CopyButton = ({
   };
 
   return (
-    <aside className="signature__copy-button">
+    <aside className={`signature__copy-button ${copyButtonClasses}`}>
       <Tooltip position={tooltipPosition}>
         <Tooltip.Content>
           <span>{isCopied ? 'Copied' : 'Copy'}</span>

--- a/apps/docs.blocksense.network/components/sol-contracts/Signature.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Signature.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { CopyButton } from '@/components/common/CopyButton';
-import { CodeBlock } from '@/components/common/CodeBlock';
 import { Signature as SignatureType } from '@blocksense/sol-reflector';
+
+import { CodeBlock } from '@/components/common/CodeBlock';
 
 type SignatureProps = {
   signature?: SignatureType;
@@ -14,14 +14,11 @@ export const Signature = ({
   return (
     signature && (
       <section className="signature border border-gray-800 mb-2 px-0 py-2 rounded-md bg-slate-100">
-        <section className="signature__content flex justify-between items-start w-full">
-          <CodeBlock code={signature.codeSnippet} lang="solidity" />
-          <aside className="signature__copy-button mr-6">
-            <CopyButton
-              textToCopy={signature.codeSnippet}
-              tooltipPosition="bottom"
-            />
-          </aside>
+        <section className="signature__content justify-between items-start w-full">
+          <CodeBlock
+            code={signature.codeSnippet}
+            precompiledHtml={signature.signatureCodeSnippetHTML}
+          />
         </section>
       </section>
     )


### PR DESCRIPTION
### Changes
- Added `CopyButton` to the `CodeBlock` component for easy copying of code snippets.
- Introduced `precompiledHtml` prop in CodeBlock for rendering precompiled HTML.
- Added `copyButtonClasses` prop in CopyButton for custom styling flexibility.
- Refactored corresponding components to support new features.

### Visual representation of changes:
before:
![image](https://github.com/user-attachments/assets/ddae8c6b-92eb-4d45-8a84-5a6e4b493419)
after:
![image](https://github.com/user-attachments/assets/9dc97caf-e7d0-467d-b112-b933540ff404)

> Note: Sub-task of https://github.com/blocksense-network/blocksense/pull/226