### PR TITLE
[data-feeds-config-generator]: Handle yf resource for `XAG` & `XAU`

### DIFF
--- a/apps/data-feeds-config-generator/src/feeds-config/index.ts
+++ b/apps/data-feeds-config-generator/src/feeds-config/index.ts
@@ -75,6 +75,18 @@ async function isFeedSupported(
     ) {
       feed.resources.yf_symbol = `${feed.pair.base}${feed.pair.quote}=X`;
     }
+
+    const specialCases: Record<string, any> = {
+      XAG: {
+        yf_symbol: 'GC=F',
+      },
+      XAU: {
+        yf_symbol: 'SI-F',
+      },
+    };
+
+    const special = specialCases[feed.pair.base];
+    if (special) feed.resources = { ...special };
     return true;
   }
 

--- a/config/chainlink_compatibility.json
+++ b/config/chainlink_compatibility.json
@@ -1914,6 +1914,18 @@
     },
     "167": {
       "id": 167,
+      "description": "USDM / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregator_proxies": {
+          "1": "0x079674468Fee6ab45aBfE986737A440701c49BdB",
+          "421614": "0x24EA2671671c33D66e9854eC06e42E5D3ac1f764"
+        }
+      }
+    },
+    "168": {
+      "id": 168,
       "description": "DPI / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1924,8 +1936,8 @@
         }
       }
     },
-    "168": {
-      "id": 168,
+    "169": {
+      "id": 169,
       "description": "WEMIX / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1933,15 +1945,6 @@
         "chainlink_aggregator_proxies": {
           "421614": "0x6FfBc6339DD46a7e0513D4887106349214C05505"
         }
-      }
-    },
-    "169": {
-      "id": 169,
-      "description": "USDM / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregator_proxies": {}
       }
     },
     "170": {
@@ -2507,6 +2510,17 @@
     },
     "223": {
       "id": 223,
+      "description": "USD0 / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregator_proxies": {
+          "1": "0x7e891DEbD8FA0A4Cf6BE58Ddff5a8ca174FebDCB"
+        }
+      }
+    },
+    "224": {
+      "id": 224,
       "description": "SHV / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2516,8 +2530,8 @@
         }
       }
     },
-    "224": {
-      "id": 224,
+    "225": {
+      "id": 225,
       "description": "IDR / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2527,8 +2541,8 @@
         }
       }
     },
-    "225": {
-      "id": 225,
+    "226": {
+      "id": 226,
       "description": "USDP / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2538,8 +2552,8 @@
         }
       }
     },
-    "226": {
-      "id": 226,
+    "227": {
+      "id": 227,
       "description": "NZD / USD",
       "chainlink_compatibility": {
         "base": "0x000000000000000000000000000000000000022A",
@@ -2549,8 +2563,8 @@
         }
       }
     },
-    "227": {
-      "id": 227,
+    "228": {
+      "id": 228,
       "description": "AMPL / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2560,18 +2574,9 @@
         }
       }
     },
-    "228": {
-      "id": 228,
-      "description": "QUICK / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregator_proxies": {}
-      }
-    },
     "229": {
       "id": 229,
-      "description": "OM / USD",
+      "description": "QUICK / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2580,7 +2585,7 @@
     },
     "230": {
       "id": 230,
-      "description": "QNT / USD",
+      "description": "OM / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2589,7 +2594,7 @@
     },
     "231": {
       "id": 231,
-      "description": "ILS / USD",
+      "description": "QNT / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2598,7 +2603,7 @@
     },
     "232": {
       "id": 232,
-      "description": "GHST / USD",
+      "description": "ILS / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2607,7 +2612,7 @@
     },
     "233": {
       "id": 233,
-      "description": "PLN / USD",
+      "description": "GHST / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2616,7 +2621,7 @@
     },
     "234": {
       "id": 234,
-      "description": "XPT / USD",
+      "description": "PLN / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2625,7 +2630,7 @@
     },
     "235": {
       "id": 235,
-      "description": "THETA / USD",
+      "description": "XPT / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2634,7 +2639,7 @@
     },
     "236": {
       "id": 236,
-      "description": "FTT / USD",
+      "description": "THETA / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2643,7 +2648,7 @@
     },
     "237": {
       "id": 237,
-      "description": "DASH / USD",
+      "description": "FTT / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2652,7 +2657,7 @@
     },
     "238": {
       "id": 238,
-      "description": "SLP / USD",
+      "description": "DASH / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2661,7 +2666,7 @@
     },
     "239": {
       "id": 239,
-      "description": "BADGER / USD",
+      "description": "SLP / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2670,7 +2675,7 @@
     },
     "240": {
       "id": 240,
-      "description": "STORJ / USD",
+      "description": "BADGER / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2679,7 +2684,7 @@
     },
     "241": {
       "id": 241,
-      "description": "HBAR / USD",
+      "description": "STORJ / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2688,7 +2693,7 @@
     },
     "242": {
       "id": 242,
-      "description": "ALCX / USD",
+      "description": "HBAR / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2697,7 +2702,7 @@
     },
     "243": {
       "id": 243,
-      "description": "DGB / USD",
+      "description": "ALCX / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2706,7 +2711,7 @@
     },
     "244": {
       "id": 244,
-      "description": "GLMR / USD",
+      "description": "DGB / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2715,7 +2720,7 @@
     },
     "245": {
       "id": 245,
-      "description": "ZERO / USD",
+      "description": "GLMR / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2724,7 +2729,7 @@
     },
     "246": {
       "id": 246,
-      "description": "SRM / USD",
+      "description": "ZERO / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2733,7 +2738,7 @@
     },
     "247": {
       "id": 247,
-      "description": "mSOL / USD",
+      "description": "SRM / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2742,7 +2747,7 @@
     },
     "248": {
       "id": 248,
-      "description": "REN / USD",
+      "description": "mSOL / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2751,6 +2756,15 @@
     },
     "249": {
       "id": 249,
+      "description": "REN / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregator_proxies": {}
+      }
+    },
+    "250": {
+      "id": 250,
       "description": "GNO / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3774,6 +3788,7 @@
     "ethereum-mainnet-arbitrum-1/0x6aCcBB82aF71B8a576B4C05D4aF92A83A035B991": 156,
     "mainnet/0x1c88503c9A52aE6aaE1f9bb99b3b7e9b8Ab35459": 156,
     "ethereum-mainnet-arbitrum-1/0x47A2fBEb46553F01E7133686Fb1b5349d4823a0C": null,
+    "ethereum-mainnet-base-1/0x30A76F4E688Cf52f4A06D7AAd987A7037f3Ae6f7": null,
     "ethereum-mainnet-arbitrum-1/0x37DDEE84dE03d039e1Bf809b7a01EDd2c4665771": 157,
     "ethereum-mainnet-arbitrum-1/0xded2c52b75B24732e9107377B7Ba93eC1fFa4BAf": null,
     "ethereum-mainnet-base-1/0xf586d0728a47229e747d824a939000Cf21dEF5A0": null,
@@ -3831,13 +3846,17 @@
     "ethereum-mainnet-arbitrum-1/0x70E48a135F76bA31B47FE944e769E052A8FeB849": 165,
     "ethereum-testnet-sepolia-arbitrum-1/0x902ac56C78058f6DE82C0610a851017901280217": 165,
     "ethereum-mainnet-arbitrum-1/0x4Ee1f9ec1048979930aC832a3C1d18a0b4955a02": 166,
+    "ethereum-mainnet-arbitrum-1/0x24EA2671671c33D66e9854eC06e42E5D3ac1f764": 167,
+    "ethereum-mainnet-base-1/0xF7742A6f36e9936CeA0E976bF6CD3930C1178775": 167,
+    "ethereum-mainnet-optimism-1/0xA45881b63ff9BE3F9a3439CA0c002686e65a8ED5": 167,
+    "mainnet/0x079674468Fee6ab45aBfE986737A440701c49BdB": 167,
     "ethereum-mainnet-arbitrum-1/0x03e4054B11ad01915257bE53Af03A32Abf7837b9": null,
     "ethereum-mainnet-optimism-1/0x8f096bFFe37313Ad6bD5B9fF48F9FF6E4E5Cd065": null,
     "ethereum-mainnet-arbitrum-1/0x41f8459f911658e9C627c5D1d2Fb18c7dbc8ceBe": null,
     "ethereum-mainnet-optimism-1/0x21515B1Da412ecdCa071a84f32193eD90D4ddb59": null,
-    "ethereum-mainnet-arbitrum-1/0x1e431E56118bE414bD91f6392414ad3833d21B0D": 167,
-    "mainnet/0xD2A593BF7594aCE1faD597adb697b5645d5edDB2": 167,
-    "matic-mainnet/0x2e48b7924FBe04d575BA229A59b64547d9da16e9": 167,
+    "ethereum-mainnet-arbitrum-1/0x1e431E56118bE414bD91f6392414ad3833d21B0D": 168,
+    "mainnet/0xD2A593BF7594aCE1faD597adb697b5645d5edDB2": 168,
+    "matic-mainnet/0x2e48b7924FBe04d575BA229A59b64547d9da16e9": 168,
     "ethereum-mainnet-arbitrum-1/0xb0EA543f9F8d4B818550365d13F66Da747e1476A": null,
     "ethereum-mainnet-base-1/0xd7221b10FBBC1e1ba95Fd0B4D031C15f7F365296": null,
     "ethereum-mainnet-linea-1/0x85342bC62aadef58f029ab6d17D643949e6F073e": null,
@@ -3846,22 +3865,23 @@
     "mainnet/0x03c68933f7a3F76875C0bc670a58e69294cDFD01": null,
     "ethereum-mainnet-arbitrum-1/0x19eCDd6DDc12597ec4A522fB1E25b1A580B605B7": null,
     "ethereum-mainnet-arbitrum-1/0xfB3264D1129824933a52374c2C1696F4470D041e": null,
+    "ethereum-mainnet-arbitrum-1/0x20b0159404886F4BFE51A1ad9c14cFc3Cde5995c": null,
+    "ethereum-mainnet-base-1/0xbb9786e37D54251477EbC1325b04ACdCA18C2254": null,
+    "ethereum-mainnet-linea-1/0x0956106Bd02f2C7eca0AbDe1d51Fc8050CC41714": null,
     "ethereum-mainnet-arbitrum-1/0xEAeFFF521cb36dFb414E8580f8635BFB44d96255": null,
-    "ethereum-mainnet-arbitrum-1/0x6FfBc6339DD46a7e0513D4887106349214C05505": 168,
-    "ethereum-testnet-sepolia-arbitrum-1/0x51529054166B417e9854c6d47AAa4720F3e277E4": 168,
+    "ethereum-mainnet-arbitrum-1/0x6FfBc6339DD46a7e0513D4887106349214C05505": 169,
+    "ethereum-testnet-sepolia-arbitrum-1/0x51529054166B417e9854c6d47AAa4720F3e277E4": 169,
     "ethereum-mainnet-arbitrum-1/0x1bD872f3A606471787B1a304cE0356e4e87Af930": null,
     "ethereum-mainnet-base-1/0xe8dD07CCf5BC4922424140E44Eb970F5950725ef": null,
     "ethereum-mainnet-optimism-1/0x73b8BE3b653c5896BC34fC87cEBC8AcF4Fb7A545": null,
     "ethereum-mainnet-base-1/0xd7818272B9e248357d13057AAb0B417aF31E817d": null,
     "ethereum-testnet-sepolia-base-1/0x3c65e28D357a37589e1C7C86044a9f44dDC17134": null,
-    "ethereum-mainnet-base-1/0xF7742A6f36e9936CeA0E976bF6CD3930C1178775": 169,
-    "ethereum-mainnet-optimism-1/0xA45881b63ff9BE3F9a3439CA0c002686e65a8ED5": 169,
     "ethereum-mainnet-base-1/0xa669E5272E60f78299F4824495cE01a3923f4380": null,
     "xdai-mainnet/0x0064AC007fF665CF8D0D3Af5E0AD1c26a3f853eA": null,
+    "ethereum-mainnet-base-1/0x07DA0E54543a844a80ABE69c8A12F22B3aA59f9D": null,
+    "mainnet/0x2665701293fCbEB223D11A08D826563EDcCE423A": null,
     "ethereum-mainnet-base-1/0x91D7AEd72bF772A0DA30199B925aCB866ACD3D9e": 170,
     "matic-mainnet/0x8Ec0eC2e0F26D8253ABf39Db4B1793D76B49C6D5": 170,
-    "ethereum-mainnet-base-1/0xbb9786e37D54251477EbC1325b04ACdCA18C2254": null,
-    "ethereum-mainnet-linea-1/0x0956106Bd02f2C7eca0AbDe1d51Fc8050CC41714": null,
     "ethereum-mainnet-base-1/0x9FB8b5A4b3FE655564f0c76616ae79DE90Cc7382": 171,
     "ethereum-mainnet-base-1/0x9452Ca03474C6B704B4e102339B451D640f57f07": null,
     "ethereum-mainnet-base-1/0x979447581b39caCA33EF0CA8208592393D16cc13": 172,
@@ -3880,6 +3900,8 @@
     "ethereum-testnet-sepolia-optimism-1/0x322D15a7B48946fbaA306Bf785d8b1443497B87c": 177,
     "ethereum-testnet-sepolia/0xaaabb530434B0EeAAc9A42E25dbC6A22D7bE218E": 177,
     "ethereum-mainnet-linea-1/0xdE14081b6bd39230EcA7Be1137413b7b87B07C07": 178,
+    "ethereum-mainnet-linea-1/0x5C5Ee01b351b7ef0b16Cfd59E93F743E0679d7bC": null,
+    "ethereum-mainnet-scroll-1/0xf42e954D384247cE971d65f09a34500551942d67": null,
     "ethereum-mainnet-optimism-1/0x2fF1EB7D0ceC35959F0248E9354c3248c6683D9b": 179,
     "ethereum-testnet-sepolia-optimism-1/0x8491546567946b508BdaE9B57eaC3ce9d420AFaF": 179,
     "ethereum-mainnet-optimism-1/0x94A178f2c480D14F8CdDa908D173d7a73F779cb7": null,
@@ -3989,6 +4011,7 @@
     "ethereum-testnet-sepolia/0x732d3C7515356eAB22E3F3DcA183c5c65102d518": null,
     "mainnet/0x289B5036cd942e619E1Ee48670F98d214E745AAC": null,
     "ethereum-testnet-sepolia/0x732A41b49f7ad45f7E773aB9224f564881c602c4": null,
+    "mainnet/0x43921Ca0eca1EA69722c048A6afbc2CAd0BB80e9": null,
     "ethereum-testnet-sepolia/0x5c13b249846540F81c093Bc342b5d963a7518145": 215,
     "mainnet/0xd27e6D02b72eB6FCe04Ad5690C419196B4EF2885": 215,
     "ethereum-testnet-sepolia/0xfD59B51F25E0Ab790a4F0c483BaC194FA0479D29": null,
@@ -4052,6 +4075,7 @@
     "mainnet/0x7c5d4F8345e66f68099581Db340cd65B078C41f4": null,
     "matic-mainnet/0x9896A1eA7A00F5f32Ab131eBbeE07487B0af31D0": null,
     "mainnet/0x82A44D92D6c329826dc557c5E1Be6ebeC5D5FeB9": null,
+    "mainnet/0x7e891DEbD8FA0A4Cf6BE58Ddff5a8ca174FebDCB": 223,
     "mainnet/0xa20623070413d42a5C01Db2c8111640DD7A5A03a": null,
     "mainnet/0xDaeA8386611A157B08829ED4997A8A62B557014C": null,
     "matic-mainnet/0xB89D583B72aBF9C3a7e6e093251C2fCad3365312": null,
@@ -4059,15 +4083,15 @@
     "mainnet/0x703118C4CbccCBF2AB31913e0f8075fbbb15f563": null,
     "mainnet/0xad4A9bED9a5E2c1c9a6E43D35Db53c83873dd901": null,
     "mainnet/0xF0985f7E2CaBFf22CecC5a71282a89582c382EFE": null,
-    "mainnet/0xc04611C43842220fd941515F86d1DDdB15F04e46": 223,
+    "mainnet/0xc04611C43842220fd941515F86d1DDdB15F04e46": 224,
     "mainnet/0x58921Ac140522867bf50b9E009599Da0CA4A2379": null,
     "matic-mainnet/0x82C9d4E88862f194C2bd874a106a90dDD0D35AAB": null,
     "mainnet/0xC9CbF687f43176B302F03f5e58470b77D07c61c6": null,
     "mainnet/0x32EaFC72772821936BCc9b8A32dC394fEFcDBfD9": null,
     "mainnet/0x48D9DA600EC48DDd6ce7FC1D47D683818e511c81": null,
     "mainnet/0x652Ac4468688f277fB84b26940e736a20A87Ac2d": null,
-    "mainnet/0x91b99C9b75aF469a71eE1AB528e8da994A5D7030": 224,
-    "matic-mainnet/0x80a5cb83ce268Ed11a6EFC4bBF0beC39dF35Db21": 224,
+    "mainnet/0x91b99C9b75aF469a71eE1AB528e8da994A5D7030": 225,
+    "matic-mainnet/0x80a5cb83ce268Ed11a6EFC4bBF0beC39dF35Db21": 225,
     "mainnet/0x164b276057258d81941e97B0a900D4C7B358bCe0": null,
     "mainnet/0x60cbE8D88EF519cF3C62414D76f50818D211fea1": null,
     "mainnet/0xCc72039A141c6e34a779eF93AEF5eB4C82A893c7": null,
@@ -4078,59 +4102,60 @@
     "mainnet/0x8a12Be339B0cD1829b91Adc01977caa5E9ac121e": null,
     "matic-mainnet/0x1CF68C76803c9A415bE301f50E82e44c64B7F1D4": null,
     "mainnet/0x0A8cD0115B1EE87EbA5b8E06A9a15ED93e230f7a": null,
-    "mainnet/0x09023c0DA49Aaf8fc3fA3ADF34C6A7016D38D5e3": 225,
+    "mainnet/0x09023c0DA49Aaf8fc3fA3ADF34C6A7016D38D5e3": 226,
     "mainnet/0xfe2db7771676c5436c1bebA2956B097f8C5b5aC6": null,
-    "mainnet/0x3977CFc9e4f29C184D4675f4EB8e0013236e5f3e": 226,
-    "matic-mainnet/0xa302a0B8a499fD0f00449df0a490DedE21105955": 226,
+    "mainnet/0x3977CFc9e4f29C184D4675f4EB8e0013236e5f3e": 227,
+    "matic-mainnet/0xa302a0B8a499fD0f00449df0a490DedE21105955": 227,
     "mainnet/0x14d04Fff8D21bd62987a5cE9ce543d2F1edF5D3E": null,
     "mainnet/0xc7de7f4d4C9c991fF62a07D18b3E31e349833A18": null,
     "mainnet/0x492575FDD11a0fCf2C6C719867890a7648d526eB": null,
     "mainnet/0x8dD1CD88F43aF196ae478e91b9F5E4Ac69A97C61": null,
-    "mainnet/0xe20CA8D7546932360e37E9D72c1a47334af57706": 227,
+    "mainnet/0xe20CA8D7546932360e37E9D72c1a47334af57706": 228,
     "mainnet/0x5b563107C8666d2142C216114228443B94152362": null,
     "mainnet/0x4e844125952D32AcdF339BE976c98E22F6F318dB": null,
-    "matic-mainnet/0x2251169D32E7538652a9a8c86bf0c43bFcd956f1": 228,
+    "matic-mainnet/0x2251169D32E7538652a9a8c86bf0c43bFcd956f1": 229,
     "matic-mainnet/0xe638249AF9642CdA55A92245525268482eE4C67b": null,
-    "matic-mainnet/0xc86105DccF9BD629Cea7Fd41f94c6050bF96D57F": 229,
+    "matic-mainnet/0xc86105DccF9BD629Cea7Fd41f94c6050bF96D57F": 230,
     "matic-mainnet/0x9b88d07B2354eF5f4579690356818e07371c7BeD": null,
+    "matic-mainnet/0x0fB2beD999da86Cb1Fdd97E746600A96141EeA09": null,
     "matic-mainnet/0x1d22c334621364F16f050076eE15Acd5eb8225Ce": null,
     "polygon-testnet-amoy/0x85F14a8F5B3Bf49C49882287FB386d809ee8944a": null,
-    "matic-mainnet/0xF7F291042F6Cbc4deC0Ad75c17786511a530dbe8": 230,
+    "matic-mainnet/0xF7F291042F6Cbc4deC0Ad75c17786511a530dbe8": 231,
     "matic-mainnet/0x4517002fCD31062Ea38680dF9Ee37f29528C2707": null,
     "matic-mainnet/0x648E0fF6A36D58F6FCE5927cB77601b73cAdc2Af": null,
-    "matic-mainnet/0x8d5eB34C509261533235b91350d359EdcB969D33": 231,
-    "matic-mainnet/0xDD229Ce42f11D8Ee7fFf29bDB71C7b81352e11be": 232,
+    "matic-mainnet/0x8d5eB34C509261533235b91350d359EdcB969D33": 232,
+    "matic-mainnet/0xDD229Ce42f11D8Ee7fFf29bDB71C7b81352e11be": 233,
     "matic-mainnet/0x187c42f6C0e7395AeA00B1B30CB0fF807ef86d5d": null,
     "matic-mainnet/0x3636B780588328dc3F5df075De5627DBc9A6BA10": null,
     "matic-mainnet/0xad4395fc414Fc1575A7a38C20B0Bfdbdb09ee41A": null,
-    "matic-mainnet/0xB34BCE11040702f71c11529D00179B2959BcE6C0": 233,
+    "matic-mainnet/0xB34BCE11040702f71c11529D00179B2959BcE6C0": 234,
     "matic-mainnet/0x5787BefDc0ECd210Dfa948264631CD53E68F7802": null,
     "polygon-testnet-amoy/0x408D97c89c141e60872C0835e18Dd1E670CD8781": null,
     "matic-mainnet/0x5b4586C911144A947D7814Fd71fe0872b8334748": null,
     "matic-mainnet/0xA338e0492B2F944E9F8C0653D3AD1484f2657a37": null,
     "matic-mainnet/0xB527769842f997d56dD1Ff73C34192141b69077e": null,
     "matic-mainnet/0xDAFA1989A504c48Ee20a582f2891eeB25E2fA23F": null,
-    "matic-mainnet/0x76631863c2ae7367aF8f37Cd10d251DA7f1DE186": 234,
+    "matic-mainnet/0x76631863c2ae7367aF8f37Cd10d251DA7f1DE186": 235,
     "matic-mainnet/0xbd238a35Fb47aE22F0cC551f14ffB8E8f04FCA21": null,
     "matic-mainnet/0x4e9fc7480c16F3FE5d956C0759eE6b4808d1F5D7": null,
-    "matic-mainnet/0x38611b09F8f2D520c14eA973765C225Bf57B9Eac": 235,
-    "matic-mainnet/0x817A7D43f0277Ca480AE03Ec76Fc63A2EC7114bA": 236,
-    "xdai-mainnet/0x0CaE8f5c10931f0Ce87Ed9BbB71391C6E93C2C26": 236,
+    "matic-mainnet/0x38611b09F8f2D520c14eA973765C225Bf57B9Eac": 236,
+    "matic-mainnet/0x817A7D43f0277Ca480AE03Ec76Fc63A2EC7114bA": 237,
+    "xdai-mainnet/0x0CaE8f5c10931f0Ce87Ed9BbB71391C6E93C2C26": 237,
     "matic-mainnet/0x97371dF4492605486e23Da797fA68e55Fc38a13f": null,
-    "matic-mainnet/0xD94427eDee70E4991b4b8DdCc848f2B58ED01C0b": 237,
-    "matic-mainnet/0xBB3eF70953fC3766bec4Ab7A9BF05B6E4caf89c6": 238,
+    "matic-mainnet/0xD94427eDee70E4991b4b8DdCc848f2B58ED01C0b": 238,
+    "matic-mainnet/0xBB3eF70953fC3766bec4Ab7A9BF05B6E4caf89c6": 239,
     "matic-mainnet/0x327e23A4855b6F663a28c5161541d69Af8973302": null,
-    "matic-mainnet/0xF626964Ba5e81405f47e8004F0b276Bb974742B5": 239,
+    "matic-mainnet/0xF626964Ba5e81405f47e8004F0b276Bb974742B5": 240,
     "matic-mainnet/0x55e75d35c44A9EE1A5b05416640965EbcA4a8D33": null,
-    "matic-mainnet/0x0F1d5Bd7be9B30Fc09E110cd6504Bd450e53cb0E": 240,
-    "matic-mainnet/0xC5878bDf8a89FA3bF0DC8389ae8EE6DE601D01bC": 241,
-    "matic-mainnet/0x5DB6e61B6159B20F068dc15A47dF2E5931b14f29": 242,
-    "matic-mainnet/0x4205eC5fd179A843caa7B0860a8eC7D980013359": 243,
+    "matic-mainnet/0x0F1d5Bd7be9B30Fc09E110cd6504Bd450e53cb0E": 241,
+    "matic-mainnet/0xC5878bDf8a89FA3bF0DC8389ae8EE6DE601D01bC": 242,
+    "matic-mainnet/0x5DB6e61B6159B20F068dc15A47dF2E5931b14f29": 243,
+    "matic-mainnet/0x4205eC5fd179A843caa7B0860a8eC7D980013359": 244,
     "matic-mainnet/0x5d37E4b374E6907de8Fc7fb33EE3b0af403C7403": null,
-    "polkadot-mainnet-moonbeam/0x4497B606be93e773bbA5eaCFCb2ac5E2214220Eb": 244,
+    "polkadot-mainnet-moonbeam/0x4497B606be93e773bbA5eaCFCb2ac5E2214220Eb": 245,
     "xdai-mainnet/0xF937ffAeA1363e4Fa260760bDFA2aA8Fc911F84D": null,
-    "xdai-mainnet/0x27d4D36968a2BD1Cc3406D99cB1DF50561dBf2a4": 248,
-    "xdai-mainnet/0x22441d81416430A54336aB28765abd31a792Ad37": 249,
+    "xdai-mainnet/0x27d4D36968a2BD1Cc3406D99cB1DF50561dBf2a4": 249,
+    "xdai-mainnet/0x22441d81416430A54336aB28765abd31a792Ad37": 250,
     "xdai-mainnet/0xc89077976e03d19057eb296215C15afAe4A7464B": null
   }
 }

--- a/config/feeds_config.json
+++ b/config/feeds_config.json
@@ -472,7 +472,7 @@
         "quote": "USD"
       },
       "resources": {
-        "yf_symbol": "XAU"
+        "yf_symbol": "SI-F"
       },
       "report_interval_ms": 300000,
       "first_report_start_time": {
@@ -1065,7 +1065,7 @@
         "quote": "USD"
       },
       "resources": {
-        "yf_symbol": "XAG"
+        "yf_symbol": "GC=F"
       },
       "report_interval_ms": 300000,
       "first_report_start_time": {
@@ -3806,6 +3806,29 @@
     },
     {
       "id": 167,
+      "name": "USDM",
+      "fullName": "",
+      "description": "USDM / USD",
+      "type": "Crypto",
+      "decimals": 8,
+      "pair": {
+        "base": "USDM",
+        "quote": "USD"
+      },
+      "resources": {
+        "cmc_id": 29569,
+        "cmc_quote": "USDM"
+      },
+      "report_interval_ms": 300000,
+      "first_report_start_time": {
+        "secs_since_epoch": 0,
+        "nanos_since_epoch": 0
+      },
+      "quorum_percentage": 1,
+      "script": "CoinMarketCap"
+    },
+    {
+      "id": 168,
       "name": "DPI",
       "fullName": "DefiPulse Index",
       "description": "DPI / USD",
@@ -3828,7 +3851,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 168,
+      "id": 169,
       "name": "WEMIX",
       "fullName": "WEMIX",
       "description": "WEMIX / USD",
@@ -3841,29 +3864,6 @@
       "resources": {
         "cmc_id": 7548,
         "cmc_quote": "WEMIX"
-      },
-      "report_interval_ms": 300000,
-      "first_report_start_time": {
-        "secs_since_epoch": 0,
-        "nanos_since_epoch": 0
-      },
-      "quorum_percentage": 1,
-      "script": "CoinMarketCap"
-    },
-    {
-      "id": 169,
-      "name": "USDM",
-      "fullName": "",
-      "description": "USDM / USD",
-      "type": "Crypto",
-      "decimals": 8,
-      "pair": {
-        "base": "USDM",
-        "quote": "USD"
-      },
-      "resources": {
-        "cmc_id": 29569,
-        "cmc_quote": "USDM"
       },
       "report_interval_ms": 300000,
       "first_report_start_time": {
@@ -5091,6 +5091,29 @@
     },
     {
       "id": 223,
+      "name": "USD0",
+      "fullName": "",
+      "description": "USD0 / USD",
+      "type": "Crypto",
+      "decimals": 8,
+      "pair": {
+        "base": "USD0",
+        "quote": "USD"
+      },
+      "resources": {
+        "cmc_id": 32307,
+        "cmc_quote": "USD0"
+      },
+      "report_interval_ms": 300000,
+      "first_report_start_time": {
+        "secs_since_epoch": 0,
+        "nanos_since_epoch": 0
+      },
+      "quorum_percentage": 1,
+      "script": "CoinMarketCap"
+    },
+    {
+      "id": 224,
       "name": "SHV",
       "fullName": "iShares Short Treasury Bond ETF",
       "description": "SHV / USD",
@@ -5112,7 +5135,7 @@
       "script": "YahooFinance"
     },
     {
-      "id": 224,
+      "id": 225,
       "name": "IDR",
       "fullName": "Indonesian Rupiah",
       "description": "IDR / USD",
@@ -5134,7 +5157,7 @@
       "script": "YahooFinance"
     },
     {
-      "id": 225,
+      "id": 226,
       "name": "USDP",
       "fullName": "Pax Dollar",
       "description": "USDP / USD",
@@ -5157,7 +5180,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 226,
+      "id": 227,
       "name": "NZD",
       "fullName": "New Zealand Dollar",
       "description": "NZD / USD",
@@ -5179,7 +5202,7 @@
       "script": "YahooFinance"
     },
     {
-      "id": 227,
+      "id": 228,
       "name": "AMPL",
       "fullName": "Ampleforth",
       "description": "AMPL / USD",
@@ -5202,7 +5225,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 228,
+      "id": 229,
       "name": "QUICK",
       "fullName": "Quickswap",
       "description": "QUICK / USD",
@@ -5225,7 +5248,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 229,
+      "id": 230,
       "name": "OM",
       "fullName": "Mantra DAO",
       "description": "OM / USD",
@@ -5248,7 +5271,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 230,
+      "id": 231,
       "name": "QNT",
       "fullName": "Quant",
       "description": "QNT / USD",
@@ -5271,7 +5294,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 231,
+      "id": 232,
       "name": "ILS",
       "fullName": "Israeli Shekel",
       "description": "ILS / USD",
@@ -5293,7 +5316,7 @@
       "script": "YahooFinance"
     },
     {
-      "id": 232,
+      "id": 233,
       "name": "GHST",
       "fullName": "Aavegotchi",
       "description": "GHST / USD",
@@ -5316,7 +5339,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 233,
+      "id": 234,
       "name": "PLN",
       "fullName": "Polish Zloty",
       "description": "PLN / USD",
@@ -5338,7 +5361,7 @@
       "script": "YahooFinance"
     },
     {
-      "id": 234,
+      "id": 235,
       "name": "XPT",
       "fullName": "Platinum",
       "description": "XPT / USD",
@@ -5360,7 +5383,7 @@
       "script": "YahooFinance"
     },
     {
-      "id": 235,
+      "id": 236,
       "name": "THETA",
       "fullName": "Theta Token",
       "description": "THETA / USD",
@@ -5383,7 +5406,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 236,
+      "id": 237,
       "name": "FTT",
       "fullName": "FTX Token",
       "description": "FTT / USD",
@@ -5406,7 +5429,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 237,
+      "id": 238,
       "name": "DASH",
       "fullName": "Dash",
       "description": "DASH / USD",
@@ -5429,7 +5452,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 238,
+      "id": 239,
       "name": "SLP",
       "fullName": "Smooth Love Potion",
       "description": "SLP / USD",
@@ -5452,7 +5475,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 239,
+      "id": 240,
       "name": "BADGER",
       "fullName": "Badger DAO",
       "description": "BADGER / USD",
@@ -5475,7 +5498,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 240,
+      "id": 241,
       "name": "STORJ",
       "fullName": "Storj",
       "description": "STORJ / USD",
@@ -5498,7 +5521,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 241,
+      "id": 242,
       "name": "HBAR",
       "fullName": "Hedera Hashgraph",
       "description": "HBAR / USD",
@@ -5521,7 +5544,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 242,
+      "id": 243,
       "name": "ALCX",
       "fullName": "Alchemix",
       "description": "ALCX / USD",
@@ -5544,7 +5567,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 243,
+      "id": 244,
       "name": "DGB",
       "fullName": "Digibyte",
       "description": "DGB / USD",
@@ -5567,7 +5590,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 244,
+      "id": 245,
       "name": "GLMR",
       "fullName": "Moonbeam",
       "description": "GLMR / USD",
@@ -5590,7 +5613,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 245,
+      "id": 246,
       "name": "ZERO",
       "fullName": "",
       "description": "ZERO / USD",
@@ -5613,7 +5636,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 246,
+      "id": 247,
       "name": "SRM",
       "fullName": "Serum",
       "description": "SRM / USD",
@@ -5636,7 +5659,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 247,
+      "id": 248,
       "name": "mSOL",
       "fullName": "Marinade Staked SOL",
       "description": "mSOL / USD",
@@ -5658,7 +5681,7 @@
       "script": "YahooFinance"
     },
     {
-      "id": 248,
+      "id": 249,
       "name": "REN",
       "fullName": "Ren",
       "description": "REN / USD",
@@ -5681,7 +5704,7 @@
       "script": "CoinMarketCap"
     },
     {
-      "id": 249,
+      "id": 250,
       "name": "GNO",
       "fullName": "Gnosis",
       "description": "GNO / USD",


### PR DESCRIPTION
Yahoo Finance has specific requirements for calling the API for some tokens. We know that for the `XAG` symbol you need to pass `GC=F` , and for the `XAU` symbol - `SI-F`.  So with this PR we refactor the config and set correct value to `feed.resources.yf_symbol`.

Also, updated generated configs