### PR TITLE
[docs.ws]: Implement `useMediaQuery` custom hook for resolution

### DIFF
--- a/apps/docs.blocksense.network/hooks/useMediaQuery.ts
+++ b/apps/docs.blocksense.network/hooks/useMediaQuery.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect } from 'react';
+
+export function useMediaQuery(query: string) {
+  const isBrowser = typeof window !== 'undefined';
+
+  const [matches, setMatches] = useState(() => {
+    if (isBrowser) {
+      return window.matchMedia(query).matches;
+    }
+    return true;
+  });
+
+  useEffect(() => {
+    if (!isBrowser) {
+      return;
+    }
+
+    const mediaQueryList = window.matchMedia(query);
+
+    function handleChange() {
+      setMatches(mediaQueryList.matches);
+    }
+
+    mediaQueryList.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQueryList.removeEventListener('change', handleChange);
+    };
+  }, [query, isBrowser]);
+
+  return matches;
+}


### PR DESCRIPTION
`useMediaQuery` is a custom hook to handle responsive design based on screen resolution.

Will find its application in the visualization of the ABIs