### PR TITLE
fix(docs.ws): Remove unnecessary title tooltips and keep links inside callouts clickable

### DIFF
--- a/apps/docs.blocksense.network/pages/docs/contracts/guide/chainlink-proxy.mdx
+++ b/apps/docs.blocksense.network/pages/docs/contracts/guide/chainlink-proxy.mdx
@@ -24,7 +24,7 @@ flowchart TD
   class A,CP,DFS node
 ```
 
-<Callout type="info" title="Note" emoji="💡">
+<Callout type="info" emoji="💡">
   Feeds without a corresponding token address, such as those for stock indices,
   do not have a dedicated Chainlink Proxy due to the lack of a canonical token
   representation.
@@ -75,7 +75,7 @@ contract ChainlinkProxyConsumer {
 
 ### Solidity Hardhat Example
 
-<Callout type="info" title="Note" emoji="💡">
+<Callout type="info" emoji="💡">
   You can find a working Hardhat project
   [here](https://github.com/blocksense-network/blocksense/tree/main/libs/contracts).
   Clone the repo and follow the setup instructions to run the example locally.

--- a/apps/docs.blocksense.network/pages/docs/contracts/guide/feed-registry.mdx
+++ b/apps/docs.blocksense.network/pages/docs/contracts/guide/feed-registry.mdx
@@ -24,7 +24,7 @@ flowchart TD
   class A,FR,DFS node
 ```
 
-<Callout type="info" title="Note" emoji="💡">
+<Callout type="info" emoji="💡">
   The Feed Registry exclusively includes feeds associated with canonical token
   addresses on a given network. Feeds without a corresponding token address,
   such as those for stock indices, are not included in the registry due to the
@@ -90,7 +90,7 @@ contract RegistryConsumer {
 
 ### Solidity Hardhat Example
 
-<Callout type="info" title="Note" emoji="💡">
+<Callout type="info" emoji="💡">
   You can find a working Hardhat project
   [here](https://github.com/blocksense-network/blocksense/tree/main/libs/contracts).
   Clone the repo and follow the setup instructions to run the example locally.

--- a/apps/docs.blocksense.network/pages/docs/contracts/guide/historic-data-feed.mdx
+++ b/apps/docs.blocksense.network/pages/docs/contracts/guide/historic-data-feed.mdx
@@ -9,7 +9,7 @@ Historic Data Feed Store contract is where all data is stored and where all cont
 
 ### Solidity
 
-<Callout type="info" title="Note" emoji="💡">
+<Callout type="info" emoji="💡">
   Use [ProxyCall
   library](https://github.com/blocksense-network/blocksense/tree/main/libs/contracts/contracts/libraries/ProxyCall.sol)
   for easy and gas optimised interaction with the contract.

--- a/libs/docs-theme/src/components/callout.tsx
+++ b/libs/docs-theme/src/components/callout.tsx
@@ -39,7 +39,7 @@ export const Callout = forwardRef<HTMLDivElement, CalloutProps>(function (
     <div
       ref={forwardedRef}
       className={cn(
-        'nextra-callout nx-overflow-x-auto nx-mt-6 nx-py-4 nx-pl-2 nx-pr-4 nx-flex nx-bg-neutral-900 nx-bg-opacity-[0.02] nx-rounded-md nx-border nx-border-neutral-200/70 ltr:nx-pr-4 rtl:nx-pl-4 nx-pointer-events-none',
+        'nextra-callout nx-overflow-x-auto nx-mt-6 nx-py-4 nx-pl-2 nx-pr-4 nx-flex nx-bg-neutral-900 nx-bg-opacity-[0.02] nx-rounded-md nx-border nx-border-neutral-200/70 ltr:nx-pr-4 rtl:nx-pl-4',
         'contrast-more:nx-border-current contrast-more:dark:nx-border-current',
         classes[type],
       )}
@@ -54,7 +54,9 @@ export const Callout = forwardRef<HTMLDivElement, CalloutProps>(function (
       >
         {emoji}
       </div>
-      <div className="nx-w-full nx-min-w-0 nx-leading-6">{children}</div>
+      <div className="nx-w-full nx-min-w-0 nx-leading-6 nx-pointer-events-none">
+        {children}
+      </div>
     </div>
   );
 });

--- a/libs/docs-theme/src/nx-utilities/nx-nextra.css
+++ b/libs/docs-theme/src/nx-utilities/nx-nextra.css
@@ -593,3 +593,24 @@ body.nextra-banner-hidden .\[body\.nextra-banner-hidden_\&\]\:nx-hidden {
 div:hover > .\[div\:hover\>\&\]\:nx-opacity-100 {
   opacity: 1;
 }
+.nextra-callout {
+  position: relative;
+}
+
+.nextra-callout,
+.nextra-callout a {
+  position: relative;
+}
+
+.nextra-callout::before,
+.nextra-callout::after,
+.nextra-callout a::before {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.nextra-callout a {
+  pointer-events: auto;
+}


### PR DESCRIPTION
In this PR we resolve two issues:

Issue 1:

Links inside callouts are not clickable.
![image](https://github.com/user-attachments/assets/d1e67561-5b90-40b2-9c6e-b32636f81f43)

Issue 2 : 

Default tooltip is appearing for the title of the snippet defined into the  mdx file.

![image](https://github.com/user-attachments/assets/ad17647d-b412-4160-9d02-d49b73266992)

Resolution:

- We don't need the titles for the callouts, because they don't bring any useful information to the end-user, so we won't have this odd tool-tip that appears there. This change into the mdx files could be considered as code clean-up.

- If we have tooltips in the future for the callout, we should be able to take control of them, defined their position and content, as we need now, so we won't be messing up with the pointer events, at all. And most importantly the tooltip won't appear in the middle/ to the bottom of the callout, as it happens in the example above.

- Remove `nx-pointer-events-none` from the callout.

**Instructions to test:**

1. Go to the deployed version of Feed Registry guide.
2. Hover anywhere inside the callout and make sure that no odd tooltip is appearing anywhere.
3. Click on a link inside the callout and it should lead you to the external page, defined into the mdx component.


