### PR TITLE
[docs.ws]: Hide the Roadmap page

### DIFF
--- a/apps/docs.blocksense.network/components/getting-started/GettingStarted.tsx
+++ b/apps/docs.blocksense.network/components/getting-started/GettingStarted.tsx
@@ -20,7 +20,11 @@ export const GettingStarted = () => {
               href="/docs/overview/getting-started"
               label="Get Started"
             />
-            <LinkButton href="/docs/overview/roadmap" label="Roadmap" />
+            <LinkButton
+              href="/docs/overview/roadmap"
+              label="Roadmap"
+              className="hidden"
+            />
           </div>
         </article>
         <aside className="getting-started__image flex-row-reverse hidden md:flex md:mt-0 lg:mt-0 lg:flex">

--- a/apps/docs.blocksense.network/pages/docs/overview/_meta.json
+++ b/apps/docs.blocksense.network/pages/docs/overview/_meta.json
@@ -1,4 +1,4 @@
 {
   "getting-started": "Getting Started",
-  "roadmap": "Roadmap"
+  "roadmap": {"title":"Roadmap","display":"hidden"}
 }


### PR DESCRIPTION
This PR aims to hide the `Roadmap Page` and the `Roadmap button` from the `Blocksense Documentation Website`.

Since, we haven’t agreed on exact technical roadmap to which we may stick to for the next couple of months, it’s wiser to hide it from the nextra sidebar. We’ll keep the page under source control and when the roadmap is ready, we will return it back.


* Hide `Roadmap page` from `meta.json`
* Hide `Roadmap button` on the `home page`

![image](https://github.com/user-attachments/assets/9a3b8fac-c5d3-4b06-804f-fd8094533ffa)

![image](https://github.com/user-attachments/assets/4b035782-14fd-44f3-ace6-64def837c4dc)
