### PR TITLE
config(nix/modules): Add the `FEEDS_CONFIG_DIR` variable

### DIFF
--- a/nix/modules/sequencer/backends/process-compose.nix
+++ b/nix/modules/sequencer/backends/process-compose.nix
@@ -41,6 +41,7 @@ let
     value.process-compose = {
       command = "${reporter.program}";
       environment = [
+        "FEEDS_CONFIG_DIR=${../../../../libs/feed_registry}"
         "REPORTER_CONFIG_DIR=${reportersConfigJSON.${name}}/reporter-${name}"
         "RUST_LOG=${conf.log-level}"
       ];
@@ -54,6 +55,7 @@ in
       blocksense-sequencer.process-compose = {
         command = "${sequencer.program}";
         environment = [
+          "FEEDS_CONFIG_DIR=${../../../../libs/feed_registry}"
           "SEQUENCER_CONFIG_DIR=${sequencerConfigJSON}"
           "SEQUENCER_LOGGING_LEVEL=${lib.toUpper cfg.sequencer.log-level}"
         ];

--- a/nix/modules/sequencer/backends/systemd.nix
+++ b/nix/modules/sequencer/backends/systemd.nix
@@ -33,6 +33,7 @@ let
       wantedBy = [ "multi-user.target" ];
       requires = [ "blocksense-sequencer.service" ];
       environment = {
+        FEEDS_CONFIG_DIR = "${../../../../libs/feed_registry}";
         REPORTER_CONFIG_DIR = "/etc/blocksense/reporter-${name}";
         RUST_LOG = "${conf.log-level}";
       };
@@ -64,6 +65,7 @@ in
           (map (x: "blocksense-anvil-${x}.service"))
         ];
         environment = {
+          FEEDS_CONFIG_DIR = "${../../../../libs/feed_registry}";
           SEQUENCER_CONFIG_DIR = "/etc/blocksense";
           SEQUENCER_LOGGING_LEVEL = "${lib.toUpper cfg.sequencer.log-level}";
         };


### PR DESCRIPTION
## Description

Since the latest refactoring to the feeds registry, the sequencer and the reporter need the `FEEDS_CONFIG_DIR` variable.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (refactoring already existing functionality)

## How to test

Run `direnv allow` and `process-compose`

## Checklist

- [X] The new changes/fixes are tested
- [ ] Documentation is updated
- [X] I have performed a self-review of my own code
- [ ] All newly added code is well commented
