### PR TITLE
[docs.ws]: Comments from `ContractOverview` with link functionality

### DIFF
--- a/apps/docs.blocksense.network/src/contract-overview.ts
+++ b/apps/docs.blocksense.network/src/contract-overview.ts
@@ -38,7 +38,7 @@ function formatComponentData(
 export function getOverviewCodeContent(contract: ContractDocItem): string {
   let content = ''
     .concat(formatComponentData('Enums', contract.enums))
-    .concat(formatComponentData('Structures', contract.structs))
+    .concat(formatComponentData('Structs', contract.structs))
     .concat(
       formatComponentData('Constants', filterConstants(contract.variables)),
     )
@@ -108,11 +108,13 @@ function getUrlTarget(node: any): string {
   const target =
     index !== -1
       ? codeSnippetTokens[index + 1]
-      : codeSnippetTokens.includes('constructor')
-        ? 'constructor'
-        : codeSnippetTokens.includes('fallback')
-          ? 'fallback'
-          : codeSnippetTokens[1];
+      : codeSnippetTokens[0].includes('// ')
+        ? codeSnippetTokens[0].substring(3)
+        : codeSnippetTokens.includes('constructor')
+          ? 'constructor'
+          : codeSnippetTokens.includes('fallback')
+            ? 'fallback'
+            : codeSnippetTokens[1];
   return target;
 }
 


### PR DESCRIPTION
In the `ContractOverview` every line leads to some contract item with anchor link, before comments were static, now they are links, it is more convenient and have anchor link functionality for the sections too.

For example in the picture below `// Functions` is link which leads to `Functions` section in the contract. 

![image](https://github.com/user-attachments/assets/dd15ef8a-f677-4adc-9163-bdcbc49fa4ec)
