### PR TITLE
[docs.ws]: Individual Data Feed Pages (Part 2)

### DIFF
--- a/apps/docs.blocksense.network/src/data-feeds/generate-data-feed-mdx.ts
+++ b/apps/docs.blocksense.network/src/data-feeds/generate-data-feed-mdx.ts
@@ -83,7 +83,7 @@ async function generateIndividualDataFeedPages(
   const dataFeedPages = feedsConfig.feeds.map((feed: Feed) => {
     return {
       description: feed.description,
-      name: `0x${feed.id}`,
+      name: `${feed.id}`,
       content: generateIndividualDataFeedPageContent(feed),
     };
   });
@@ -106,7 +106,8 @@ async function generateIndividualDataFeedPages(
   rootMetaFileContent = {
     ...rootMetaFileContent,
     feed: {
-      display: 'hidden',
+      title: 'Supported Data Feeds',
+      display: 'children',
     },
   };
 


### PR DESCRIPTION
#### With this PR we bring 2 changes to the Individual Data Feed Pages

#### Changes:
* Get rid of `0x` prefix in file names and URLs;
    ref: https://github.com/blocksense-network/blocksense/pull/412#pullrequestreview-2295560716
* Fix displaying of the `feed` folder in the left sidebar;
   Seems like `hidden` does not work as there are files in the folder, but since all files are hidden already we can use the `children` option.
    ref: https://github.com/blocksense-network/blocksense/pull/412#discussion_r1753884581

### Visual representation of changes
Before:
![image](https://github.com/user-attachments/assets/a17a2c86-6ca6-42f7-83d0-fc0df08b7a1e)
After:
![image](https://github.com/user-attachments/assets/9334afdd-d2d0-4ba4-87fb-0c928883f25a)

> Hint: see URLs and the `feed` folder in the left sidebar