### PR TITLE
[docs.ws]: Rename feeds overview file name

### DIFF
--- a/apps/docs.blocksense.network/src/data-feeds/generate-data-feed-mdx.ts
+++ b/apps/docs.blocksense.network/src/data-feeds/generate-data-feed-mdx.ts
@@ -45,7 +45,7 @@ import { DataFeeds } from '@/components/DataFeeds/DataFeeds';
 
 function generateDataFeedsFile(): Promise<string[]> {
   const mdxFile = {
-    name: 'data-feeds-overview',
+    name: 'overview',
     content: generateMarkdownContent(),
   };
 
@@ -55,7 +55,7 @@ function generateDataFeedsFile(): Promise<string[]> {
     write({ ext: '.mdx', ...mdxFile }),
     writeJSON({
       base: '_meta.json',
-      content: { 'data-feeds-overview': 'Data Feeds Overview' },
+      content: { overview: 'Overview' },
     }),
   ]);
 }


### PR DESCRIPTION
With this, we fix word duplication in the url - > `docs/data-feeds/data-feeds-overview` -> `docs/data-feeds/overview`