### PR TITLE
feat(docs.ws): Modify focus states across components

### DIFF
--- a/apps/docs.blocksense.network/components/ui/badge.tsx
+++ b/apps/docs.blocksense.network/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2.5 py-0.5 mr-4 mt-4 mb-4 text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 mr-4 mt-4 mb-4 text-sm font-semibold transition-colors focus:ring-1 focus:ring-gray-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border border-gray-200 rounded-md',
   {
     variants: {
       variant: {

--- a/apps/docs.blocksense.network/components/ui/button.tsx
+++ b/apps/docs.blocksense.network/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors disabled:pointer-events-none disabled:opacity-50 focus:ring-1 focus:ring-gray-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border border-gray-200 rounded-md',
   {
     variants: {
       variant: {

--- a/apps/docs.blocksense.network/components/ui/dialog.tsx
+++ b/apps/docs.blocksense.network/components/ui/dialog.tsx
@@ -43,7 +43,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground focus:ring-1 focus:ring-gray-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border border-gray-200">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/apps/docs.blocksense.network/components/ui/input.tsx
+++ b/apps/docs.blocksense.network/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 focus:ring-1 focus:ring-gray-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border-gray-200',
           className,
         )}
         ref={ref}

--- a/apps/docs.blocksense.network/components/ui/select.tsx
+++ b/apps/docs.blocksense.network/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 focus:ring-1 focus:ring-gray-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border-gray-200',
       className,
     )}
     {...props}

--- a/apps/docs.blocksense.network/components/ui/switch.tsx
+++ b/apps/docs.blocksense.network/components/ui/switch.tsx
@@ -9,7 +9,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus:ring-1 focus:ring-gray-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border-gray-200',
       className,
     )}
     {...props}

--- a/apps/docs.blocksense.network/components/ui/tabs.tsx
+++ b/apps/docs.blocksense.network/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 mb-2 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 mb-2 text-sm font-medium ring-offset-background transition-all disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm focus:ring-1 focus:ring-gray-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border border-gray-200',
       className,
     )}
     {...props}
@@ -42,7 +42,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      'mt-2 px-2 py-2 rounded-md bg-white tabs border-solid focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      'mt-2 px-2 py-2 rounded-md bg-white tabs border-solid',
       className,
     )}
     {...props}

--- a/apps/docs.blocksense.network/tailwind.config.ts
+++ b/apps/docs.blocksense.network/tailwind.config.ts
@@ -89,6 +89,9 @@ const config = {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
       },
+      boxShadow: {
+        sm: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)',
+      },
     },
     fontFamily: {
       body: ['Noto Sans', ...fallbackFonts],

--- a/libs/docs-theme/css/styles.css
+++ b/libs/docs-theme/css/styles.css
@@ -24,17 +24,6 @@ body {
 }
 
 a,
-summary,
-button,
-input,
-[tabindex]:not([tabindex='-1']) {
-  @apply nx-outline-none;
-  &:focus-visible {
-    @apply nx-ring-2 nx-ring-primary-200 nx-ring-offset-1 nx-ring-offset-primary-300 dark:nx-ring-primary-800 dark:nx-ring-offset-primary-700;
-  }
-}
-
-a,
 summary {
   @apply nx-rounded;
 }

--- a/libs/docs-theme/src/nx-utilities/nx-customizations.css
+++ b/libs/docs-theme/src/nx-utilities/nx-customizations.css
@@ -26,31 +26,31 @@ summary,
 button,
 input,
 [tabindex]:not([tabindex='-1']) {
-  outline-offset: 2px;
-  outline: 2px solid transparent;
+  outline-offset: 1px;
+  outline: 1px solid transparent;
 }
 a:focus-visible {
-  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
-    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
-    calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
-    var(--tw-shadow, 0 0 transparent);
+  --tw-ring-offset-width: 0px;
+  --tw-ring-color: #d1d5db;
+  --tw-ring-offset-color: transparent;
   --tw-ring-opacity: 1;
-  --tw-ring-color: hsl(
-    var(--nextra-primary-hue) var(--nextra-primary-saturation) 86% /
-      var(--tw-ring-opacity)
-  );
-  --tw-ring-offset-width: 1px;
-  --tw-ring-offset-color: hsl(
-    var(--nextra-primary-hue) var(--nextra-primary-saturation) 77%
-  );
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 1px var(--tw-ring-color);
+  --tw-ring-offset-shadow: none;
+
+  box-shadow:
+    var(--tw-ring-shadow),
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -2px rgba(0, 0, 0, 0.1);
+
+  border-radius: 0.375rem;
+  border-width: 1px;
+  border-color: #e5e5e5;
 }
 summary:focus-visible {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
     var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
-    calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+    calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
     var(--tw-shadow, 0 0 transparent);
   --tw-ring-opacity: 1;
@@ -58,61 +58,61 @@ summary:focus-visible {
     var(--nextra-primary-hue) var(--nextra-primary-saturation) 86% /
       var(--tw-ring-opacity)
   );
-  --tw-ring-offset-width: 1px;
+  --tw-ring-offset-width: 0px;
   --tw-ring-offset-color: hsl(
     var(--nextra-primary-hue) var(--nextra-primary-saturation) 77%
   );
 }
 button:focus-visible {
-  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
-    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
-    calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
-    var(--tw-shadow, 0 0 transparent);
+  --tw-ring-offset-width: 0px;
+  --tw-ring-color: #d1d5db;
+  --tw-ring-offset-color: transparent;
   --tw-ring-opacity: 1;
-  --tw-ring-color: hsl(
-    var(--nextra-primary-hue) var(--nextra-primary-saturation) 86% /
-      var(--tw-ring-opacity)
-  );
-  --tw-ring-offset-width: 1px;
-  --tw-ring-offset-color: hsl(
-    var(--nextra-primary-hue) var(--nextra-primary-saturation) 77%
-  );
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 1px var(--tw-ring-color);
+  --tw-ring-offset-shadow: none;
+
+  box-shadow:
+    var(--tw-ring-shadow),
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -2px rgba(0, 0, 0, 0.1);
+
+  border-radius: 0.375rem;
+  border-width: 1px;
+  border-color: #e5e5e5;
 }
 input:focus-visible {
-  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
-    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
-    calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
-    var(--tw-shadow, 0 0 transparent);
+  --tw-ring-offset-width: 0px;
+  --tw-ring-color: #d1d5db;
+  --tw-ring-offset-color: transparent;
   --tw-ring-opacity: 1;
-  --tw-ring-color: hsl(
-    var(--nextra-primary-hue) var(--nextra-primary-saturation) 86% /
-      var(--tw-ring-opacity)
-  );
-  --tw-ring-offset-width: 1px;
-  --tw-ring-offset-color: hsl(
-    var(--nextra-primary-hue) var(--nextra-primary-saturation) 77%
-  );
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 1px var(--tw-ring-color);
+  --tw-ring-offset-shadow: none;
+
+  box-shadow:
+    var(--tw-ring-shadow),
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -2px rgba(0, 0, 0, 0.1);
+
+  border-radius: 0.375rem;
+  border-width: 1px;
+  border-color: #e5e5e5;
 }
 [tabindex]:not([tabindex='-1']):focus-visible {
-  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
-    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
-    calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
-    var(--tw-shadow, 0 0 transparent);
+  --tw-ring-offset-width: 0px;
+  --tw-ring-color: #d1d5db;
+  --tw-ring-offset-color: transparent;
   --tw-ring-opacity: 1;
-  --tw-ring-color: hsl(
-    var(--nextra-primary-hue) var(--nextra-primary-saturation) 86% /
-      var(--tw-ring-opacity)
-  );
-  --tw-ring-offset-width: 1px;
-  --tw-ring-offset-color: hsl(
-    var(--nextra-primary-hue) var(--nextra-primary-saturation) 77%
-  );
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 1px var(--tw-ring-color);
+  --tw-ring-offset-shadow: none;
+
+  box-shadow:
+    var(--tw-ring-shadow),
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -2px rgba(0, 0, 0, 0.1);
+
+  border-radius: 0.375rem;
+  border-width: 1px;
+  border-color: #e5e5e5;
 }
 :is(html[class~='dark'] a:focus-visible) {
   --tw-ring-opacity: 1;


### PR DESCRIPTION
This PR is focused on improvements on the focus-visible states across several components to make them more user-friendly and accessible. We’ve made some  updates to ensure that focus indicators are clear and effective, enhancing both usability and accessibility.

Updates on the following:
**Blocksense Components:**

We’ve upgraded the styling and behavior of focus-visible states in Blocksense components. Expect clearer visual indicators and more intuitive interactions.

**Nextra Components:**

The focus-visible states in Nextra have been refined for better visual feedback and consistency across components.

**Shadcn Components:**

Enhanced Experience: Improved the look and feel of focus-visible states to provide clearer focus indications.

![image](https://github.com/user-attachments/assets/79481dfb-9021-4ef3-a775-f00019e6e5c6)
![image](https://github.com/user-attachments/assets/a56879be-df84-4aa0-a043-e1f371478e37)

