### PR TITLE
fix(docs.ws): Nextra toc is overlapping sidebar items content during scroll

### DIFF
--- a/libs/docs-theme/src/components/toc.tsx
+++ b/libs/docs-theme/src/components/toc.tsx
@@ -106,39 +106,40 @@ export function TOC({ headings, filePath }: TOCProps): ReactElement {
       )}
 
       {hasMetaInfo && (
-        <div
-          className={cn(
-            hasHeadings && 'nextra-toc__info-section',
-            'nx-mt-8 nx-bg-neutral-900 nx-bg-opacity-[0.02] nx-rounded-md nx-border nx-px-6 nx-py-4 nx-border-neutral-200/70 nx-pt-4',
-            'nx-sticky nx-bottom-0 nx-flex nx-flex-col nx-items-start nx-gap-1 nx-pb-2 dark:nx-border-neutral-800',
-            'contrast-more:nx-border-t contrast-more:nx-border-neutral-400 contrast-more:nx-shadow-none contrast-more:dark:nx-border-neutral-400',
-          )}
-        >
-          <div className="nx-flex nx-items-center nx-gap-2 dark:nx-border-neutral-600">
-            <FeedbackIcon />
-            {config.feedback.content ? (
-              <Anchor
-                className={linkClassName}
-                href={config.feedback.useLink()}
-                newWindow
-              >
-                {renderComponent(config.feedback.content)}
-              </Anchor>
-            ) : null}
+        <div className="nextra-toc__info-container nx-bg-white nx-sticky nx-bottom-0 nx-flex nx-flex-col nx-items-start nx-gap-1 nx-pb-2 dark:nx-border-neutral-800">
+          <div
+            className={cn(
+              hasHeadings && 'nextra-toc__info-section',
+              'nx-mt-4 nx-bg-neutral-900 nx-bg-opacity-[0.02] nx-rounded-md nx-border nx-px-6 nx-py-4 nx-border-neutral-200/70 nx-pt-4',
+              'contrast-more:nx-border-t contrast-more:nx-border-neutral-400 contrast-more:nx-shadow-none contrast-more:dark:nx-border-neutral-400',
+            )}
+          >
+            <div className="nx-flex nx-items-center nx-gap-2 dark:nx-border-neutral-600">
+              <FeedbackIcon />
+              {config.feedback.content ? (
+                <Anchor
+                  className={linkClassName}
+                  href={config.feedback.useLink()}
+                  newWindow
+                >
+                  {renderComponent(config.feedback.content)}
+                </Anchor>
+              ) : null}
+            </div>
+
+            <div className="nx-flex nx-items-center nx-gap-2 dark:nx-border-neutral-600">
+              <EditIcon />
+              {renderComponent(config.editLink.component, {
+                filePath,
+                className: linkClassName,
+                children: renderComponent(config.editLink.text),
+              })}
+            </div>
+
+            {renderComponent(config.toc.extraContent)}
+
+            {config.toc.backToTop && <BackToTop className={linkClassName} />}
           </div>
-
-          <div className="nx-flex nx-items-center nx-gap-2 dark:nx-border-neutral-600">
-            <EditIcon />
-            {renderComponent(config.editLink.component, {
-              filePath,
-              className: linkClassName,
-              children: renderComponent(config.editLink.text),
-            })}
-          </div>
-
-          {renderComponent(config.toc.extraContent)}
-
-          {config.toc.backToTop && <BackToTop className={linkClassName} />}
         </div>
       )}
     </div>

--- a/libs/docs-theme/src/nx-utilities/nx-background.css
+++ b/libs/docs-theme/src/nx-utilities/nx-background.css
@@ -1,3 +1,7 @@
+.nx-bg-white {
+  --tw-bg-opacity: 1;
+  background-color: rgba(255, 255, 255, var(--tw-bg-opacity));
+}
 .nx-bg-black {
   --tw-bg-opacity: 1;
   background-color: rgba(0, 0, 0, var(--tw-bg-opacity));


### PR DESCRIPTION
**Before:**
![image](https://github.com/user-attachments/assets/e4f5d016-ffca-470a-9902-e66b32e7fd83)

**After**
![image](https://github.com/user-attachments/assets/896ab5a9-5b1f-42a2-a84d-0325d14d1b47)

**Instructions to test:**
1. Go to the [**RoadMap**](https://docsblocksensenetwork-k09w4g246-blocksense.vercel.app/docs/overview/roadmap) page.
2. Start scrolling items to the bottom and see whether the content overlap continues. 
