### PR TITLE
build(nix): Fix `foundry` on Apple Silicon systems

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, inputs, ... }:
 {
   imports = [
     ./shells
@@ -12,7 +12,7 @@
   } // (import ./lib lib);
 
   perSystem =
-    { inputs', ... }:
+    { inputs', system, ... }:
     {
       legacyPackages = {
         rustToolchain =
@@ -28,7 +28,12 @@
             targets.wasm32-wasi.latest.rust-std
           ];
 
-        inherit (inputs'.mcl-nixos-modules.checks) foundry;
+        foundry =
+          let
+            # https://github.com/ethereum/solidity/issues/12291
+            foundrySystem = if system == "aarch64-darwin" then "x86_64-darwin" else system;
+          in
+          inputs.mcl-nixos-modules.checks.${foundrySystem}.foundry;
       };
     };
 }


### PR DESCRIPTION
## Description

Due to this upstream issue [1], Foundry does not have aarch64-darwin.
To workaround this, we use the x86_64-darwin derivation, which should work via Rosetta 2.

[1]: https://github.com/ethereum/solidity/issues/12291

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (refactoring already existing functionality)

## Changes

Switched `foundry` from `aarch64-darwin` to `x86_64-darwin` on macos.

## How to test

`nix develop --impure` on MacOS Apple Silicon systems.