### PR TITLE
chore(cargo test): Temporarily ignore flaky tests

### DIFF
--- a/apps/sequencer/src/feeds/feeds_slots_manager.rs
+++ b/apps/sequencer/src/feeds/feeds_slots_manager.rs
@@ -115,6 +115,7 @@ mod tests {
     use utils::logging::init_shared_logging_handle;
     use utils::to_hex_string;
 
+    #[ignore]
     #[actix_web::test]
     async fn test_feed_slots_manager_loop() {
         let repo_root_dir = env::var("GIT_ROOT").unwrap();

--- a/apps/sequencer/src/http_handlers/data_feeds.rs
+++ b/apps/sequencer/src/http_handlers/data_feeds.rs
@@ -378,6 +378,7 @@ mod tests {
     use tokio::sync::{mpsc, RwLock};
     use utils::logging::init_shared_logging_handle;
 
+    #[ignore]
     #[actix_web::test]
     async fn post_report_from_unknown_reporter_fails_with_401() {
         let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();


### PR DESCRIPTION
The purpose of this PR is to improve the developer experience by addressing the constantly failing rust job of the CI, which has been quite frustrating and delays merge times.

Currently, two tests are causing problems in the Rust job due to their flaky behavior. For now, the solution is to ignore these tests. @HristoStaykov  is actively working on resolving the underlying issues.