### PR TITLE
[base-utils]: Init `evm-utils` module

### DIFF
--- a/libs/base-utils/package.json
+++ b/libs/base-utils/package.json
@@ -36,6 +36,11 @@
       "require": "./dist/cjs/buffer-and-hex-utils/index.cjs",
       "import": "./dist/esm/buffer-and-hex-utils/index.mjs",
       "types": "./dist/types/buffer-and-hex-utils/index.d.ts"
+    },
+    "./evm-utils": {
+      "require": "./dist/cjs/evm-utils/index.cjs",
+      "import": "./dist/esm/evm-utils/index.mjs",
+      "types": "./dist/types/evm-utils/index.d.ts"
     }
   },
   "scripts": {

--- a/libs/base-utils/src/buffer-and-hex-utils/types.spec.ts
+++ b/libs/base-utils/src/buffer-and-hex-utils/types.spec.ts
@@ -14,8 +14,6 @@ import {
   parseHexDataString,
   parseHexQuantityString,
   parseHexString,
-  isEthereumAddress,
-  parseEthereumAddress,
 } from './types';
 
 describe('`hex-types` tests', () => {
@@ -139,25 +137,5 @@ describe('`hex-types` tests', () => {
     expect(parseHexDataString('0x00420000')).toBe('0x00420000');
     expect(parseHexDataString('0x41')).toBe('0x41');
     expect(parseHexDataString('0x000000000000')).toBe('0x000000000000');
-  });
-
-  test(`'Ethereum address encoding`, () => {
-    expect(isEthereumAddress('0xabc')).toBe(false);
-    expect(
-      isEthereumAddress('0xabcdef0123456789abcdef0123456789abcdef01'),
-    ).toBe(true);
-    expect(
-      isEthereumAddress('0xabcdef0123456789abcdef0123456789abcdef012'),
-    ).toBe(false);
-
-    expect(
-      parseEthereumAddress('0xabcdef0123456789abcdef0123456789abcdef01'),
-    ).toBe('0xabcdef0123456789abcdef0123456789abcdef01');
-
-    expect(() => {
-      parseEthereumAddress('0xabc');
-    }).toThrowError(
-      `Expected argument in hex string format (0xab12...) with byte length >= 40. Got: '0xabc'`,
-    );
   });
 });

--- a/libs/base-utils/src/buffer-and-hex-utils/types.ts
+++ b/libs/base-utils/src/buffer-and-hex-utils/types.ts
@@ -80,19 +80,4 @@ export function parseHexQuantityString(input: unknown): HexQuantityString {
   else throw new ExpectedHexStringError(String(input), 'quantity');
 }
 
-// Ethereum address
-
-export const ethereumAddress = hexDataString.pipe(
-  S.pattern(/^0x([0-9a-fA-F]{40})$/),
-  S.brand('EthereumAddress'),
-);
-export type EthereumAddress = S.Schema.Type<typeof ethereumAddress>;
-
-export const isEthereumAddress = S.is(ethereumAddress);
-
-export function parseEthereumAddress(input: unknown): EthereumAddress {
-  if (isEthereumAddress(input)) return input;
-  else throw new ExpectedHexStringError(String(input), 40);
-}
-
 export type Without0x<S extends string> = S extends `0x${infer R}` ? R : S;

--- a/libs/base-utils/src/evm-utils/hex-types.spec.ts
+++ b/libs/base-utils/src/evm-utils/hex-types.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2023 Blockdaemon Inc.
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Schelling Point Labs Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, expect, test } from 'vitest';
+
+import {
+  isEthereumAddress,
+  parseEthereumAddress,
+  isHash32byte,
+  parseHash32byte,
+  isTxHash,
+  parseTxHash,
+} from './hex-types';
+
+describe('Hex types', () => {
+  test(`'isEthereumAddress' should return true for valid Ethereum addresses`, () => {
+    expect(
+      isEthereumAddress('0x0001020304050607080910111213141516171819'),
+    ).toBe(true);
+    expect(
+      isEthereumAddress('0xaabbccddeeff00112233445566778899aabbccdd'),
+    ).toBe(true);
+    expect(
+      isEthereumAddress('0xAABBCCDDEEFF00112233445566778899AABBCCDD'),
+    ).toBe(true);
+
+    expect(
+      parseEthereumAddress('0x0001020304050607080910111213141516171819'),
+    ).toBe('0x0001020304050607080910111213141516171819');
+    expect(
+      parseEthereumAddress('0xaabbccddeeff00112233445566778899aabbccdd'),
+    ).toBe('0xaabbccddeeff00112233445566778899aabbccdd');
+    expect(
+      parseEthereumAddress('0xAABBCCDDEEFF00112233445566778899AABBCCDD'),
+    ).toBe('0xAABBCCDDEEFF00112233445566778899AABBCCDD');
+  });
+
+  test(`'isEthereumAddress' should return false for invalid Ethereum addresses`, () => {
+    expect(isEthereumAddress('')).toBe(false);
+    expect(isEthereumAddress('0x')).toBe(false);
+    expect(isEthereumAddress('0x0')).toBe(false);
+    expect(isEthereumAddress('0x00')).toBe(false);
+    // 0x prefix is required
+    expect(isEthereumAddress('0001020304050607080910111213141516171819')).toBe(
+      false,
+    );
+    expect(isEthereumAddress('0xAABBCCDDEEFF00112233445566778899AABBCC')).toBe(
+      false,
+    );
+    expect(isEthereumAddress('0xAABBCCDDEEFF00112233445566778899AABBCCD')).toBe(
+      false,
+    );
+    expect(
+      isEthereumAddress('0xAABBCCDDEEFF00112233445566778899AABBCCDDE'),
+    ).toBe(false);
+    expect(
+      isEthereumAddress('0xAABBCCDDEEFF00112233445566778899AABBCCDDEE'),
+    ).toBe(false);
+  });
+
+  test(`'isEthereumAddress' - 0X prefix is not allowed`, () => {
+    expect(
+      isEthereumAddress('0Xaabbccddeeff00112233445566778899aabbccdd'),
+    ).toBe(false);
+    expect(
+      isEthereumAddress('0XAABBCCDDEEFF00112233445566778899AABBCCDD'),
+    ).toBe(false);
+  });
+
+  test(`'isHash32byte|isTxHash' should return true for valid 32-byte hashes`, () => {
+    expect(
+      isHash32byte(
+        '0x0001020304050607080910111213141516171819202122232425262728293031',
+      ),
+    ).toBe(true);
+    expect(
+      isTxHash(
+        '0x0001020304050607080910111213141516171819202122232425262728293031',
+      ),
+    ).toBe(true);
+
+    expect(
+      isHash32byte(
+        '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
+      ),
+    ).toBe(true);
+    expect(
+      isTxHash(
+        '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
+      ),
+    ).toBe(true);
+    expect(
+      isHash32byte(
+        '0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F',
+      ),
+    ).toBe(true);
+    expect(
+      isTxHash(
+        '0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F',
+      ),
+    ).toBe(true);
+
+    expect(
+      parseHash32byte(
+        '0x0001020304050607080910111213141516171819202122232425262728293031',
+      ),
+    ).toBe(
+      '0x0001020304050607080910111213141516171819202122232425262728293031',
+    );
+    expect(
+      parseTxHash(
+        '0x0001020304050607080910111213141516171819202122232425262728293031',
+      ),
+    ).toBe(
+      '0x0001020304050607080910111213141516171819202122232425262728293031',
+    );
+
+    expect(
+      parseHash32byte(
+        '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
+      ),
+    ).toBe(
+      '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
+    );
+    expect(
+      parseTxHash(
+        '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
+      ),
+    ).toBe(
+      '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
+    );
+
+    expect(
+      parseHash32byte(
+        '0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F',
+      ),
+    ).toBe(
+      '0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F',
+    );
+    expect(
+      parseTxHash(
+        '0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F',
+      ),
+    ).toBe(
+      '0x000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F',
+    );
+  });
+
+  test(`'isHash32byte|isTxHash' should return false for invalid 32-byte hashes`, () => {
+    expect(isHash32byte('')).toBe(false);
+    expect(isTxHash('')).toBe(false);
+    expect(isHash32byte('0x')).toBe(false);
+    expect(isTxHash('0x')).toBe(false);
+    expect(isHash32byte('0x0')).toBe(false);
+    expect(isTxHash('0x00')).toBe(false);
+    expect(
+      isHash32byte(
+        '0x000102030405060708091011121314151617181920212223242526272829303',
+      ),
+    ).toBe(false);
+    expect(
+      isTxHash(
+        '0x000102030405060708091011121314151617181920212223242526272829303',
+      ),
+    ).toBe(false);
+    expect(
+      isHash32byte(
+        '0x00010203040506070809101112131415161718192021222324252627282930331',
+      ),
+    ).toBe(false);
+    expect(
+      isTxHash(
+        '0x00010203040506070809101112131415161718192021222324252627282930331',
+      ),
+    ).toBe(false);
+    expect(
+      isHash32byte(
+        '0x000102030405060708091011121314151617181920212223242526272829303312',
+      ),
+    ).toBe(false);
+    expect(
+      isTxHash(
+        '0x000102030405060708091011121314151617181920212223242526272829303312',
+      ),
+    ).toBe(false);
+    expect(
+      isHash32byte(
+        '0x000102030405060708091011121314151617181920212223242526272829303313',
+      ),
+    ).toBe(false);
+    expect(
+      isTxHash(
+        '0x000102030405060708091011121314151617181920212223242526272829303313',
+      ),
+    ).toBe(false);
+    expect(
+      isEthereumAddress(
+        '0X0001020304050607080910111213141516171819202122232425262728293031',
+      ),
+    ).toBe(false);
+    expect(
+      isTxHash(
+        '0X0001020304050607080910111213141516171819202122232425262728293031',
+      ),
+    ).toBe(false);
+  });
+});

--- a/libs/base-utils/src/evm-utils/hex-types.ts
+++ b/libs/base-utils/src/evm-utils/hex-types.ts
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2023 Blockdaemon Inc.
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Schelling Point Labs Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import * as S from '@effect/schema/Schema';
+
+import { hexDataString } from '../buffer-and-hex-utils';
+
+// Ethereum address
+
+export const ethereumAddress = hexDataString.pipe(
+  S.pattern(/^0x([0-9a-fA-F]{40})$/),
+  S.brand('EthereumAddress'),
+);
+export type EthereumAddress = S.Schema.Type<typeof ethereumAddress>;
+export const isEthereumAddress = S.is(ethereumAddress);
+export const parseEthereumAddress = S.decodeUnknownSync(ethereumAddress);
+
+// 32-byte hex string
+
+export const hash32byte = hexDataString.pipe(
+  S.pattern(/^0x([0-9a-fA-F]{64})$/),
+  S.brand('32 byte hex string'),
+);
+export type Hash32byte = S.Schema.Type<typeof hash32byte>;
+
+export const isHash32byte = S.is(hash32byte);
+export const parseHash32byte = S.decodeUnknownSync(hash32byte);
+
+// EVM transaction hash
+
+export const txHash = hash32byte.pipe(S.brand('EVM transaction hash'));
+export type TxHash = S.Schema.Type<typeof txHash>;
+
+export const isTxHash = S.is(txHash);
+export const parseTxHash = S.decodeUnknownSync(txHash);

--- a/libs/base-utils/src/evm-utils/index.ts
+++ b/libs/base-utils/src/evm-utils/index.ts
@@ -1,0 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Schelling Point Labs Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+export * from './networks';
+export * from './hex-types';

--- a/libs/base-utils/src/evm-utils/networks.spec.ts
+++ b/libs/base-utils/src/evm-utils/networks.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2023 Blockdaemon Inc.
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Schelling Point Labs Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, expect, test } from 'vitest';
+import {
+  isNetworkName,
+  isChainId,
+  isNetwork,
+  parseNetworkName,
+  parseChainId,
+  parseNetwork,
+  chainIdToNetworkName,
+  explorerUrls,
+  networkNameToChainId,
+} from './networks';
+import { parseTxHash } from './hex-types';
+
+describe('Network constants tests', () => {
+  test(`'isNetworkName' should return true for valid network names`, () => {
+    expect(isNetworkName('mainnet')).toBe(true);
+    expect(isNetworkName('sepolia')).toBe(true);
+    expect(isNetworkName('holesky')).toBe(true);
+  });
+
+  test(`'isNetworkName' should return false for invalid network names`, () => {
+    expect(isNetworkName('')).toBe(false);
+    expect(isNetworkName('asd')).toBe(false);
+    expect(isNetworkName('MAINNET')).toBe(false);
+    expect(isNetworkName('goerli')).toBe(false);
+    expect(isNetworkName('HOLESKY')).toBe(false);
+  });
+
+  test(`'parseNetworkName' should return the network name if it is valid`, () => {
+    const validNetworkName = 'mainnet';
+    const result = parseNetworkName(validNetworkName);
+    expect(result).toBe(validNetworkName);
+  });
+
+  test(`'parseNetworkName' should throw an error if the network name is not valid`, () => {
+    const invalidNetworkName = 'asd';
+    expect(() => parseNetworkName(invalidNetworkName)).toThrowError();
+  });
+
+  test(`'isChainId' should return true for valid chain IDs`, () => {
+    expect(isChainId(1)).toBe(true);
+    expect(isChainId(11155111)).toBe(true);
+    expect(isChainId(17000)).toBe(true);
+  });
+
+  test(`'isChainId' should return false for invalid chain IDs`, () => {
+    expect(isChainId(0)).toBe(false);
+    expect(isChainId('asd')).toBe(false);
+    expect(isChainId(false)).toBe(false);
+    expect(isChainId({})).toBe(false);
+  });
+
+  test(`'parseChainId' should return the chain ID if it is valid`, () => {
+    expect(parseChainId(1)).toBe(1);
+  });
+
+  test(`'parseChainId' should throw an error if the chain ID is not valid`, () => {
+    expect(() => parseChainId(0)).toThrowError();
+    expect(() => parseChainId(true)).toThrowError();
+    expect(() => parseChainId({})).toThrowError();
+  });
+
+  test(`'isNetwork' should return true for network names and chain ids`, () => {
+    expect(isNetwork('mainnet')).toBe(true);
+    expect(isNetwork(1)).toBe(true);
+  });
+
+  test(`'isNetwork' should return false for invalid network names and chain ids`, () => {
+    expect(isNetwork('asd')).toBe(false);
+    expect(isNetwork(0)).toBe(false);
+    expect(isNetwork(true)).toBe(false);
+    expect(isNetwork({})).toBe(false);
+  });
+
+  test(`'parseNetwork' should return the network name if it is valid`, () => {
+    expect(parseNetwork(1)).toBe(1);
+    expect(parseNetwork('mainnet')).toBe('mainnet');
+  });
+
+  test(`'parseNetwork' should throw an error if the network name is not valid`, () => {
+    expect(() => parseNetwork('asd')).toThrowError();
+    expect(() => parseNetwork(0)).toThrowError();
+    expect(() => parseNetwork(true)).toThrowError();
+    expect(() => parseNetwork({})).toThrowError();
+  });
+
+  test(`'networkNameToChainId' should return the correct chain ID for each network`, () => {
+    expect(networkNameToChainId.mainnet).toBe(1);
+    expect(networkNameToChainId.sepolia).toBe(11155111);
+    expect(networkNameToChainId.holesky).toBe(17000);
+  });
+
+  test(`'chainIdToNetworkName' should return the network name for a valid chain ID`, () => {
+    expect(chainIdToNetworkName[1]).toBe('mainnet');
+    expect(chainIdToNetworkName[11155111]).toBe('sepolia');
+    expect(chainIdToNetworkName[17000]).toBe('holesky');
+  });
+
+  test(`'explorerUrls' should return the correct explorer URL for supported network`, () => {
+    const txHash = parseTxHash(
+      '0xe75fb554e433e03763a1560646ee22dcb74e5274b34c5ad644e7c0f619a7e1d0',
+    );
+    expect(explorerUrls.mainnet(txHash)).toBe(
+      `https://etherscan.io/tx/${txHash}`,
+    );
+    expect(explorerUrls.sepolia(txHash)).toBe(
+      `https://sepolia.etherscan.io/tx/${txHash}`,
+    );
+    expect(explorerUrls.holesky(txHash)).toBe(
+      `https://holesky.etherscan.io/tx/${txHash}`,
+    );
+    expect(explorerUrls.amoy(txHash)).toBe(
+      `https://amoy.polygonscan.com/tx/${txHash}`,
+    );
+    expect(explorerUrls.manta(txHash)).toBe(
+      `https://pacific-explorer.sepolia-testnet.manta.network/tx/${txHash}`,
+    );
+    expect(explorerUrls.fuji(txHash)).toBe(
+      `https://testnet.snowtrace.io/tx/${txHash}`,
+    );
+    expect(explorerUrls.chiado(txHash)).toBe(
+      `https://gnosis-chiado.blockscout.com/tx/${txHash}`,
+    );
+    expect(explorerUrls.opSepolia(txHash)).toBe(
+      `https://sepolia-optimism.etherscan.io/tx/${txHash}`,
+    );
+    expect(explorerUrls.zkSyncSepolia(txHash)).toBe(
+      `https://sepolia.explorer.zksync.io/tx/${txHash}`,
+    );
+    expect(explorerUrls.baseSepolia(txHash)).toBe(
+      `https://sepolia.basescan.org/tx/${txHash}`,
+    );
+    expect(explorerUrls.specular(txHash)).toBe(
+      `https://explorer.specular.network/tx/${txHash}`,
+    );
+    expect(explorerUrls.scrollSepolia(txHash)).toBe(
+      `https://sepolia.scrollscan.com/tx/${txHash}`,
+    );
+    expect(explorerUrls.arbSepolia(txHash)).toBe(
+      `https://sepolia.arbiscan.io/tx/${txHash}`,
+    );
+    expect(explorerUrls.artio(txHash)).toBe(
+      `https://artio.beratrail.io/tx/${txHash}`,
+    );
+    expect(explorerUrls.hekla(txHash)).toBe(
+      `https://hekla.taikoscan.io/tx/${txHash}`,
+    );
+  });
+});

--- a/libs/base-utils/src/evm-utils/networks.ts
+++ b/libs/base-utils/src/evm-utils/networks.ts
@@ -1,0 +1,138 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2023 Blockdaemon Inc.
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Schelling Point Labs Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import * as S from '@effect/schema/Schema';
+import { InverseOf } from '../type-level';
+import { TxHash } from './hex-types';
+
+const networks = [
+  'mainnet',
+  'sepolia',
+  'holesky',
+  'amoy',
+  'manta',
+  'fuji',
+  'chiado',
+  'opSepolia',
+  'zkSyncSepolia',
+  'baseSepolia',
+  'specular',
+  'scrollSepolia',
+  'arbSepolia',
+  'artio',
+  'hekla',
+] as const;
+
+const chainIds = [
+  1, 11155111, 17000, 80002, 3441006, 43113, 10200, 11155420, 300, 84532, 13527,
+  534351, 421614, 80085, 167009,
+] as const;
+
+export const networkName = S.Literal(...networks);
+export const isNetworkName = S.is(networkName);
+export const parseNetworkName = S.encodeSync(networkName);
+export type NetworkName = S.Schema.Type<typeof networkName>;
+
+export const chainId = S.Literal(...chainIds);
+export const isChainId = S.is(chainId);
+export const parseChainId = S.encodeSync(chainId);
+export type ChainId = S.Schema.Type<typeof chainId>;
+
+export const network = S.Union(networkName, chainId);
+export const isNetwork = S.is(network);
+export const parseNetwork = S.encodeSync(network);
+export type Network = S.Schema.Type<typeof network>;
+
+/**
+ * Maps network names to their corresponding chain IDs.
+ *
+ * @remarks
+ * The `networkNameToChainId` constant is a mapping object that associates network names with their respective chain IDs.
+ * The keys of the object are the network names, and the values are the corresponding chain IDs.
+ *
+ * Example:
+ * ```typescript
+ * networkNameToChainId.mainnet; // Returns 1
+ * networkNameToChainId.sepolia; // Returns 11155111
+ * networkNameToChainId.holesky; // Returns 17000
+ * ```
+ */
+export const networkNameToChainId = {
+  mainnet: 1,
+  sepolia: 11155111,
+  holesky: 17000,
+  amoy: 80002,
+  manta: 3441006,
+  fuji: 43113,
+  chiado: 10200,
+  opSepolia: 11155420,
+  zkSyncSepolia: 300,
+  baseSepolia: 84532,
+  specular: 13527,
+  scrollSepolia: 534351,
+  arbSepolia: 421614,
+  artio: 80085,
+  hekla: 167009,
+} satisfies {
+  [Net in NetworkName]: ChainId;
+};
+
+/**
+ * Converts a chain ID to its corresponding network name.
+ *
+ * @param chainId - The chain ID to convert.
+ * @returns The network name associated with the given chain ID.
+ *
+ * Example:
+ * ```typescript
+ * chainIdToNetworkName[1]; // Returns 'mainnet'
+ * chainIdToNetworkName[11155111]; // Returns 'sepolia'
+ * chainIdToNetworkName[17000]; // Returns 'holesky'
+ * ```
+ */
+export const chainIdToNetworkName = {
+  1: 'mainnet',
+  11155111: 'sepolia',
+  17000: 'holesky',
+  80002: 'amoy',
+  3441006: 'manta',
+  43113: 'fuji',
+  10200: 'chiado',
+  11155420: 'opSepolia',
+  300: 'zkSyncSepolia',
+  84532: 'baseSepolia',
+  13527: 'specular',
+  534351: 'scrollSepolia',
+  421614: 'arbSepolia',
+  80085: 'artio',
+  167009: 'hekla',
+} satisfies InverseOf<typeof networkNameToChainId>;
+
+/**
+ * Mapping of network names to explorer URL.
+ * The URL generator function takes a transaction hash as input and returns the corresponding explorer URL.
+ */
+export const explorerUrls = {
+  mainnet: txHash => `https://etherscan.io/tx/${txHash}`,
+  sepolia: txHash => `https://sepolia.etherscan.io/tx/${txHash}`,
+  holesky: txHash => `https://holesky.etherscan.io/tx/${txHash}`,
+  amoy: txHash => `https://amoy.polygonscan.com/tx/${txHash}`,
+  manta: txHash =>
+    `https://pacific-explorer.sepolia-testnet.manta.network/tx/${txHash}`,
+  fuji: txHash => `https://testnet.snowtrace.io/tx/${txHash}`,
+  chiado: txHash => `https://gnosis-chiado.blockscout.com/tx/${txHash}`,
+  opSepolia: txHash => `https://sepolia-optimism.etherscan.io/tx/${txHash}`,
+  zkSyncSepolia: txHash => `https://sepolia.explorer.zksync.io/tx/${txHash}`,
+  baseSepolia: txHash => `https://sepolia.basescan.org/tx/${txHash}`,
+  specular: txHash => `https://explorer.specular.network/tx/${txHash}`,
+  scrollSepolia: txHash => `https://sepolia.scrollscan.com/tx/${txHash}`,
+  arbSepolia: txHash => `https://sepolia.arbiscan.io/tx/${txHash}`,
+  artio: txHash => `https://artio.beratrail.io/tx/${txHash}`,
+  hekla: txHash => `https://hekla.taikoscan.io/tx/${txHash}`,
+} satisfies {
+  [network in NetworkName]: (tx: TxHash) => string;
+};

--- a/libs/base-utils/src/type-level.ts
+++ b/libs/base-utils/src/type-level.ts
@@ -7,6 +7,24 @@
 
 export type PrimitiveType = boolean | number | string | symbol | bigint;
 
+export type KeysOf<T> = Extract<keyof T, string>;
+export type ValuesOf<T> = T[KeysOf<T>];
+export type Entries<T> = {
+  [K in keyof T]: [K, T[K]];
+}[keyof T][];
+
+export type KeyFromValue<V, T extends Record<PropertyKey, PropertyKey>> = {
+  [K in KeysOf<T>]: V extends T[K] ? K : never;
+}[KeysOf<T>];
+
+/**
+ *  Computes the inverse map of an object.
+ *  Example: { a: 1, b: 2} => { 1: a, 2: b}
+ */
+export type InverseOf<T extends Record<PropertyKey, PropertyKey>> = {
+  [V in ValuesOf<T>]: KeyFromValue<V, T>;
+};
+
 /**
  * Recursively replaces instances of the type `Replace` with `WithThat` in the
  * given type `Where`.


### PR DESCRIPTION
#### Summary:
This PR introduces the `evm-utils` module within the `base-utils` library. The new module provides utility functions and types for handling Ethereum addresses, 32-byte hashes, and EVM transaction hashes, as well as network-related utilities.

#### Key Changes:
1. **Removal of Ethereum Address Utilities from `buffer-and-hex-utils`:**
   - The Ethereum address-related utilities (validation, parsing, type definition) have been removed from `buffer-and-hex-utils/types.ts` to avoid redundancy with the new `evm-utils` module.

2. **New `evm-utils` Module:**
   - **Types and Functions:**
     - Introduced types for Ethereum addresses, 32-byte hashes, and EVM transaction hashes.
     - Added functions for validating and parsing these types (`isEthereumAddress`, `parseEthereumAddress`, `isHash32byte`, `parseHash32byte`, `isTxHash`, `parseTxHash`).
   - **Network Utilities:**
     - Added support for Ethereum network names and chain IDs (`isNetworkName`, `isChainId`, `isNetwork`, `parseNetworkName`, `parseChainId`, `parseNetwork`).
     - Mapping between network names and chain IDs and vice versa (`networkNameToChainId`, `chainIdToNetworkName`).
     - Explorer URLs for different networks (`explorerUrls`).

3. **Tests:**
   - Added comprehensive unit tests for the `evm-utils` module:
     - Address and hash validations.
     - Parsing functions.
     - Network name and chain ID utilities.

#### Impact:
- This module centralizes EVM-related utilities, making it easier to manage and extend. It also decouples Ethereum-specific logic from the more generic `buffer-and-hex-utils` module.
