### PR TITLE
[docs-theme]: Fix export of our version of the components

### DIFF
--- a/libs/docs-theme/src/index.tsx
+++ b/libs/docs-theme/src/index.tsx
@@ -260,25 +260,33 @@ export default function Layout({
 
 export { useConfig, PartialDocsThemeConfig as DocsThemeConfig };
 export { useMDXComponents } from 'nextra/mdx';
-export {
-  Callout,
-  Steps,
-  Tabs,
-  Tab,
-  Cards,
-  Card,
-  FileTree,
-} from 'nextra/components';
+export { Steps, Tabs, Tab, Cards, Card, FileTree } from 'nextra/components';
 export { useTheme } from 'next-themes';
 export { Link } from './mdx-components';
-export {
-  Bleed,
-  Collapse,
-  NotFoundPage,
-  ServerSideErrorPage,
-  Navbar,
-  SkipNavContent,
-  SkipNavLink,
-  ThemeSwitch,
-  LocaleSwitch,
-} from './components';
+
+// Exporting out version of the components
+export { Anchor } from './components/anchor';
+export { Button } from './components/button';
+export { Pre } from './components/pre';
+export { Banner } from './components/banner';
+export { Bleed } from './components/bleed';
+export { Breadcrumb } from './components/breadcrumb';
+export { Collapse } from './components/collapse';
+export { Code } from './components/code';
+export { CopyToClipboard } from './components/copy-to-clipboard';
+export { Flexsearch } from './components/flexsearch';
+export { Footer } from './components/footer';
+export { Head } from './components/head';
+export { Input } from './components/input';
+export { LocaleSwitch } from './components/locale-switch';
+export { NavLinks } from './components/nav-links';
+export { Navbar } from './components/navbar';
+export { NotFoundPage } from './components/404';
+export { Search } from './components/search';
+export { Select } from './components/select';
+export { ServerSideErrorPage } from './components/500';
+export { Sidebar } from './components/sidebar';
+export { SkipNavContent, SkipNavLink } from './components/skip-nav';
+export { ThemeSwitch } from './components/theme-switch';
+export { TOC } from './components/toc';
+export { Tooltip } from './components/tooltip';


### PR DESCRIPTION
As discussed previously, we needed to manipulate the source-code of nextra built-in components so we may achieve what we need outside of their predefined UI/UX.

We've managed to apply modifications for some of them, however with the newly added components the situation is not the same. 

This PR fixes this problem and we can manage everything we need - old and new ones. 