### PR TITLE
[docs.ws] Format NatSpec new rows

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/NatSpec.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/NatSpec.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
+
 import { NatSpec as NatSpecType } from '@blocksense/sol-reflector';
+
+import { NatSpecItem } from '@/sol-contracts-components/NatSpecItem';
 
 type NatSpecProps = {
   natspec: NatSpecType;
@@ -10,48 +13,11 @@ export const NatSpec = ({ natspec }: NatSpecProps) => {
     <>
       {Object.keys(natspec).length > 0 && (
         <ol className="relative border-l-2 border-gray-200 dark:border-gray-700">
-          {natspec.author && (
-            <li className="mb-4">
-              <h3 className="mb-1 text-lg font-semibold text-gray-900 dark:text-white">
-                Author
-              </h3>
-              <p className="block mb-2 text-sm font-normal text-gray-500 dark:text-gray-500">
-                {natspec.author}
-              </p>
-            </li>
-          )}
-          {natspec.notice && (
-            <li className="mb-4">
-              <h3 className="mb-1 text-lg font-semibold text-gray-900 dark:text-white">
-                Notice
-              </h3>
-              <p className="block mb-2 text-sm font-normal text-gray-500 dark:text-gray-500 italic">
-                {natspec.notice}
-              </p>
-            </li>
-          )}
-          {natspec.dev && (
-            <li className="mb-4">
-              <h3 className="mb-1 text-lg font-semibold text-gray-900 dark:text-white">
-                Developer notes
-              </h3>
-              <p className="block mb-2 text-sm font-normal text-gray-500 dark:text-gray-500 italic">
-                {natspec.dev}
-              </p>
-            </li>
-          )}
+          <NatSpecItem title="Author" content={natspec.author} />
+          <NatSpecItem title="Notice" content={natspec.notice} />
+          <NatSpecItem title="Developer notes" content={natspec.dev} />
           {Object.entries(natspec.custom || {}).map(([key, value], index) => (
-            <li
-              className={`ml-4 ${index < Object.keys(natspec.custom || {}).length - 1 ? 'mb-4' : ''}`}
-              key={index}
-            >
-              <h3 className="mb-1 text-lg font-semibold text-gray-900 dark:text-white">
-                {key}
-              </h3>
-              <p className="block mb-2 text-sm font-normal text-gray-500 dark:text-gray-500 italic">
-                {value}
-              </p>
-            </li>
+            <NatSpecItem key={index} title={key} content={value} />
           ))}
         </ol>
       )}

--- a/apps/docs.blocksense.network/components/sol-contracts/NatSpecItem.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/NatSpecItem.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+type NatSpecItemProps = {
+  title: string;
+  content?: string;
+};
+
+export const NatSpecItem = ({ title, content = '' }: NatSpecItemProps) =>
+  content && (
+    <li className="mb-4">
+      <h3 className="mb-1 font-semibold text-gray-900 dark:text-white">
+        {title}
+      </h3>
+      {content.split('\n').map((line, index) => (
+        <p
+          key={index}
+          className="block mb-1 text-sm font-normal text-gray-500 dark:text-gray-500 italic"
+        >
+          {line}
+        </p>
+      ))}
+    </li>
+  );


### PR DESCRIPTION
Implement `NatSpecItem` component to render each NatSpec item and each paragraph on a new line, and everything to be reusable. Also made NatSpec item title to be smaller.

Before:
![image](https://github.com/user-attachments/assets/b21359ed-ed5b-4c48-80ac-00c3a0c1f787)

After:
![image](https://github.com/user-attachments/assets/408a61d7-78d4-48e5-9e35-6eefbf91d03b)
