### PR TITLE
fix(docs.ws): Fix the position of tab-buttons-shadcn-ui

### DIFF
--- a/apps/docs.blocksense.network/components/ui/tabs.tsx
+++ b/apps/docs.blocksense.network/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 mb-2 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
       className,
     )}
     {...props}


### PR DESCRIPTION
During testing process of docs.ws, we noticed that the selected area tab roles are going out of the boundaries for the shadcn/ui tab. 

**Before:**
![image](https://github.com/user-attachments/assets/6be3b3a6-41b6-44f3-9e41-d69c1c67330c)
**After**
![image](https://github.com/user-attachments/assets/11f733f2-e9c6-4437-9d1e-3978619604c3)


