### PR TITLE
[docs.ws]: Fix: Remove `0x` prefix from individual df links

### DIFF
--- a/apps/docs.blocksense.network/components/DataFeeds/columns.tsx
+++ b/apps/docs.blocksense.network/components/DataFeeds/columns.tsx
@@ -103,7 +103,7 @@ type DataFeedLinkProps = {
 
 const DataFeedLink = ({ row, placeholderId }: DataFeedLinkProps) => {
   return (
-    <Link href={`feed/0x${row.getValue('id')}`}>
+    <Link href={`feed/${row.getValue('id')}`}>
       {row.getValue(placeholderId)}
     </Link>
   );


### PR DESCRIPTION
Well, in [this PR](https://github.com/blocksense-network/blocksense/pull/415), I forgot to update the link generation to remove the `0x` prefix. I've made the necessary adjustments in this PR, so everything should work correctly now.