### PR TITLE
fix(docs.ws): Decrease vertical space below all h1 titles

### DIFF
--- a/libs/docs-theme/src/mdx-components.tsx
+++ b/libs/docs-theme/src/mdx-components.tsx
@@ -193,7 +193,7 @@ export const getComponents = ({
 
   const context = { index: 0 };
   return {
-    h1: props => <h1 className="nx-mt-6 nx-text-4xl nx-pb-4" {...props} />,
+    h1: props => <h1 className="nx-mt-6 nx-text-4xl" {...props} />,
     h2: props => <HeadingLink tag="h2" context={context} {...props} />,
     h3: props => <HeadingLink tag="h3" context={context} {...props} />,
     h4: props => <HeadingLink tag="h4" context={context} {...props} />,


### PR DESCRIPTION
We need to decrease a bit the space between titles and descriptions coming from Nextra.

**Before** vs **After**
_side by side_

![image](https://github.com/user-attachments/assets/5c81d9e0-9842-4180-ab4b-2a01a206f1f4)
