### PR TITLE
refactor(data-feeds-config-generator): Improve error message

### DIFF
--- a/apps/data-feeds-config-generator/src/data-services/cmc.ts
+++ b/apps/data-feeds-config-generator/src/data-services/cmc.ts
@@ -7,7 +7,10 @@ import { artifactsDir } from '../paths';
 export async function getCMCCryptoList(): Promise<readonly CMCInfo[]> {
   const url = 'https://pro-api.coinmarketcap.com/v1/cryptocurrency/map';
   const headers = {
-    'X-CMC_PRO_API_KEY': assertNotNull(process.env['CMC_API_KEY']),
+    'X-CMC_PRO_API_KEY': assertNotNull(
+      process.env['CMC_API_KEY'],
+      'CMC_API_KEY env variable not set',
+    ),
     Accept: 'application/json',
   };
 
@@ -15,7 +18,13 @@ export async function getCMCCryptoList(): Promise<readonly CMCInfo[]> {
 
   const response = await fetch(fullUrl, { headers });
   if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
+    throw new Error(
+      `Failed to fetch CoinMarketCap crypto list;
+response:
+  status=${response.status};
+  text=
+${await response.text()}`,
+    );
   }
   const typedData = (await response.json()) as { data: unknown[] };
 


### PR DESCRIPTION
To test error 1: key has expired
---

```
yarn workspace '@blocksense/config-types'  build
yarn workspace '@blocksense/base-utils'  build
 # use an expired CMC key in .env
yarn generate-data-feeds-config
```

Now, you get this:

```
/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/data-services/cmc.ts:21
    throw new Error(
          ^

Error: Failed to fetch CoinMarketCap crypto list;
response:
  status=429;
  text=
{
    "status": {
        "timestamp": "2024-09-18T08:19:27.995Z",
        "error_code": 1010,
        "error_message": "You've exceeded your API Key's monthly credit limit. Please contact us at api@coinmarketcap.com if you need assistance upgrading your plan.",
        "elapsed": 0,
        "credit_count": 0,
        "notice": "You have used 100% of your plan's monthly credit limit."
    }
}
    at getCMCCryptoList (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/data-services/cmc.ts:21:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at generateFeedConfig (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/feeds-config/index.ts:97:34)
    at main (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/scripts/generate-feeds-config.ts:24:22)
    at <anonymous> (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/scripts/generate-feeds-config.ts:40:1)
```

Before, you would have gotten this:

```
/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/data-services/cmc.ts:18
    throw new Error(`HTTP error! status: ${response.status}`);
          ^

Error: HTTP error! status: 429
    at getCMCCryptoList (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/data-services/cmc.ts:18:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at generateFeedConfig (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/feeds-config/index.ts:97:34)
    at main (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/scripts/generate-feeds-config.ts:24:22)
    at <anonymous> (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/scripts/generate-feeds-config.ts:40:1)
```

To test error 2: no env var set
---

```
yarn workspace '@blocksense/config-types'  build
yarn workspace '@blocksense/base-utils'  build
 # remove CMC key from .env
yarn generate-data-feeds-config
```

Now, you get this:

```
file:///home/stan/code/repos/blocksense/libs/base-utils/dist/esm/asserts.mjs:13
        throw new Error(errorMessage ?? 'Assertion failed: value is null');
              ^

Error: CMC_API_KEY env variable not set
    at assertNotNull (file:///home/stan/code/repos/blocksense/libs/base-utils/dist/esm/asserts.mjs:13:15)
    at getCMCCryptoList (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/data-services/cmc.ts:10:26)
    at generateFeedConfig (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/feeds-config/index.ts:97:40)
    at main (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/scripts/generate-feeds-config.ts:24:28)
    at <anonymous> (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/scripts/generate-feeds-config.ts:40:1)
```

Before, you would have gotten this:

```
file:///home/stan/code/repos/blocksense/libs/base-utils/dist/esm/asserts.mjs:13
        throw new Error(errorMessage ?? 'Assertion failed: value is null');
              ^

Error: Assertion failed: value is null
    at assertNotNull (file:///home/stan/code/repos/blocksense/libs/base-utils/dist/esm/asserts.mjs:13:15)
    at getCMCCryptoList (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/data-services/cmc.ts:10:26)
    at generateFeedConfig (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/feeds-config/index.ts:97:40)
    at main (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/scripts/generate-feeds-config.ts:24:28)
    at <anonymous> (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/scripts/generate-feeds-config.ts:40:1)
```

To test error 3: a wrong key:
---

```
yarn workspace '@blocksense/config-types'  build
yarn workspace '@blocksense/base-utils'  build
 # use a fake CMC key in .env
yarn generate-data-feeds-config
```

Now, you get this:

```
/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/data-services/cmc.ts:21
    throw new Error(
          ^

Error: Failed to fetch CoinMarketCap crypto list;
response:
  status=401;
  text=
{
    "status": {
        "timestamp": "2024-09-18T08:24:51.638Z",
        "error_code": 1001,
        "error_message": "This API Key is invalid.",
        "elapsed": 0,
        "credit_count": 0
    }
}
    at getCMCCryptoList (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/data-services/cmc.ts:21:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at generateFeedConfig (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/feeds-config/index.ts:97:34)
    at main (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/scripts/generate-feeds-config.ts:24:22)
    at <anonymous> (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/scripts/generate-feeds-config.ts:40:1)
```

Before, you would have gotten this:

```
/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/data-services/cmc.ts:18
    throw new Error(`HTTP error! status: ${response.status}`);
          ^

Error: HTTP error! status: 401
    at getCMCCryptoList (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/data-services/cmc.ts:18:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at generateFeedConfig (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/feeds-config/index.ts:97:34)
    at main (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/scripts/generate-feeds-config.ts:24:22)
    at <anonymous> (/home/stan/code/repos/blocksense/apps/data-feeds-config-generator/src/scripts/generate-feeds-config.ts:40:1)
```