### PR TITLE
[sol reflector]: Refactor `iterateContractElements`

### DIFF
--- a/libs/sol-reflector/src/types.ts
+++ b/libs/sol-reflector/src/types.ts
@@ -105,6 +105,15 @@ export type ASTNode =
 
 export type SolReflection = { rawData: ASTNode; fineData: SourceUnitDocItem }[];
 
+export type ContractElement =
+  | FunctionDocItem
+  | ErrorDocItem
+  | EventDocItem
+  | ModifierDocItem
+  | VariableDocItem
+  | EnumDocItem
+  | StructDocItem;
+
 export type DocItemConstructor<T> = new (...args: any[]) => T;
 
 export class SourceUnitDocItem {

--- a/libs/sol-reflector/src/utils/signature.ts
+++ b/libs/sol-reflector/src/utils/signature.ts
@@ -103,9 +103,12 @@ export function getSignature(node: ASTNode): Signature | undefined {
  *   when all signatures have been formatted and highlighted.
  */
 export async function formatAndHighlightSignatures(docItem: SolReflection) {
-  await iterateContractElements(docItem, async (element: any) => {
+  for (const { element } of iterateContractElements(docItem)) {
+    if (!element.signature) {
+      continue;
+    }
     await formatAndHighlightSignature(element.signature);
-  });
+  }
 }
 
 /**


### PR DESCRIPTION
### Overview
This PR refactors the `iterateContractElements` function in the `sol-reflector` module.

### Key Changes

1. **Refactoring `iterateContractElements` Function**:
   - Converted `iterateContractElements` into a generator function, making it an iterator. This allows the function to yield contract elements one by one, enabling more flexible usage patterns.
   - Updated the function's signature to reflect its new behavior, yielding objects containing the `sourceUnit`, `contract`, and individual `element`.

2. **Introduction of New Types**:
   - Defined a new type `ContractElement`, which is a union of possible contract elements (`functions`, `errors`, `events`, `modifiers`, `variables`, `enums`, `structs`).
   - Added this new type to the iteration logic.

3. **Added `iterateContracts` Helper Function**:
   - Introduced the `iterateContracts` function as a generator that iterates over all contracts in a `SolReflection` object. This provides a more modular approach to iterating over contracts, which can be reused in other parts of the codebase.

