### PR TITLE
fix(docs.ws): Buttons and links inside nextra sidebar container should be using black Tailwind alternatives

### DIFF
--- a/apps/docs.blocksense.network/blocksense-theme/noto.css
+++ b/apps/docs.blocksense.network/blocksense-theme/noto.css
@@ -32,10 +32,6 @@ a {
   @apply text-slate-800;
 }
 
-a > span {
-  @apply not-italic text-slate-950;
-}
-
 ul > li {
   @apply text-neutral-600 mb-3 font-noto-sans-bold;
 }

--- a/libs/docs-theme/src/components/sidebar.tsx
+++ b/libs/docs-theme/src/components/sidebar.tsx
@@ -138,7 +138,7 @@ function FolderImpl({ item, anchors }: FolderProps): ReactElement {
       <ComponentToUse
         href={isLink ? item.route : undefined}
         className={cn(
-          'nx-items-center nx-justify-between nx-gap-1.5',
+          'nx-items-center nx-text-black nx-justify-between nx-gap-1.5',
           !isLink && 'nx-text-left nx-w-full nx-font-bold',
           classes.link,
           active ? classes.active : classes.inactive,

--- a/libs/docs-theme/src/components/toc.tsx
+++ b/libs/docs-theme/src/components/toc.tsx
@@ -104,7 +104,7 @@ export function TOC({ headings, filePath }: TOCProps): ReactElement {
       )}
 
       {hasMetaInfo && (
-        <div className="nextra-toc__info-container nx-sticky nx-bottom-0 nx-flex nx-flex-col nx-items-start nx-gap-1 dark:nx-border-neutral-800">
+        <div className="nextra-toc__info-container nx-bg-white nx-sticky nx-bottom-0 nx-flex nx-flex-col nx-items-start nx-gap-1 nx-pb-2 dark:nx-border-neutral-800">
           <div
             className={cn(
               hasHeadings && 'nextra-toc__info-section',


### PR DESCRIPTION
It seems that there is some small style inheritance problem for all links inside Nextra sidebar and they're not completely black:
**Before:**
![image](https://github.com/user-attachments/assets/bd3de07f-6150-409c-8766-8882509c685c)
**After:**
![image](https://github.com/user-attachments/assets/c04a2f40-da5a-45a2-8e08-189e54dce466)
