### PR TITLE
style(docs.ws): Styling list, dynamically generated by the mdx

### DIFF
--- a/libs/docs-theme/src/icons/list.tsx
+++ b/libs/docs-theme/src/icons/list.tsx
@@ -1,0 +1,26 @@
+import type { ComponentProps, ReactElement } from 'react';
+
+export const ListIcon = (props: ComponentProps<'svg'>): ReactElement => {
+  return (
+    <svg width="24px" height="24px" viewBox="0 0 24 24" fill="none">
+      <path
+        d="M20 7L4 7"
+        stroke="#1C274C"
+        stroke-width="1.5"
+        stroke-linecap="round"
+      />
+      <path
+        d="M15 12L4 12"
+        stroke="#1C274C"
+        stroke-width="1.5"
+        stroke-linecap="round"
+      />
+      <path
+        d="M9 17H4"
+        stroke="#1C274C"
+        stroke-width="1.5"
+        stroke-linecap="round"
+      />
+    </svg>
+  );
+};

--- a/libs/docs-theme/src/mdx-components.tsx
+++ b/libs/docs-theme/src/mdx-components.tsx
@@ -10,6 +10,7 @@ import type { AnchorProps } from './components/anchor';
 import type { DocsThemeConfig } from './constants';
 import { DetailsProvider, useDetails, useSetActiveAnchor } from './contexts';
 import { useIntersectionObserver, useSlugs } from './contexts/active-anchor';
+import { ListIcon } from './icons/list';
 
 // Anchor links
 function HeadingLink({
@@ -206,17 +207,24 @@ export const getComponents = ({
     h6: props => <HeadingLink tag="h6" context={context} {...props} />,
     ul: props => (
       <ul
-        className="nx-mt-6 nx-list-disc first:nx-mt-0 ltr:nx-ml-6 rtl:nx-mr-6"
+        className="nx-mt-6 nx-list-none first:nx-mt-0 ltr:nx-ml-0 rtl:nx-mr-6"
         {...props}
       />
     ),
     ol: props => (
       <ol
-        className="nx-mt-6 nx-list-decimal first:nx-mt-0 ltr:nx-ml-6 rtl:nx-mr-6"
+        className="nx-mt-6 nx-list-decimal first:nx-mt-0 rtl:nx-mr-6"
         {...props}
       />
     ),
-    li: props => <li className="nx-my-2" {...props} />,
+    li: props => (
+      <li className="flex items-start nx-gap-4 nx-my-2" {...props}>
+        <aside className="w-4 h-4 nx-flex-shrink-0" aria-hidden="true">
+          <ListIcon />
+        </aside>
+        <span className="flex-grow">{props.children}</span>
+      </li>
+    ),
     blockquote: props => (
       <blockquote
         className={cn(

--- a/libs/docs-theme/src/nx-utilities/nx-layout-and-positioning.css
+++ b/libs/docs-theme/src/nx-utilities/nx-layout-and-positioning.css
@@ -145,6 +145,9 @@
 .nx-mb-8 {
   margin-bottom: 2rem;
 }
+.nx-ml-0 {
+  margin-left: 0;
+}
 .nx-ml-1 {
   margin-left: 0.25rem;
 }


### PR DESCRIPTION
**Before:**
![image](https://github.com/user-attachments/assets/58336aef-5643-4081-9f31-3953445b00d0)

**After**
![image](https://github.com/user-attachments/assets/cab10d9d-a1dc-4ec1-b18c-ddeba2c4b4d7)



