### PR TITLE
fix(docs.ws) Modify-sidebar-so-it-will-fit-focus-able-items on Nextra

### DIFF
--- a/apps/docs.blocksense.network/blocksense-theme/noto.css
+++ b/apps/docs.blocksense.network/blocksense-theme/noto.css
@@ -79,7 +79,13 @@ blockquote {
 }
 
 .nextra-sidebar-container ul > li {
-  @apply mb-0 mt-0.5;
+  @apply mb-[2px] mx-[2px];
+}
+
+@media (max-width: 640px) {
+  .nextra-sidebar-container ul > li a {
+    @apply mt-1;
+  }
 }
 
 .nextra-toc ul > li {


### PR DESCRIPTION
This issue is coming from Nextra and it was always presented. Focused items into the sidebar are cut, either to the left or right, or to the bottom, without having enough space for them. This PR fixes this scenario.

**Before:**
![image](https://github.com/user-attachments/assets/b8f5c3c2-f816-46f7-aefc-22c67627b27a)

**After:**
![image](https://github.com/user-attachments/assets/d4932b54-aca2-46d1-a58d-88d287e877a5)

