### PR TITLE
feat(docs.ws): Restyle Nextra search results items

### DIFF
--- a/apps/docs.blocksense.network/blocksense-theme/noto.css
+++ b/apps/docs.blocksense.network/blocksense-theme/noto.css
@@ -51,6 +51,14 @@ blockquote {
   @apply font-noto-sans-regular;
 }
 
+.nextra-search ul > li a {
+  @apply font-noto-sans-light;
+}
+
+.nextra-search ul > li a:hover {
+  @apply bg-zinc-100/10;
+}
+
 .nextra-sidebar-container ul > li a {
   @apply font-noto-sans-regular;
 }

--- a/libs/docs-theme/src/components/flexsearch.tsx
+++ b/libs/docs-theme/src/components/flexsearch.tsx
@@ -211,7 +211,7 @@ export function Flexsearch({
                 <HighlightMatches match={search} value={title} />
               </div>
               {content && (
-                <div className="excerpt nx-mt-1 nx-text-sm nx-leading-[1.35rem] nx-text-gray-600 dark:nx-text-gray-400 contrast-more:dark:nx-text-gray-50">
+                <div className="excerpt nx-mt-1 nx-text-sm nx-leading-[1.35rem] nx-text-gray-500 dark:nx-text-gray-400 contrast-more:dark:nx-text-gray-50">
                   <HighlightMatches match={search} value={content} />
                 </div>
               )}


### PR DESCRIPTION
V1 is knocking on the door! The purpose of this PR is to quickly and effectively style the search items, without disrupting anything else on the page. 

**Before:**
![image](https://github.com/user-attachments/assets/1e05722b-af03-47ee-8fc5-7e1231034df5)

**After:**
![image](https://github.com/user-attachments/assets/cba6ca9c-16dc-471f-b72a-db7930ef362a)
