### PR TITLE
fix(sol-reflector): Fix natspec parsing logic for return params

### DIFF
--- a/libs/sol-reflector/src/utils/natspec.ts
+++ b/libs/sol-reflector/src/utils/natspec.ts
@@ -79,26 +79,19 @@ export function parseNatspec(node: ASTNode): NatSpec {
         if (p === undefined) {
           throw new ItemError('Got more @return tags than expected', node);
         }
-        if (!p.name) {
-          natSpec.returns.push({ description: content.trim() });
-        } else {
-          const paramMatches = content.match(/(\w+)( ([^]*))?/);
-          if (!paramMatches || paramMatches[1] !== p.name) {
-            throw new ItemError(
-              `Expected @return tag to start with name '${p.name}'`,
-              node,
-            );
-          }
-          const [, name, description] = paramMatches as [
-            string,
-            string,
-            string?,
-          ];
-          natSpec.returns.push({
-            name,
-            description: description?.trim() ?? '',
-          });
+        const returnParamMatches = content.match(/(\w+)( ([^]*))?/);
+        if (!returnParamMatches) {
+          throw new ItemError(
+            `Expected @return tag to start with name '${p.name}'`,
+            node,
+          );
         }
+        const [, returnParamName, returnParamDescription] =
+          returnParamMatches as [string, string, string?];
+        natSpec.returns.push({
+          name: returnParamName,
+          description: returnParamDescription?.trim() ?? '',
+        });
         break;
       case '@custom':
         const [customTag, ...customDesc] = content.replace(':', '').split(' ');


### PR DESCRIPTION
Some return parameters in the code are unnamed, but they are given names in the NatSpec documentation. We need to display these names from NatSpec instead of leaving the parameters unnamed.

For example, in the _getRoundData function of ProxyCall, the Return Parameters table currently shows some parameters as unnamed. However, as seen in the image below, while the code itself might not have names for some return values, the NatSpec documentation does provide names for them, which we should display instead.

![image](https://github.com/user-attachments/assets/4d9080e8-cd3b-4688-9326-151657718af0)
![image](https://github.com/user-attachments/assets/a0ee22a9-6115-4285-a879-070dcce79dcd)


Here is the result:
![image](https://github.com/user-attachments/assets/3b658315-8e88-4223-8023-886111a40e28)

