### PR TITLE
[base-utils/buffer-and-hex-utils]: Fix circular dependencies

### DIFF
--- a/libs/base-utils/src/buffer-and-hex-utils/functions.spec.ts
+++ b/libs/base-utils/src/buffer-and-hex-utils/functions.spec.ts
@@ -8,12 +8,16 @@
 import { describe, expect, test } from 'vitest';
 import { Buffer } from 'buffer';
 
-import { HexDataString, parseHexDataString, parseHexString } from './types';
+import {
+  HexDataString,
+  parseHexDataString,
+  parseHexString,
+  byteLength,
+} from './types';
 
 import {
   addHexPrefix,
   arrayToHex,
-  byteLength,
   checkedHexToArray,
   hexToArray,
   hexToBuffer,

--- a/libs/base-utils/src/buffer-and-hex-utils/functions.ts
+++ b/libs/base-utils/src/buffer-and-hex-utils/functions.ts
@@ -9,6 +9,7 @@ import { Buffer } from 'buffer';
 
 import { ReplaceType } from '../type-level';
 import {
+  byteLength,
   HexDataString,
   HexQuantityString,
   HexString,
@@ -131,27 +132,6 @@ export function checkedHexToArray(
     );
   }
   return hexToArray(hex);
-}
-
-/**
- * Returns the byte length of a hexadecimal data string.
- *
- * This function calculates the byte length of the input hex string. If the hex string starts with '0x',
- * these two characters are not counted in the byte length. If the length of the hex string is not a multiple of 2,
- * an error is thrown.
- *
- * @param {HexDataString} hex - The hexadecimal data string to calculate the byte length of.
- * @returns {number} The byte length of the hex string.
- * @throws {Error} If the length of the hex string is not a multiple of 2.
- */
-export function byteLength(hex: HexDataString): number {
-  if (hex.length % 2 !== 0) {
-    throw new Error(
-      `Invalid length. Received: string '${hex}' with length ${hex.length}. Expected length to be a multiple of 2`,
-    );
-  }
-  const stringLength = hex.length - (hex.startsWith('0x') ? 2 : 0);
-  return stringLength / 2;
 }
 
 /**

--- a/libs/base-utils/src/buffer-and-hex-utils/types.ts
+++ b/libs/base-utils/src/buffer-and-hex-utils/types.ts
@@ -8,7 +8,6 @@
 import * as S from '@effect/schema/Schema';
 
 import { ExpectedHexStringError } from './errors';
-import { byteLength } from './functions';
 
 /**
  * Ethereum hex value encoding
@@ -81,3 +80,24 @@ export function parseHexQuantityString(input: unknown): HexQuantityString {
 }
 
 export type Without0x<S extends string> = S extends `0x${infer R}` ? R : S;
+
+/**
+ * Returns the byte length of a hexadecimal data string.
+ *
+ * This function calculates the byte length of the input hex string. If the hex string starts with '0x',
+ * these two characters are not counted in the byte length. If the length of the hex string is not a multiple of 2,
+ * an error is thrown.
+ *
+ * @param {HexDataString} hex - The hexadecimal data string to calculate the byte length of.
+ * @returns {number} The byte length of the hex string.
+ * @throws {Error} If the length of the hex string is not a multiple of 2.
+ */
+export function byteLength(hex: HexDataString): number {
+  if (hex.length % 2 !== 0) {
+    throw new Error(
+      `Invalid length. Received: string '${hex}' with length ${hex.length}. Expected length to be a multiple of 2`,
+    );
+  }
+  const stringLength = hex.length - (hex.startsWith('0x') ? 2 : 0);
+  return stringLength / 2;
+}


### PR DESCRIPTION
We encountered a circular dependency issue between `functions.ts` and `types.ts`. The `functions.ts` file was importing `types.ts` (as expected), but `types.ts` was also importing `functions.ts` solely for the `byteLength` function. This circular dependency caused Rollup to generate unexpected hash-indexed files for all exported functions and types during the build process, leading to problems when using the library.

**Solution:**  
To resolve this, we moved the `byteLength` function from `functions.ts` to `types.ts`, breaking the circular dependency. 