### PR TITLE
feat(docs.ws): Modify info icon from Nextra Callout

### DIFF
--- a/apps/docs.blocksense.network/pages/docs/contracts/guide/historic-data-feed.mdx
+++ b/apps/docs.blocksense.network/pages/docs/contracts/guide/historic-data-feed.mdx
@@ -170,7 +170,7 @@ In order to retrieve data from the contract, the client must call the `fallback`
 
 ### Solidity Hardhat Example
 
-<Callout type="info" title="Note">
+<Callout type="info">
   You can find a working Hardhat project
   [here](https://github.com/blocksense-network/blocksense/tree/main/libs/contracts).
   Clone the repo and follow the setup instructions to run the example locally.

--- a/libs/docs-theme/src/components/callout.tsx
+++ b/libs/docs-theme/src/components/callout.tsx
@@ -6,7 +6,7 @@ import { InformationCircleIcon } from '../icons/information-circle';
 const TypeToEmoji = {
   default: '💡',
   error: '🚫',
-  info: <InformationCircleIcon className="nx-mt-1" />,
+  info: <InformationCircleIcon />,
   warning: '⚠️',
 };
 

--- a/libs/docs-theme/src/icons/information-circle.tsx
+++ b/libs/docs-theme/src/icons/information-circle.tsx
@@ -6,17 +6,20 @@ export const InformationCircleIcon = (
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 20 20"
-      fill="currentColor"
-      width="20"
-      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      width="24"
+      height="24"
       {...props}
     >
+      <circle cx="12" cy="12" r="10" stroke="#1C274C" strokeWidth="1.5" />
       <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+        d="M12 17V11"
+        stroke="#1C274C"
+        strokeWidth="1.5"
+        strokeLinecap="round"
       />
+      <circle cx="12" cy="8" r="1" fill="#1C274C" />
     </svg>
   );
 };


### PR DESCRIPTION
Designed informational circle icon by Nextra looks like a spot, that has to be wiped out. We're modifying it with another so it will look more appealing to the end-user.

**Before:**
![image](https://github.com/user-attachments/assets/478ff811-b49c-41f7-b2b0-3ee83d070117)
**After:**
![image](https://github.com/user-attachments/assets/ca3e73ce-fe40-4474-af29-9fd57c2ad2c1)

**Instructions to test:**
1. Go to [Historic Data Feed, Solidity Hardhat example](https://docsblocksensenetwork-jw7ow9td9-blocksense.vercel.app/docs/contracts/guide/historic-data-feed#solidity-hardhat-example) from this deployment.
2. Make sure that the icon is there and hover it, no additional tooltips should be presented.
In our case we needed to remove the title from the callout defined into the mdx, so it's not giving very useful information and it's presenting dynamically the default tooltip we don't want. 