### PR TITLE
update(docs.ws): Fix file formatting

### DIFF
--- a/apps/docs.blocksense.network/pages/docs/contracts/guide/historic-data-feed.mdx
+++ b/apps/docs.blocksense.network/pages/docs/contracts/guide/historic-data-feed.mdx
@@ -1,4 +1,3 @@
-
 import { Callout } from '@blocksense/docs-theme';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 


### PR DESCRIPTION
There was a new line at the beginning of `apps/docs.blocksense.network/pages/docs/contracts/guide/historic-data-feed.mdx` that got deleted on each build, causing annoying diffs. This PR removes it for good.