### PR TITLE
[sol-reflector]: Add `visibility` to variables signatures. Minor signature related changes

### DIFF
--- a/libs/sol-reflector/src/types.ts
+++ b/libs/sol-reflector/src/types.ts
@@ -61,6 +61,7 @@ export type FunctionModifierKind =
 export type Signature = {
   codeSnippet: string;
   signatureCodeSnippetHTML: string;
+  type?: NodeType;
 };
 
 export type NatSpecParam = {

--- a/libs/sol-reflector/src/utils/common.ts
+++ b/libs/sol-reflector/src/utils/common.ts
@@ -152,7 +152,6 @@ export function filterRelevantFiles(output: SolcOutput, config: FullConfig) {
  */
 export function formatVariable(v: VariableDeclaration): string {
   return [v.typeName?.typeDescriptions.typeString!]
-    .concat(v.constant || v.mutability == 'immutable' ? v.mutability : [])
     .concat(v.name || [])
     .join(' ');
 }


### PR DESCRIPTION
### Purpose of the PR
 Add `visibility` to variables signatures

### Changes
* Edit signature parsing logic for variables. Include `visibility`.
* Revert https://github.com/blocksense-network/blocksense/commit/8620164fe74280425e61f05bfe019be5f7c28001
* Add `type` filed in type `Signature`
* Do not format signatures of type variables, as they are not correct sol code according to `prettier-plugin-solidity`