### PR TITLE
Setup script for building dependencies

### DIFF
--- a/libs/contracts/README.md
+++ b/libs/contracts/README.md
@@ -97,6 +97,7 @@ All calls are handled by a fallback function based on the selector:
 Available scripts:
 
 ```sh
+yarn setup # Builds dependencies if not built
 yarn hardhat help # Display Hardhat commands
 yarn clean # Clean all untracked files
 yarn build:deps # Build workspace dependencies
@@ -118,6 +119,9 @@ FORKING=true yarn hardhat run ./scripts/chainlink-event-fetcher.ts
 # To run tests with opcodes & gas tracing:
 TRACE_TX=true yarn test
 ```
+
+> [!NOTE]
+> When calling raw hardhat commands, make sure that the `setup` command is called to initialize dependencies if necessary.
 
 ## Testing
 

--- a/libs/contracts/package.json
+++ b/libs/contracts/package.json
@@ -11,15 +11,16 @@
     }
   },
   "scripts": {
-    "build:deps": "yarn workspace @blocksense/base-utils build && yarn workspace @blocksense/sol-reflector build",
+    "setup": "node pre-build.mjs",
     "clean": "git clean -fdx -e .env",
-    "build": "hardhat compile",
+    "build:deps": "yarn workspace @blocksense/base-utils build && yarn workspace @blocksense/sol-reflector build",
+    "build": "yarn setup && yarn hardhat compile",
     "sol-reflect": "yarn build:deps && yarn hardhat reflect",
-    "test": "hardhat test",
-    "test:fork": "FORKING=true hardhat test --grep '@fork'",
-    "coverage": "hardhat coverage",
-    "deploy:local": "hardhat run --network localhost",
-    "size": "hardhat size-contracts"
+    "test": "yarn setup && yarn hardhat test",
+    "test:fork": "yarn setup && FORKING=true hardhat test --grep '@fork'",
+    "coverage": "yarn setup && hardhat coverage",
+    "deploy:local": "yarn setup && hardhat run --network localhost",
+    "size": "yarn setup && hardhat size-contracts"
   },
   "devDependencies": {
     "@blocksense/sol-reflector": "workspace:*",

--- a/libs/contracts/pre-build.mjs
+++ b/libs/contracts/pre-build.mjs
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import { execSync } from 'child_process';
+
+// This script is run before Hardhat environment is loaded to build the dependencies if not already built
+
+// Define the path to the dist folders
+const distBaseUtilsFolderPath = '../base-utils/dist';
+const distSolReflectFolderPath = '../sol-reflector/dist';
+
+// Check if the dist folders exist
+if (
+  !fs.existsSync(distBaseUtilsFolderPath) ||
+  !fs.existsSync(distSolReflectFolderPath)
+) {
+  try {
+    // Run the yarn build:deps command
+    execSync('yarn build:deps', { stdio: 'inherit' });
+  } catch (error) {
+    console.error('Failed to build dependencies. Exiting...');
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
This script runs before the Hardhat environment is created to build the `base-utils` and the `sol-reflector` dependencies only if they have not been built yet.