### PR TITLE
[docs.ws]: Add padding in data table toolbar

### DIFF
--- a/apps/docs.blocksense.network/components/ui/DataTable/DataTableToolbar.tsx
+++ b/apps/docs.blocksense.network/components/ui/DataTable/DataTableToolbar.tsx
@@ -28,7 +28,7 @@ export function DataTableToolbar<TData>({
   const isFiltered = table.getState().columnFilters.length > 0;
 
   return (
-    <div className="flex items-center justify-between overflow-x-auto gap-2">
+    <div className="flex items-center justify-between overflow-x-auto gap-2 p-1">
       <div className="flex flex-1 space-x-2 items-end">
         {filterCell && (
           <Input


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/a08baba8-1439-4ed1-b373-147846a3ec1b)
after:
![image](https://github.com/user-attachments/assets/8a2e7857-56f4-4542-97b7-38b65c71fc55)
