### PR TITLE
feat(docs.ws): Increase width of Nextra main content space

### DIFF
--- a/apps/docs.blocksense.network/components/common/Footer.tsx
+++ b/apps/docs.blocksense.network/components/common/Footer.tsx
@@ -5,7 +5,7 @@ import { config } from '@/config';
 export const Footer = () => {
   return (
     <footer
-      className="footer nx-mx-auto nx-flex nx-h-[var(--nextra-navbar-height)] nx-max-w-[90rem]
+      className="footer nx-mx-auto nx-flex nx-h-[var(--nextra-navbar-height)] nx-max-w-[100rem]
   nx-items-center nx-justify-end nx-gap-2 nx-pl-[max(env(safe-area-inset-left),1.5rem)]
   nx-pr-[max(env(safe-area-inset-right),1.5rem)] h-20"
     >

--- a/libs/docs-theme/src/components/footer.tsx
+++ b/libs/docs-theme/src/components/footer.tsx
@@ -10,7 +10,7 @@ export function Footer({ menu }: { menu?: boolean }): ReactElement {
     <footer className="nx-bg-white-100 nx-pb-[env(safe-area-inset-bottom)] dark:nx-bg-neutral-900 print:nx-bg-transparent">
       {/* <div
         className={cn(
-          'nx-mx-auto nx-flex nx-max-w-[90rem] nx-gap-2 nx-py-2 nx-px-4',
+          'nx-mx-auto nx-flex nx-max-w-[100rem] nx-gap-2 nx-py-2 nx-px-4',
           menu && (config.i18n.length > 0 || config.darkMode)
             ? 'nx-flex'
             : 'nx-hidden',
@@ -22,7 +22,7 @@ export function Footer({ menu }: { menu?: boolean }): ReactElement {
       {/* <hr className="dark:nx-border-neutral-800" /> */}
       <div
         className={cn(
-          'nx-mx-auto nx-flex nx-max-w-[90rem] nx-justify-center nx-py-12 nx-text-gray-600 dark:nx-text-gray-400 md:nx-justify-start',
+          'nx-mx-auto nx-flex nx-max-w-[100rem] nx-justify-center nx-py-12 nx-text-gray-600 dark:nx-text-gray-400 md:nx-justify-start',
           'nx-pl-[max(env(safe-area-inset-left),1.5rem)] nx-pr-[max(env(safe-area-inset-right),1.5rem)]',
         )}
       >

--- a/libs/docs-theme/src/components/navbar.tsx
+++ b/libs/docs-theme/src/components/navbar.tsx
@@ -91,7 +91,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
           'nx-pointer-events-none nx-absolute nx-z-[-1] nx-h-full nx-w-full',
         )}
       />
-      <nav className="nx-bg-white nx-mx-auto nx-flex nx-h-[var(--nextra-navbar-height)] nx-max-w-[90rem] nx-items-center nx-justify-end nx-gap-2 nx-pl-[max(env(safe-area-inset-left),1.5rem)] nx-pr-[max(env(safe-area-inset-right),1.5rem)] dark:nx-bg-black">
+      <nav className="nx-bg-white nx-mx-auto nx-flex nx-h-[var(--nextra-navbar-height)] nx-max-w-[100rem] nx-items-center nx-justify-end nx-gap-2 nx-pl-[max(env(safe-area-inset-left),1.5rem)] nx-pr-[max(env(safe-area-inset-right),1.5rem)] dark:nx-bg-black">
         {config.logoLink ? (
           <Anchor
             href={typeof config.logoLink === 'string' ? config.logoLink : '/'}

--- a/libs/docs-theme/src/index.tsx
+++ b/libs/docs-theme/src/index.tsx
@@ -199,7 +199,7 @@ const InnerLayout = ({
       <div
         className={cn(
           'nx-mx-auto nx-flex',
-          themeContext.layout !== 'raw' && 'nx-max-w-[90rem]',
+          themeContext.layout !== 'raw' && 'nx-max-w-[100rem]',
         )}
       >
         <ActiveAnchorProvider>

--- a/libs/docs-theme/src/nx-utilities/nx-dimensions.css
+++ b/libs/docs-theme/src/nx-utilities/nx-dimensions.css
@@ -100,8 +100,8 @@
 .nx-max-w-\[50\%\] {
   max-width: 50%;
 }
-.nx-max-w-\[90rem\] {
-  max-width: 90rem;
+.nx-max-w-\[100rem\] {
+  max-width: 100rem;
 }
 .nx-max-w-\[min\(calc\(100vw-2rem\)\,calc\(100\%\+20rem\)\)\] {
   max-width: min(100vw - 2rem, 100% + 20rem);


### PR DESCRIPTION
As previously discussed, the max-width of the main Nextra content should be 100rem, not 90. This PR does this trick.
It looks like the following:

![image](https://github.com/user-attachments/assets/a724c950-ced8-4b5f-9ea0-44d7254a09cc)
