### PR TITLE
fix(docs.ws): Brand name typo into the Blockchain integration

### DIFF
--- a/apps/docs.blocksense.network/pages/docs/architecture/blockchain-integration.mdx
+++ b/apps/docs.blocksense.network/pages/docs/architecture/blockchain-integration.mdx
@@ -29,7 +29,7 @@ To enhance interoperability and provide a wider range of data access, Blocksense
 
 ## Delegate Calls and Static Calls
 
-BlockSense employs advanced functionalities to enhance contract interactions and security.
+Blocksense employs advanced functionalities to enhance contract interactions and security.
 
 - **Delegate Calls:**
   - **Function:** Enable the execution of functions from one contract in the context of another contract.


### PR DESCRIPTION
Fixing Blocksense typo into the mdx file for "Blockchain integration".