### PR TITLE
style(docs.ws): Change scrollbar color on all devices

### DIFF
--- a/libs/docs-theme/src/nx-utilities/nx-scrollbar.css
+++ b/libs/docs-theme/src/nx-utilities/nx-scrollbar.css
@@ -36,12 +36,12 @@ span:target + .subheading-anchor:after {
 }
 .nextra-scrollbar {
   scrollbar-width: thin;
-  scrollbar-color: rgba(115, 115, 115, 0.4) transparent;
+  scrollbar-color: rgba(229, 231, 235, 0.6) transparent;
   scrollbar-gutter: stable;
 }
 @supports (color: lab(0% 0 0)) {
   .nextra-scrollbar {
-    scrollbar-color: lab(48.438% 0 0/0.4) transparent;
+    scrollbar-color: lab(91.37% -0.01 -0.54/0.6) transparent;
   }
 }
 .nextra-scrollbar::-webkit-scrollbar {


### PR DESCRIPTION
Right now, the scrollbar color of Nextra scrollbar is looking like a dark spot on the page that distracts the user from the main content. We need to adjust the color in the way that Nextra won't break anything on the page.

**Before:**
![image](https://github.com/user-attachments/assets/ddc58c8b-730b-4eff-ae0f-657f63047b2a)

**After:**
![image](https://github.com/user-attachments/assets/2ef775a1-5c2b-4989-bcf3-98dbe900a4fa)


 