### PR TITLE
[docs.ws]: Add missing abi name to functions

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/Functions.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Functions.tsx
@@ -60,18 +60,18 @@ export const Functions = ({ functions, isFromSourceUnit }: FunctionsProps) => {
         ref={elementsRef}
       >
         {functions?.map(_function => {
-          const id = _function.name || _function.kind;
+          const functionId = _function.name || _function.kind;
           return (
-            <AccordionItem key={id} value={id}>
-              <AccordionTrigger onClick={() => toggleAccordion(id)}>
+            <AccordionItem key={functionId} value={functionId}>
+              <AccordionTrigger onClick={() => toggleAccordion(functionId)}>
                 <AnchorLinkTitle
                   accordion
-                  title={_function.name || _function.kind}
+                  title={functionId}
                   titleLevel={isFromSourceUnit ? 4 : 5}
                 />
               </AccordionTrigger>
               <AccordionContent
-                className={`accordion-content ${accordionStates[id] ? 'expanded' : ''} p-2 sm:p-4 border-b border-gray-200`}
+                className={`accordion-content ${accordionStates[functionId] ? 'expanded' : ''} p-2 sm:p-4 border-b border-gray-200`}
               >
                 <section className="function-details__signature">
                   <Signature signature={_function.signature} />
@@ -84,7 +84,7 @@ export const Functions = ({ functions, isFromSourceUnit }: FunctionsProps) => {
                   <section className="function-details__parameters mb-4">
                     <Parameters
                       parameters={_function._parameters}
-                      parentTitle={_function.name || _function.kind}
+                      parentTitle={functionId}
                       titleLevel={isFromSourceUnit ? 5 : 6}
                       columns={['type', 'name', 'dataLocation', 'description']}
                     />
@@ -97,7 +97,7 @@ export const Functions = ({ functions, isFromSourceUnit }: FunctionsProps) => {
                       <Parameters
                         parameters={_function._returnParameters}
                         title="Return Parameters"
-                        parentTitle={_function.name || _function.kind}
+                        parentTitle={functionId}
                         titleLevel={isFromSourceUnit ? 5 : 6}
                         columns={[
                           'type',
@@ -114,7 +114,7 @@ export const Functions = ({ functions, isFromSourceUnit }: FunctionsProps) => {
                 </section>
                 <footer className="function-details__footer flex justify-between items-center mt-2">
                   <aside className="function-details__abi-modal flex-shrink-0">
-                    <ABIModal abi={_function.abi} name={_function.name} />
+                    <ABIModal abi={_function.abi} name={functionId} />
                   </aside>
                   <aside className="function-details__selector flex-shrink-0">
                     <Selector selector={_function.functionSelector} />


### PR DESCRIPTION
When the function has no name, it is empty, instead we need to get the kind of the function.

Before:
![image](https://github.com/user-attachments/assets/f1df0156-436b-4ab0-9d15-f07c4f916e8c)
![image](https://github.com/user-attachments/assets/e94e07b5-2f39-46bd-8ea2-85f12e2389ee)

After:
![image](https://github.com/user-attachments/assets/30ec3120-6ac8-4c22-a9b9-1b1cce10ed9d)
![image](https://github.com/user-attachments/assets/7db85eea-dc8f-4d26-9875-9ae3d38ae1bd)