### PR TITLE
feat(docs.ws): Remove focused state for entire accordion and modify it

### DIFF
--- a/apps/docs.blocksense.network/components/ui/accordion.tsx
+++ b/apps/docs.blocksense.network/components/ui/accordion.tsx
@@ -29,7 +29,7 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        'accordion-item__trigger flex flex-1 items-center h-[36px] pb-[0.4rem] justify-between font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180 focus:ring-1 focus:ring-gray-300 focus:ring-opacity-100 focus:rounded-md focus:shadow-md',
+        'accordion-item__trigger flex flex-1 items-center h-[36px] pb-[0.5rem] justify-between font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180 focus:ring-0 focus:outline-none focus:border-transparent focus:text-blue-700',
         className,
       )}
       {...props}


### PR DESCRIPTION
In reference to PR: [#410](https://github.com/blocksense-network/blocksense/pull/410)
We needed to decrease a bit the load from focused state of the accordion when we navigate and when we click on it, so we modified it, as shown below:

**Before:**

![image](https://github.com/user-attachments/assets/c6f54caa-000b-4537-98d2-44329c86e31b)

**After:**

![image](https://github.com/user-attachments/assets/f5ad3c2f-d05c-488c-9819-9b89e2f58ce7)
