### PR TITLE
feat(docs.ws): Modify shadcn-ui-data-table-toolbar

### DIFF
--- a/apps/docs.blocksense.network/components/ui/DataTable/DataTableFacetedFilter.tsx
+++ b/apps/docs.blocksense.network/components/ui/DataTable/DataTableFacetedFilter.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { CirclePlus, Check } from 'lucide-react';
+import { Check } from 'lucide-react';
 import { Column } from '@tanstack/react-table';
 
 import { cn } from '@/lib/utils';
@@ -42,19 +42,7 @@ export function DataTableFacetedFilter<TData, TValue>({
     <Popover>
       <PopoverTrigger asChild>
         <Button variant="outline" size="sm" className="h-8 border-dashed">
-          <CirclePlus className="mr-2 h-4 w-4" />
           {title}
-          {selectedValues?.size > 0 && (
-            <>
-              <Separator orientation="vertical" className="mx-2 h-4" />
-              <Badge
-                variant="secondary"
-                className="rounded-sm px-1 font-normal m-0"
-              >
-                {selectedValues.size} selected
-              </Badge>
-            </>
-          )}
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[200px] p-0" align="start">

--- a/apps/docs.blocksense.network/components/ui/DataTable/DataTableToolbar.tsx
+++ b/apps/docs.blocksense.network/components/ui/DataTable/DataTableToolbar.tsx
@@ -28,21 +28,26 @@ export function DataTableToolbar<TData>({
   const isFiltered = table.getState().columnFilters.length > 0;
 
   return (
-    <div className="flex items-center justify-between overflow-x-auto gap-2 p-1">
-      <div className="flex flex-1 space-x-2 items-end">
-        {filterCell && (
-          <Input
-            placeholder="Filter descriptions..."
-            value={
-              (table.getColumn(filterCell)?.getFilterValue() as string) ?? ''
-            }
-            onChange={event =>
-              table.getColumn(filterCell)?.setFilterValue(event.target.value)
-            }
-            className="h-8 w-[150px] lg:w-[250px] border-solid border-slate-200"
-            type="search"
-          />
-        )}
+    <div className="flex flex-col md:flex-row items-center justify-between overflow-x-auto gap-2 px-1 py-2 lg:py-1">
+      <div className="flex flex-1 space-x-2 items-start w-full">
+        <div className="flex items-center space-x-2 w-full">
+          {filterCell && (
+            <Input
+              placeholder="Filter descriptions..."
+              value={
+                (table.getColumn(filterCell)?.getFilterValue() as string) ?? ''
+              }
+              onChange={event =>
+                table.getColumn(filterCell)?.setFilterValue(event.target.value)
+              }
+              className={`h-8 w-full lg:w-[250px] mr-1 lg:mr-2 border-solid border-slate-200 transition-all duration-200`}
+              type="search"
+            />
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-end w-full gap-1 lg:gap-2 mb-2">
         {filters?.map(
           filter =>
             table.getColumn(filter.name) && (
@@ -56,16 +61,15 @@ export function DataTableToolbar<TData>({
         )}
         {isFiltered && (
           <Button
-            variant="outline"
+            variant="ghost"
             onClick={() => table.resetColumnFilters()}
-            className="h-8 px-2 lg:px-3 border-solid border-slate-200"
+            className="h-8 p-1"
           >
-            Reset
-            <X className="ml-2 h-4 w-4" />
+            <X className="h-4 w-4" />
           </Button>
         )}
+        <DataTableViewOptions table={table} columnsTitles={columnsTitles} />
       </div>
-      <DataTableViewOptions table={table} columnsTitles={columnsTitles} />
     </div>
   );
 }


### PR DESCRIPTION
DataTable toolbar was not fitting well for smaller screens, so we needed to modify it, so it will fit better on mobile and slightly changed for large screens.

**After**:
![image](https://github.com/user-attachments/assets/d8bdedcd-54a0-46db-af4a-db2d96398565)
![image](https://github.com/user-attachments/assets/a25a3e44-6334-4103-9b8f-f50f42f59a80)


![image](https://github.com/user-attachments/assets/4d54647b-0f7c-473f-948c-6e09baea45fa)
![image](https://github.com/user-attachments/assets/bf900d59-9d6f-4a03-8cb5-a0192338fdfa)



