### PR TITLE
(docs.ws): Improve bottom navigation links appearance through mdx fs

### DIFF
--- a/libs/docs-theme/src/components/nav-links.tsx
+++ b/libs/docs-theme/src/components/nav-links.tsx
@@ -5,6 +5,7 @@ import type { ReactElement } from 'react';
 import { useConfig } from '../contexts';
 import type { DocsThemeConfig } from '../index';
 import { Anchor } from './anchor';
+import { Tooltip } from './tooltip';
 
 interface NavLinkProps {
   currentIndex: number;
@@ -13,7 +14,7 @@ interface NavLinkProps {
 
 const classes = {
   link: cn(
-    'nx-flex nx-max-w-[50%] nx-items-center nx-gap-1 nx-py-4 nx-text-sm nx-text-gray-600 nx-transition-colors [word-break:break-word] hover:nx-text-primary-600 dark:nx-text-gray-300',
+    'nx-flex nx-max-w-[50%] nx-items-center nx-gap-1 nx-py-4 nx-text-sm nx-transition-colors [word-break:break-word] nx-font-semibold',
   ),
   icon: cn('nx-inline nx-h-5 nx-shrink-0'),
 };
@@ -45,23 +46,44 @@ export const NavLinks = ({
       {prev && (
         <Anchor
           href={prev.route}
-          title={prev.title}
-          className={cn(classes.link, 'ltr:nx-pr-4 rtl:nx-pl-4')}
+          className={cn(
+            classes.link,
+            'ltr:nx-mr-auto ltr:nx-pr-4 rtl:nx-pl-4 rtl:nx-mr-auto nx-text-black hover:nx-text-blue-900',
+          )}
         >
           <ArrowRightIcon className={cn(classes.icon, 'ltr:nx-rotate-180')} />
-          {prev.title}
+          <span className="nx-block nx-text-sm nx-font-semibold nx-text-black hover:nx-text-blue-900">
+            {prev.title}
+          </span>
+          <Tooltip>
+            <Tooltip.Content>
+              <span>Back to Previous</span>
+            </Tooltip.Content>
+            <span className="nx-hidden md:nx-block nx-text-xs nx-font-semibold nx-text-gray-600">
+              Previous
+            </span>
+          </Tooltip>
         </Anchor>
       )}
       {next && (
         <Anchor
           href={next.route}
-          title={next.title}
           className={cn(
             classes.link,
-            'ltr:nx-ml-auto ltr:nx-pl-4 ltr:nx-text-right rtl:nx-mr-auto rtl:nx-pr-4 rtl:nx-text-left',
+            'ltr:nx-ml-auto ltr:nx-pl-4 ltr:nx-text-right rtl:nx-mr-auto rtl:nx-pr-4 rtl:nx-text-left nx-text-blue-900 hover:nx-text-black',
           )}
         >
-          {next.title}
+          <Tooltip>
+            <Tooltip.Content>
+              <span>Move Forward</span>
+            </Tooltip.Content>
+            <span className="nx-hidden md:nx-block nx-text-xs nx-font-semibold">
+              Next
+            </span>
+          </Tooltip>
+          <span className="nx-block nx-text-sm nx-font-semibold nx-text-black hover:nx-text-blue-900">
+            {next.title}
+          </span>
           <ArrowRightIcon className={cn(classes.icon, 'rtl:nx-rotate-180')} />
         </Anchor>
       )}

--- a/libs/docs-theme/src/components/tooltip.tsx
+++ b/libs/docs-theme/src/components/tooltip.tsx
@@ -33,7 +33,7 @@ export const Tooltip = ({ children }: TooltipProps) => {
     <div className="relative inline-flex items-center group">
       {trigger}
       <div
-        className={`absolute ${positionClass} hidden group-hover:block group-focus:block px-4 py-1.5 text-sm font-semibold text-gray-800 bg-white border border-neutral-300 rounded-md shadow-md z-50 whitespace-nowrap`}
+        className={`absolute ${positionClass} hidden group-hover:block group-focus:block px-4 py-1.5 text-sm font-semibold text-gray-800 nx-bg-white nx-border-b nx-border-neutral-300 rounded-md shadow-md z-50 whitespace-nowrap`}
       >
         {content?.props.children}
         <div className={`absolute ${arrowClass} border-solid`} />

--- a/libs/docs-theme/src/nx-utilities/common.css
+++ b/libs/docs-theme/src/nx-utilities/common.css
@@ -393,3 +393,12 @@ video {
   --tw-backdrop-saturate: ;
   --tw-backdrop-sepia: ;
 }
+
+.tooltip {
+  display: none;
+}
+
+.tooltip-visible:hover .tooltip,
+.tooltip-visible:focus .tooltip {
+  display: none;
+}

--- a/libs/docs-theme/src/nx-utilities/nx-border.css
+++ b/libs/docs-theme/src/nx-utilities/nx-border.css
@@ -48,6 +48,10 @@
   --tw-border-opacity: 1;
   border-color: rgba(209, 213, 219, var(--tw-border-opacity));
 }
+.nx-border-neutral-300 {
+  --tw-border-opacity: 1;
+  border-color: rgba(203, 213, 225, var(--tw-border-opacity));
+}
 .nx-border-neutral-200\/70 {
   border-color: rgba(229, 229, 229, 0.7);
 }

--- a/libs/docs-theme/src/nx-utilities/nx-nextra.css
+++ b/libs/docs-theme/src/nx-utilities/nx-nextra.css
@@ -552,6 +552,11 @@
     right: auto;
   }
 }
+@media (min-width: 768px) {
+  .md\:nx-block {
+    display: block;
+  }
+}
 @media (min-width: 1280px) {
   .xl\:nx-block {
     display: block;

--- a/libs/docs-theme/src/nx-utilities/nx-text.css
+++ b/libs/docs-theme/src/nx-utilities/nx-text.css
@@ -87,6 +87,10 @@
 .nx-tracking-tight {
   letter-spacing: -0.015em;
 }
+.nx-text-black {
+  --tw-text-opacity: 1;
+  color: rgba(0, 0, 0, var(--tw-text-opacity));
+}
 .nx-text-blue-900 {
   --tw-text-opacity: 1;
   color: rgba(30, 58, 138, var(--tw-text-opacity));


### PR DESCRIPTION
We needed to improve bottom navigation appearance, that's coming from [Nextra](https://nextra.site/).

**Before:**
![image](https://github.com/user-attachments/assets/0eeac1ad-5009-404c-b361-5a731a16062e)
![image](https://github.com/user-attachments/assets/a379954e-5b2d-4555-8894-d2f48df74bc0)

After:
![image](https://github.com/user-attachments/assets/282b1a8f-7f5a-46a9-8da2-bd94ce09262e)
![image](https://github.com/user-attachments/assets/f229341a-0967-43c4-9c95-9d11fc5d94b2)

This PR includes
- Added new labels - **Previous** and **Next** (these labels are visible only for md screens and above).
- The tool-tip we've redesigned is appearing when you hover on these labels. 
- Text-color adjustments
- Css fixes, adding new utility-classes and resolving existing ones.