### PR TITLE
fix(docs.ws): Copy button and toggle wordwrap buttons are misligned

### DIFF
--- a/libs/docs-theme/src/components/pre.tsx
+++ b/libs/docs-theme/src/components/pre.tsx
@@ -48,7 +48,7 @@ export const Pre = ({
       </pre>
       <div
         className={cn(
-          'nx-opacity-0 nx-transition [div:hover>&]:nx-opacity-100 focus-within:nx-opacity-100',
+          'nx-opacity-0 nx-transition nx-mt-0 [div:hover>&]:nx-opacity-100 focus-within:nx-opacity-100',
           'nx-flex nx-gap-1 nx-absolute nx-m-[11px] nx-right-0',
           filename ? 'nx-top-8' : 'nx-top-0',
         )}

--- a/libs/docs-theme/src/nx-utilities/nx-layout-and-positioning.css
+++ b/libs/docs-theme/src/nx-utilities/nx-layout-and-positioning.css
@@ -168,8 +168,11 @@
 .nx-mr-2 {
   margin-right: 0.5rem;
 }
-.nx-mt-1 {
+.nx-mt-0 {
   margin-top: 0.25rem;
+}
+.nx-mt-1 {
+  margin-top: 0rem;
 }
 .nx-mt-1\.5 {
   margin-top: 0.375rem;


### PR DESCRIPTION
Small, but essential fix for copy and toogle word wrap buttons when they're available. They are misaligned and this PR resolves this case for all Nextra code blocks.

**Before:**

![image](https://github.com/user-attachments/assets/46a5c225-ceeb-44f5-be5e-726787f21a84)

**After:**

![image](https://github.com/user-attachments/assets/43dbb436-de15-49f7-a68a-3f8b6018a7f8)

**Instructions to test:**

1. Go to: [docs/contracts/guide/historic-data-feed](https://docsblocksensenetwork-aahc1stmv-blocksense.vercel.app/docs/contracts/guide/historic-data-feed).
Hover any code block and see the Nextra copy button.

2. Go to: [docs/contribution/guide](https://docsblocksensenetwork-aahc1stmv-blocksense.vercel.app/docs/contribution/guide) and the copy button should be aligned next to the snippet.  

3. Go to: [docs/contracts/commands](https://docsblocksensenetwork-aahc1stmv-blocksense.vercel.app/docs/contracts/commands) and do the same for Nextra code blocks.
