### PR TITLE
fix(docs.ws): Overview list items are not getting focused text color, as required

### DIFF
--- a/apps/docs.blocksense.network/blocksense-theme/base.css
+++ b/apps/docs.blocksense.network/blocksense-theme/base.css
@@ -286,4 +286,8 @@ main {
   .scroll-area .signature__code {
     @apply p-1;
   }
+
+  .overview__list li a:focus-visible {
+    @apply text-blue-700;
+  }
 }


### PR DESCRIPTION
In reference to this one [feat(docs.ws): Modify link states and apply small UI fixes related to the U](https://github.com/blocksense-network/blocksense/pull/422), only for overview-list items the color is not set to `text-blue-700`, as we need. 

That's how they should look like:
![image](https://github.com/user-attachments/assets/b8166199-9a57-4779-acba-acd8312cd155)

For that reason and for the health of the states of other elements, we're adding this color only for overview-list-items.
For everything else, we should have the same behavior, as presented in [PR #422].

**Instructions to test:**

1. Go to [/docs/contracts/reference-documentation](https://docsblocksensenetwork-35zv5mmlr-blocksense.vercel.app/docs/contracts/reference-documentation).
2. Navigate through the items using Tab keyboard button and they should be blue-colored. 
3. Press Enter on a focused item and you should be redirected to that page. 