### PR TITLE
feat(docs): Move deployments instructions to root

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,46 @@
 
 ## Running the system
 
-### Supported deployment options:
+### Supported deployment options
 
-See [Blocksense Network Documentation Site](/apps/docs.blocksense.network/README.md)
+Supported deployments can be found under blocksense/nix/test-environments
+
+#### systemd deployment
+
+In order to perform a systemd deployment one needs to:
+
+1. Add as flake input `github:blocksense-network/blocksense`
+2. In the configuration of the machine, where the blocksense micro services will be deployed, the blocksense NixOS module must be imported:
+
+```
+imports = [
+   inputs.blocksense.nixosModules.blocksense-systemd
+];
+```
+
+3. To configure the sequencer, the reporters and the anvil nodes one can use the [setup1.nix](/nix/test-environments/setup1.nix) file.
+
+#### process-compose deployment
+
+First, make sure you have a `process-compose.yaml` file that can be generated
+by executing command:
+
+```sh
+direnv reload
+```
+
+the contents of `process-compose.yaml` are populated from the file
+`nix/test-environments/example-setup-01.nix`. To change the setup (add more
+reporters, change the feeds list etc) edit `example-setup-01.nix` and then run
+`direnv reload` again.
+
+The example setup is with 1 instance of the sequencer, 2 anvil nodes is
+supported.
+
+To perform this deployment, we need to run:
+
+```sh
+process-compose up
+```
+
+For more information, see [Blocksense Network Documentation Site](/apps/docs.blocksense.network/README.md)

--- a/apps/docs.blocksense.network/README.md
+++ b/apps/docs.blocksense.network/README.md
@@ -64,42 +64,4 @@ yarn test
 
 ### Available Deployments
 
-Supported deployments can be found under blocksense/nix/test-environments
-
-#### systemd deployment
-
-In order to perform a systemd deployment one needs to:
-
-1. Add as flake input `github:blocksense-network/blocksense`
-2. In the configuration of the machine, where the blocksense micro services will be deployed, the blocksense NixOS module must be imported:
-
-```
-imports = [
-   inputs.blocksense.nixosModules.blocksense-systemd
-];
-```
-
-3. To configure the sequencer, the reporters and the anvil nodes one can use the [setup1.nix](/nix/test-environments/setup1.nix) file.
-
-#### process-compose deployment
-
-First, make sure you have a `process-compose.yaml` file that can be generated
-by executing command:
-
-```sh
-direnv reload
-```
-
-the contents of `process-compose.yaml` are populated from the file
-`nix/test-environments/example-setup-01.nix`. To change the setup (add more
-reporters, change the feeds list etc) edit `example-setup-01.nix` and then run
-`direnv reload` again.
-
-The example setup is with 1 instance of the sequencer, 2 anvil nodes is
-supported.
-
-To perform this deployment, we need to run:
-
-```sh
-process-compose up
-```
+To learn more, see [the root readme](/README.md), section "Supported deployment options".


### PR DESCRIPTION
# What?

This PR moves the deployment instructions for the node software from the README of the docs project to the root of the monorepo. It also links back and forth between the two, to improve discovery for users.

# Background

This PR is due to the following comment:
https://github.com/blocksense-network/blocksense/pull/338#discussion_r1736911732

tl;dr: Pesho has noted that the right place for the deployment instructions is in the root README.md, not in apps/docs.blocksense.network/README.md.

This was noticed by Toni before, when he suggested the doc fix that sparked Pesho's comment. We decided to delay the move then, to keep the fix simpler and easier to review.