### PR TITLE
feat(sequencer): tokio_console support added

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+
+[build]
+rustflags = ["--cfg", "tokio_unstable"]
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,7 +1498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes 1.7.1",
  "futures-util",
@@ -1520,6 +1520,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.3",
+ "bytes 1.7.1",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa 1.0.11",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite 0.2.14",
+ "rustversion",
+ "serde 1.0.210",
+ "sync_wrapper 1.0.1",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "axum-core"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1559,26 @@ dependencies = [
  "http-body 0.4.6",
  "mime",
  "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes 1.7.1",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite 0.2.14",
+ "rustversion",
+ "sync_wrapper 0.1.2",
  "tower-layer",
  "tower-service",
 ]
@@ -2475,6 +2522,45 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "console-api"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ed14aa9c9f927213c6e4f3ef75faaad3406134efe84ba2cb7983431d5f0931"
+dependencies = [
+ "futures-core",
+ "prost 0.13.2",
+ "prost-types 0.13.2",
+ "tonic 0.12.2",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e3a111a37f3333946ebf9da370ba5c5577b18eb342ec683eb488dd21980302"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "hyper-util",
+ "prost 0.13.2",
+ "prost-types 0.13.2",
+ "serde 1.0.210",
+ "serde_json",
+ "thread_local",
+ "tokio 1.40.0",
+ "tokio-stream",
+ "tonic 0.12.2",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4147,6 +4233,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "flate2",
+ "nom 7.1.3",
+ "num-traits 0.2.19",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4489,6 +4588,19 @@ dependencies = [
  "pin-project-lite 0.2.14",
  "tokio 1.40.0",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite 0.2.14",
+ "tokio 1.40.0",
+ "tower-service",
 ]
 
 [[package]]
@@ -5100,7 +5212,7 @@ checksum = "220a925fe6d49dbfa7523b20f5a5391f579b5d9dcf9dd1225606d00929fcab3a"
 dependencies = [
  "base64 0.21.7",
  "bytes 1.7.1",
- "prost",
+ "prost 0.12.6",
  "serde 1.0.210",
 ]
 
@@ -6134,11 +6246,11 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.12.6",
  "reqwest 0.11.27",
  "thiserror",
  "tokio 1.40.0",
- "tonic",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -6149,8 +6261,8 @@ checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
- "tonic",
+ "prost 0.12.6",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -6529,8 +6641,8 @@ checksum = "2580e33f2292d34be285c5bc3dba5259542b083cfad6037b6d70345f24dcb735"
 dependencies = [
  "heck 0.4.1",
  "itertools 0.11.0",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
 ]
 
 [[package]]
@@ -6543,7 +6655,7 @@ dependencies = [
  "chrono",
  "pbjson",
  "pbjson-build",
- "prost",
+ "prost 0.12.6",
  "prost-build",
  "serde 1.0.210",
 ]
@@ -7056,7 +7168,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes 1.7.1",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2ecbe40f08db5c006b5764a2645f7f3f141ce756412ac9e1dd6087e6d32995"
+dependencies = [
+ "bytes 1.7.1",
+ "prost-derive 0.13.2",
 ]
 
 [[package]]
@@ -7073,8 +7195,8 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "regex",
  "syn 2.0.77",
  "tempfile",
@@ -7094,6 +7216,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "prost-reflect"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7102,8 +7237,8 @@ dependencies = [
  "logos",
  "miette",
  "once_cell",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
 ]
 
 [[package]]
@@ -7112,7 +7247,16 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost",
+ "prost 0.12.6",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60caa6738c7369b940c3d49246a8d1749323674c65cb13010134f5c9bad5b519"
+dependencies = [
+ "prost 0.13.2",
 ]
 
 [[package]]
@@ -7149,9 +7293,9 @@ checksum = "ac532509cee918d40f38c3e12f8ef9230f215f017d54de7dd975015538a42ce7"
 dependencies = [
  "bytes 1.7.1",
  "miette",
- "prost",
+ "prost 0.12.6",
  "prost-reflect",
- "prost-types",
+ "prost-types 0.12.6",
  "protox-parse",
  "thiserror",
 ]
@@ -7164,7 +7308,7 @@ checksum = "7f6c33f43516fe397e2f930779d720ca12cd057f7da4cd6326a0ef78d69dee96"
 dependencies = [
  "logos",
  "miette",
- "prost-types",
+ "prost-types 0.12.6",
  "thiserror",
 ]
 
@@ -8236,6 +8380,7 @@ dependencies = [
  "async-channel 2.3.1",
  "bytes 1.7.1",
  "chrono",
+ "console-subscriber",
  "conv",
  "crypto",
  "data_feeds",
@@ -9711,6 +9856,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.7",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -9979,17 +10125,47 @@ checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes 1.7.1",
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.12.6",
+ "tokio 1.40.0",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.5",
+ "base64 0.22.1",
+ "bytes 1.7.1",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-timeout 0.5.1",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.2",
+ "socket2 0.5.7",
  "tokio 1.40.0",
  "tokio-stream",
  "tower",
@@ -10426,6 +10602,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 name = "utils"
 version = "0.1.1"
 dependencies = [
+ "console-subscriber",
  "hex",
  "once_cell",
  "tokio 1.40.0",
@@ -10648,9 +10825,9 @@ dependencies = [
  "pbjson",
  "pbjson-build",
  "pbjson-types",
- "prost",
+ "prost 0.12.6",
  "prost-build",
- "prost-types",
+ "prost-types 0.12.6",
  "protox",
  "regex",
  "serde 1.0.210",
@@ -10668,8 +10845,8 @@ dependencies = [
  "hex",
  "indexmap 2.5.0",
  "pbjson-types",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "semver 1.0.23",
  "serde 1.0.210",
  "serde_with",
@@ -10688,7 +10865,7 @@ checksum = "513ef81a5bb1ac5d7bd04f90d3c192dad8f590f4c02b3ef68d3ae4fbbb53c1d7"
 dependencies = [
  "anyhow",
  "indexmap 2.5.0",
- "prost",
+ "prost 0.12.6",
  "thiserror",
  "warg-crypto",
  "warg-protobuf",

--- a/apps/sequencer/Cargo.toml
+++ b/apps/sequencer/Cargo.toml
@@ -54,7 +54,7 @@ prometheus = { path = "../../libs/prometheus" }
 
 reqwest = { version = "0.12", features = ["multipart", "blocking"] }
 # async
-tokio = { version = "1.4.0", features = ["full"] }
+tokio = { version = "1.4.0", features = ["full", "tracing"] }
 
 # misc
 eyre = "0.6.12"
@@ -81,6 +81,7 @@ conv = "0.3.3"
 uuid = { version = "1.8.0", features = ["v4"] }
 chrono = "0.4.38"
 ringbuf = "0.4.0"
+console-subscriber = "0.4.0"
 
 [[bin]]
 name = "sequencer"

--- a/apps/sequencer/bin/sequencer_runner.rs
+++ b/apps/sequencer/bin/sequencer_runner.rs
@@ -117,7 +117,6 @@ pub async fn prepare_http_servers(
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    init_shared_logging_handle();
     let mut start_metrics_server = true;
 
     let mut args = env::args().skip(1);
@@ -133,7 +132,11 @@ async fn main() -> std::io::Result<()> {
             "--no-metrics-server" => {
                 start_metrics_server = false;
             }
+            "--no-tokio-console" => {
+                env::set_var("SEQUENCER_TOKIO_CONSOLE", "false");
+            }
             "--validate-config" => {
+                init_shared_logging_handle();
                 println!("Validating configuration for version:");
                 println!("version => {BLOCKSENSE_VERSION}");
                 println!("git_hash => {GIT_HASH}");
@@ -171,6 +174,7 @@ async fn main() -> std::io::Result<()> {
             }
         }
     }
+    init_shared_logging_handle();
 
     let sequencer_config = get_validated_sequencer_config();
     let feeds_config = get_validated_feeds_config();

--- a/libs/utils/Cargo.toml
+++ b/libs/utils/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { version = "1.4.0", features = ["full"] }
 tracing = { version = "0.1.40", features = ["async-await", "log"] }
 tracing-subscriber = { version = "0.3.18", features = ["json"] }
 once_cell = "1.20.0"
+console-subscriber = "0.4.0"
 
 [build-dependencies]
 # All features enabled

--- a/libs/utils/src/logging.rs
+++ b/libs/utils/src/logging.rs
@@ -3,7 +3,8 @@ use std::env;
 use std::sync::Arc;
 use std::sync::Mutex;
 use tracing_subscriber::filter::LevelFilter;
-use tracing_subscriber::{filter, fmt, prelude::*, reload, Registry};
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::{filter, fmt, reload, Registry};
 
 type Handle = tracing_subscriber::reload::Handle<LevelFilter, Registry>;
 pub type SharedLoggingHandle = Arc<Mutex<LoggingHandle>>;
@@ -41,6 +42,13 @@ pub fn init_shared_logging_handle() -> SharedLoggingHandle {
     SHARED_LOGGING_HANDLE.clone()
 }
 
+pub fn tokio_console_active() -> bool {
+    match env::var("SEQUENCER_TOKIO_CONSOLE") {
+        Ok(val) => val == "true",
+        Err(_) => true,
+    }
+}
+
 pub fn init_logging_handle() -> LoggingHandle {
     let filter = match env::var("SEQUENCER_LOGGING_LEVEL") {
         Ok(logging_level) => match str_to_filter_level(logging_level.as_str()) {
@@ -50,11 +58,29 @@ pub fn init_logging_handle() -> LoggingHandle {
         Err(_) => filter::LevelFilter::INFO,
     };
 
-    let (filter, reload_handle) = reload::Layer::new(filter);
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(fmt::Layer::default())
-        .init();
+    let tokio_console = tokio_console_active();
+
+    let (layer_filter, reload_handle) = reload::Layer::new(filter);
+
+    if tokio_console {
+        // spawn the console server in the background,
+        // returning a `Layer`:
+        let console_layer = console_subscriber::spawn();
+
+        // build a `Subscriber` by combining layers with a
+        // `tracing_subscriber::Registry`:
+        tracing_subscriber::registry()
+            // add the console layer to the subscriber
+            .with(console_layer)
+            // add the logs layer
+            .with(tracing_subscriber::fmt::layer().with_filter(filter))
+            .init();
+    } else {
+        tracing_subscriber::registry()
+            .with(layer_filter)
+            .with(fmt::Layer::default())
+            .init();
+    }
     LoggingHandle {
         handle: reload_handle,
     }
@@ -69,6 +95,7 @@ mod tests {
     fn test_set_logging_levels() {
         // Test env variable sets up the logging level
         env::set_var("SEQUENCER_LOGGING_LEVEL", "TRACE");
+        env::set_var("SEQUENCER_TOKIO_CONSOLE", "false");
         let shared_logging_handle = init_shared_logging_handle();
         let logging_handle = shared_logging_handle.lock().unwrap();
 


### PR DESCRIPTION
In order to have better insight into the performance of the sequencer this commit introduces console-subscriber integration, which serves telemetry data to be used by tokio_console. The serving of telemetry on port 6669 (the default for tokio console) is activated in the sequencer by default and can be disabled by providing a parameter `--no-tokio-console` to the sequencer executable, or an environment variable `SEQUENCER_TOKIO_CONSOLE=false`. To monitor the data we need to install `cargo install tokio-console`and run it while the sequencer is running.