### PR TITLE
[sol-reflector][docs.ws]: Use and add contract code snippet

### DIFF
--- a/apps/docs.blocksense.network/src/contract-overview.ts
+++ b/apps/docs.blocksense.network/src/contract-overview.ts
@@ -50,7 +50,7 @@ export function getOverviewCodeContent(contract: ContractDocItem): string {
     .concat(formatComponentData('Modifiers', contract.modifiers))
     .concat(formatComponentData('Functions', contract.functions));
 
-  let contractData = `contract ${contract.name} {\n${content}}`;
+  let contractData = `${contract.signature?.codeSnippet} {\n${content}}`;
 
   return contractData;
 }

--- a/libs/sol-reflector/src/types.ts
+++ b/libs/sol-reflector/src/types.ts
@@ -146,6 +146,7 @@ export class ContractDocItem {
   variables?: VariableDocItem[];
   enums?: EnumDocItem[];
   structs?: StructDocItem[];
+  signature?: Signature;
 }
 
 export class ErrorDocItem {

--- a/libs/sol-reflector/src/utils/convertors.ts
+++ b/libs/sol-reflector/src/utils/convertors.ts
@@ -97,6 +97,7 @@ export function convertContract(
   const extracted = extractFields(node, ContractDocItem);
   return {
     ...extracted,
+    signature: getSignature(node),
     _baseContracts: node.baseContracts.map(c => c.baseName.name!),
     functions: deriveFunctions(node),
     errors: deriveErrors(node),

--- a/libs/sol-reflector/src/utils/signature.ts
+++ b/libs/sol-reflector/src/utils/signature.ts
@@ -11,7 +11,7 @@ export function getSignature(node: ASTNode): Signature | undefined {
   switch (node.nodeType) {
     case 'ContractDefinition':
       return {
-        codeSnippet: `contract ${node.name} { ... };`,
+        codeSnippet: `contract ${node.name}`,
         signatureCodeSnippetHTML: '',
       };
 


### PR DESCRIPTION
I finished adding signature with codeSnippet in `sol-reflector` and added it in the contract overview.