### PR TITLE
fix(node): dedup current_unix_time

### DIFF
--- a/libs/data_feeds/src/connector/dispatch.rs
+++ b/libs/data_feeds/src/connector/dispatch.rs
@@ -110,9 +110,9 @@ pub fn dispatch(
             &reporter_config.sequencer_url,
         );
 
-        let elapsed_time = start_time.elapsed().as_millis();
+        let elapsed_time_ms = start_time.elapsed().as_millis();
         DATA_FEED_PARSE_TIME_GAUGE
             .with_label_values(&[&feed.id.to_string()])
-            .set(elapsed_time as i64);
+            .set(elapsed_time_ms as i64);
     }
 }

--- a/libs/data_feeds/src/connector/post.rs
+++ b/libs/data_feeds/src/connector/post.rs
@@ -81,19 +81,19 @@ pub fn post_feed_response(
     asset: &str,
     sequencer_url: &str,
 ) {
-    let (result, timestamp) = data_feed.borrow_mut().poll(asset);
+    let (result, timestamp_ms) = data_feed.borrow_mut().poll(asset);
 
     let signature = generate_signature(
         secret_key,
         format!("{}", feed_id).as_str(),
-        timestamp,
+        timestamp_ms,
         &result,
     );
 
     let payload_json = handle_feed_response(
         reporter.id,
         feed_id.to_string(),
-        timestamp,
+        timestamp_ms,
         result,
         signature,
     );

--- a/libs/data_feeds/src/orchestrator.rs
+++ b/libs/data_feeds/src/orchestrator.rs
@@ -58,16 +58,16 @@ pub async fn orchestrator() {
 
         info!("Finished with {}-th batch..\n", BATCH_COUNTER.get());
 
-        let elapsed_time = start_time.elapsed().as_millis();
+        let elapsed_time_ms = start_time.elapsed().as_millis();
 
         //TODO(snikolov): `poll_period_ms` is dependent on the feed, we should ship payload ASAP and sleep this feed only.
-        if elapsed_time < reporter_config.poll_period_ms.into() {
-            let remaining_time_ms = reporter_config.poll_period_ms - (elapsed_time as u64);
+        if elapsed_time_ms < reporter_config.poll_period_ms.into() {
+            let remaining_time_ms = reporter_config.poll_period_ms - (elapsed_time_ms as u64);
             sleep(Duration::from_millis(remaining_time_ms));
         }
 
         UPTIME_COUNTER.inc_by((reporter_config.poll_period_ms as f64) / 1000.0);
-        BATCH_PARSE_TIME_GAUGE.set(elapsed_time as i64);
+        BATCH_PARSE_TIME_GAUGE.set(elapsed_time_ms as i64);
 
         let metrics_result = handle_prometheus_metrics(
             &request_client,

--- a/libs/data_feeds/src/services/coinmarketcap.rs
+++ b/libs/data_feeds/src/services/coinmarketcap.rs
@@ -6,7 +6,7 @@ use feed_registry::{
 };
 use ringbuf::{self, storage::Heap, traits::RingBuffer, HeapRb, SharedRb};
 use tracing::{trace, warn};
-use utils::{current_unix_time, get_env_var, read_file};
+use utils::{get_env_var, read_file, time::current_unix_time};
 
 use derive::{ApiConnect, Historical};
 

--- a/libs/data_feeds/src/services/yahoo_finance.rs
+++ b/libs/data_feeds/src/services/yahoo_finance.rs
@@ -2,7 +2,7 @@ use ringbuf::storage::Heap;
 use ringbuf::traits::RingBuffer;
 use ringbuf::{HeapRb, SharedRb};
 use tracing::{trace, warn};
-use utils::{current_unix_time, get_env_var};
+use utils::{get_env_var, time::current_unix_time};
 use yahoo_finance_api::YahooConnector;
 
 extern crate derive;

--- a/libs/utils/src/lib.rs
+++ b/libs/utils/src/lib.rs
@@ -9,15 +9,7 @@ use std::{
     hash::{DefaultHasher, Hash, Hasher},
     io::Read,
     str::FromStr,
-    time::{SystemTime, UNIX_EPOCH},
 };
-
-pub fn current_unix_time() -> u128 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("SystemTime before UNIX EPOCH!")
-        .as_secs() as u128
-}
 
 pub fn get_env_var<T>(key: &str) -> Result<T, String>
 where


### PR DESCRIPTION
There were two implementations, one returning seconds, one milliseconds.

The sequencer was using one, the reporter the other, which caused a bug with slots positioning. This is now fixed.

Now there's only one, returning milliseconds.

Also, renamed some variables to have _ms suffix to make clear the intention about what the unit should have.