### PR TITLE
config(pre-commit/nix): Switch to `nixfmt-rfc-style` for `*.nix` files

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,8 +24,9 @@
     mk-shell-bin.url = "github:rrbutani/nix-mk-shell-bin";
   };
 
-  outputs = inputs @ {flake-parts, ...}:
-    flake-parts.lib.mkFlake {inherit inputs;} {
+  outputs =
+    inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
         # Third-party flake-parts modules
         inputs.devenv.flakeModule
@@ -33,6 +34,9 @@
         # Local flake-parts modules
         ./nix
       ];
-      systems = ["x86_64-linux" "aarch64-darwin"];
+      systems = [
+        "x86_64-linux"
+        "aarch64-darwin"
+      ];
     };
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,23 +1,30 @@
-{lib, ...}: {
-  imports = [./shells ./pkgs];
+{ lib, ... }:
+{
+  imports = [
+    ./shells
+    ./pkgs
+  ];
 
   flake.lib = {
-    filesets = import ./filesets.nix {inherit lib;};
+    filesets = import ./filesets.nix { inherit lib; };
   };
 
-  perSystem = {inputs', ...}: {
-    legacyPackages = {
-      rustToolchain = with inputs'.fenix.packages;
-      with latest;
-        combine [
-          cargo
-          clippy
-          rust-analyzer
-          rust-src
-          rustc
-          rustfmt
-          targets.wasm32-wasi.latest.rust-std
-        ];
+  perSystem =
+    { inputs', ... }:
+    {
+      legacyPackages = {
+        rustToolchain =
+          with inputs'.fenix.packages;
+          with latest;
+          combine [
+            cargo
+            clippy
+            rust-analyzer
+            rust-src
+            rustc
+            rustfmt
+            targets.wasm32-wasi.latest.rust-std
+          ];
+      };
     };
-  };
 }

--- a/nix/filesets.nix
+++ b/nix/filesets.nix
@@ -1,17 +1,24 @@
-{lib, ...}: let
+{ lib, ... }:
+let
   root = ../.;
 in
-  with lib.fileset; {
-    trace = lib.fileset.trace;
+with lib.fileset;
+{
+  trace = lib.fileset.trace;
 
-    rustSrc = rec {
-      fileset = unions [
-        (root + "/Cargo.toml")
-        (root + "/Cargo.lock")
-        (fileFilter (file: builtins.any file.hasExt ["rs" "toml" "wit"]) root)
-      ];
-      src = toSource {
-        inherit root fileset;
-      };
-    };
-  }
+  rustSrc = rec {
+    fileset = unions [
+      (root + "/Cargo.toml")
+      (root + "/Cargo.lock")
+      (fileFilter (
+        file:
+        builtins.any file.hasExt [
+          "rs"
+          "toml"
+          "wit"
+        ]
+      ) root)
+    ];
+    src = toSource { inherit root fileset; };
+  };
+}

--- a/nix/pkgs/blocksense-rs/default.nix
+++ b/nix/pkgs/blocksense-rs/default.nix
@@ -8,21 +8,20 @@
   stdenv,
   darwin,
   filesets,
-}: let
+}:
+let
   sharedAttrs = {
     pname = "blocksense";
     version = "alpha";
     inherit (filesets.rustSrc) src;
 
-    nativeBuildInputs = [pkg-config];
+    nativeBuildInputs = [ pkg-config ];
 
-    buildInputs =
-      [
-        libusb
-        openssl
-        zstd
-      ]
-      ++ lib.optionals stdenv.isDarwin [darwin.apple_sdk.frameworks.Security];
+    buildInputs = [
+      libusb
+      openssl
+      zstd
+    ] ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
 
     env = {
       ZSTD_SYS_USE_PKG_CONFIG = true;
@@ -34,6 +33,5 @@
 
   cargoArtifacts = craneLib.buildDepsOnly sharedAttrs;
 in
-  craneLib.buildPackage (sharedAttrs // {inherit cargoArtifacts;})
+craneLib.buildPackage (sharedAttrs // { inherit cargoArtifacts; })
 # craneLib.buildPackage sharedAttrs
-

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -1,37 +1,33 @@
+{ inputs, self, ... }:
 {
-  inputs,
-  self,
-  ...
-}: {
-  perSystem = {
-    pkgs,
-    self',
-    ...
-  }: let
-    rust = self'.legacyPackages.rustToolchain;
+  perSystem =
+    { pkgs, self', ... }:
+    let
+      rust = self'.legacyPackages.rustToolchain;
 
-    rustPlatform = pkgs.makeRustPlatform {
-      cargo = rust;
-      rustc = rust;
-    };
+      rustPlatform = pkgs.makeRustPlatform {
+        cargo = rust;
+        rustc = rust;
+      };
 
-    craneLib = (inputs.mcl-blockchain.inputs.crane.mkLib pkgs).overrideToolchain rust;
+      craneLib = (inputs.mcl-blockchain.inputs.crane.mkLib pkgs).overrideToolchain rust;
 
-    blocksense-rs = pkgs.callPackage ./blocksense-rs {
-      inherit (self.lib) filesets;
-      inherit craneLib;
-    };
+      blocksense-rs = pkgs.callPackage ./blocksense-rs {
+        inherit (self.lib) filesets;
+        inherit craneLib;
+      };
 
-    mkApp = package: exeName: {
-      type = "app";
-      program = "${package}/bin/${exeName}";
+      mkApp = package: exeName: {
+        type = "app";
+        program = "${package}/bin/${exeName}";
+      };
+    in
+    {
+      apps = {
+        sequencer = mkApp blocksense-rs "sequencer";
+      };
+      packages = {
+        inherit blocksense-rs;
+      };
     };
-  in {
-    apps = {
-      sequencer = mkApp blocksense-rs "sequencer";
-    };
-    packages = {
-      inherit blocksense-rs;
-    };
-  };
 }

--- a/nix/shells/default.nix
+++ b/nix/shells/default.nix
@@ -1,25 +1,25 @@
-{...}: {
-  perSystem = {
-    inputs',
-    self',
-    ...
-  }: let
-    createShell = module: shellName: {
-      imports = [
-        {
-          _module.args = {
-            inherit inputs' self' shellName;
-          };
-        }
-        ./pkg-sets/dev-shell.nix
-        module
-      ];
+{ ... }:
+{
+  perSystem =
+    { inputs', self', ... }:
+    let
+      createShell = module: shellName: {
+        imports = [
+          {
+            _module.args = {
+              inherit inputs' self' shellName;
+            };
+          }
+          ./pkg-sets/dev-shell.nix
+          module
+        ];
+      };
+    in
+    {
+      devenv.shells = {
+        default = createShell ./pkg-sets/all.nix "Main";
+        rust = createShell ./pkg-sets/rust.nix "Rust";
+        js = createShell ./pkg-sets/js.nix "JS";
+      };
     };
-  in {
-    devenv.shells = {
-      default = createShell ./pkg-sets/all.nix "Main";
-      rust = createShell ./pkg-sets/rust.nix "Rust";
-      js = createShell ./pkg-sets/js.nix "JS";
-    };
-  };
 }

--- a/nix/shells/pkg-sets/all.nix
+++ b/nix/shells/pkg-sets/all.nix
@@ -1,4 +1,5 @@
-{...}: {
+{ ... }:
+{
   imports = [
     ./js.nix
     ./rust.nix

--- a/nix/shells/pkg-sets/anvil.nix
+++ b/nix/shells/pkg-sets/anvil.nix
@@ -1,13 +1,9 @@
+{ pkgs, inputs', ... }:
 {
-  pkgs,
-  inputs',
-  ...
-}: {
-  packages = with pkgs;
+  packages =
+    with pkgs;
     [
       # ...
     ]
-    ++ lib.optionals stdenv.isLinux [
-      inputs'.ethereum-nix.packages.foundry
-    ];
+    ++ lib.optionals stdenv.isLinux [ inputs'.ethereum-nix.packages.foundry ];
 }

--- a/nix/shells/pkg-sets/dev-shell.nix
+++ b/nix/shells/pkg-sets/dev-shell.nix
@@ -3,10 +3,9 @@
   pkgs,
   shellName,
   ...
-}: {
-  imports = [
-    ./pre-commit.nix
-  ];
+}:
+{
+  imports = [ ./pre-commit.nix ];
 
   packages = with pkgs; [
     figlet
@@ -26,7 +25,12 @@
     # Set up the environment for the Solidity compiler
     ./nix/scripts/config_solidity_import_mapping.sh
 
-    export LD_LIBRARY_PATH="${lib.makeLibraryPath [pkgs.openssl pkgs.curl]}:$LD_LIBRARY_PATH"
+    export LD_LIBRARY_PATH="${
+      lib.makeLibraryPath [
+        pkgs.openssl
+        pkgs.curl
+      ]
+    }:$LD_LIBRARY_PATH"
     export GIT_ROOT="$(git rev-parse --show-toplevel)"
   '';
 }

--- a/nix/shells/pkg-sets/js.nix
+++ b/nix/shells/pkg-sets/js.nix
@@ -1,11 +1,13 @@
-{pkgs, ...}: let
+{ pkgs, ... }:
+let
   nodejs = pkgs.nodejs_22;
-  oldYarn = pkgs.yarn.override {inherit nodejs;};
+  oldYarn = pkgs.yarn.override { inherit nodejs; };
   yarn = pkgs.yarn-berry.override {
     inherit nodejs;
     yarn = oldYarn;
   };
-in {
+in
+{
   packages = [
     nodejs
     yarn

--- a/nix/shells/pkg-sets/pre-commit.nix
+++ b/nix/shells/pkg-sets/pre-commit.nix
@@ -1,8 +1,12 @@
-{...}: {
+{ pkgs, ... }:
+{
   pre-commit.hooks = {
-    alejandra.enable = true;
+    nixfmt = {
+      enable = true;
+      package = pkgs.nixfmt-rfc-style;
+    };
     editorconfig-checker = {
-      excludes = ["libs/sdk/wit/deps"];
+      excludes = [ "libs/sdk/wit/deps" ];
       enable = true;
     };
     cargo-check.enable = true;

--- a/nix/shells/pkg-sets/rust.nix
+++ b/nix/shells/pkg-sets/rust.nix
@@ -1,15 +1,10 @@
+{ pkgs, self', ... }:
 {
-  pkgs,
-  self',
-  ...
-}: {
   env.SEQUENCER_CONFIG_DIR = "./apps/sequencer/";
   env.REPORTER_SECRET_KEY_FILE_PATH = "./apps/reporter";
 
   packages =
-    [
-      self'.legacyPackages.rustToolchain
-    ]
+    [ self'.legacyPackages.rustToolchain ]
     ++ (with pkgs; [
       openssl
       pkg-config

--- a/nix/shells/pkg-sets/spin.nix
+++ b/nix/shells/pkg-sets/spin.nix
@@ -1,8 +1,5 @@
+{ pkgs, inputs', ... }:
 {
-  pkgs,
-  inputs',
-  ...
-}: {
   packages = with pkgs; [
     inputs'.nixpkgs-unstable.legacyPackages.fermyon-spin
     coreutils


### PR DESCRIPTION
Nix RFC 166 [1] has been officially accepted and `nixfmt-rfc-style` [2] is the
official formatter implementation conforming to the rules agreed upon in the RFC.

This commit configures the the Devenv `pre-commit` [3] options to replace
our previous formatter `alejandra` [4] with `nixfmt-rfc-style` [2].

[1]: https://github.com/NixOS/rfcs/blob/master/rfcs/0166-nix-formatting.md
[2]: https://github.com/NixOS/nixfmt
[3]: https://devenv.sh/pre-commit-hooks/
[4]: https://github.com/kamadorueda/alejandra
