### PR TITLE
feat(docs.ws): DataFeed pages, tables and layout updates

### DIFF
--- a/apps/docs.blocksense.network/components/DataFeeds/DataFeeds.tsx
+++ b/apps/docs.blocksense.network/components/DataFeeds/DataFeeds.tsx
@@ -25,26 +25,29 @@ export const DataFeeds = ({ dataFeedsOverviewString }: ParametersProps) => {
   );
 
   return (
-    <ContractItemWrapper
-      title="Data Feeds"
-      titleLevel={2}
-      itemsLength={feeds.length}
-    >
-      <p className="mt-2">
-        Blocksense provides a platform for securely and efficiently collecting
-        various data feeds and integrating them into the blockchain ecosystem.
-        Our protocol supports a wide range of data types, from financial market
-        data and decentralized finance (DeFi) metrics to weather data, sports
-        scores, and more. Explore the range of data feeds provided by the
-        Blocksense Network.
-      </p>
-      <DataTable
-        columns={columns}
-        data={feeds}
-        filterCell={'description'}
-        filters={filters}
-        columnsTitles={dataFeedsColumnsTitles}
-      />
-    </ContractItemWrapper>
+    <section className="mt-4">
+      <ContractItemWrapper
+        title="Data Feeds"
+        titleLevel={2}
+        itemsLength={feeds.length}
+      >
+        <article className="mt-4 mb-6">
+          <span className="text-gray-500 text-md">
+            Blocksense offers a platform to securely collect and integrate
+            diverse data feeds into the blockchain. Our protocol supports many
+            data types, including financial markets, DeFi metrics, weather,
+            sports scores, and more. Discover the data feeds available through
+            the Blocksense Network.
+          </span>
+        </article>
+        <DataTable
+          columns={columns}
+          data={feeds}
+          filterCell={'description'}
+          filters={filters}
+          columnsTitles={dataFeedsColumnsTitles}
+        />
+      </ContractItemWrapper>
+    </section>
   );
 };

--- a/apps/docs.blocksense.network/components/DeployedContracts/DeployedContracts.tsx
+++ b/apps/docs.blocksense.network/components/DeployedContracts/DeployedContracts.tsx
@@ -45,13 +45,32 @@ export const DeployedContracts = ({
     [deployedProxyContracts],
   );
 
+  const smartContractsUrl = './#smart-contract-architecture';
+
   return (
-    <div className="mt-4">
+    <section className="mt-4">
       <ContractItemWrapper
         title="Core Contracts"
         titleLevel={2}
         itemsLength={deployedContracts.length}
       >
+        <article className="mt-4 mb-6">
+          <span className="text-gray-500 text-md">
+            Explore the deployed core contracts, including their addresses and
+            networks where they are available. These contracts are key
+            components of the Blocksense platform and provide essential
+            functionalities that support the ecosystem.
+            <br />
+            Discover more into our smart contracts
+            <a
+              href={smartContractsUrl}
+              className="nx-text-primary-600 nx-underline nx-decoration-from-font [text-underline-position:from-font] mx-1"
+            >
+              architecture
+            </a>
+            documentation section.
+          </span>
+        </article>
         <DataTable
           hasToolbar={false}
           columns={coreContractsColumns}
@@ -60,12 +79,20 @@ export const DeployedContracts = ({
         />
       </ContractItemWrapper>
 
-      <div className="mt-10">
+      <div className="mt-6">
         <ContractItemWrapper
           title="Aggregator Proxy Contracts"
           titleLevel={2}
           itemsLength={deployedProxyContracts.length}
         >
+          <article className="mt-4 mb-6">
+            <span className="text-gray-500 text-md">
+              Blocksense aggregator proxy contracts table allows users to
+              explore contracts that serve as an alternative to the Chainlink
+              proxy contracts. Additionally, the table provides information
+              about data feed names, IDs, and relevant addresses.
+            </span>
+          </article>
           <DataTable
             columns={proxyContractsColumns}
             data={deployedProxyContracts}
@@ -74,6 +101,6 @@ export const DeployedContracts = ({
           />
         </ContractItemWrapper>
       </div>
-    </div>
+    </section>
   );
 };

--- a/apps/docs.blocksense.network/components/DeployedContracts/coreContractsColumns.tsx
+++ b/apps/docs.blocksense.network/components/DeployedContracts/coreContractsColumns.tsx
@@ -63,7 +63,7 @@ type RowWrapper = {
 const NetworkAddressExplorerLink = ({ row }: RowWrapper) => {
   const address = row.original.address;
   return (
-    <div>
+    <aside className="space-x-2 space-y-1">
       {row.original.networks.map((network: NetworkName) => (
         <Badge
           key={network}
@@ -75,6 +75,6 @@ const NetworkAddressExplorerLink = ({ row }: RowWrapper) => {
           </Link>
         </Badge>
       ))}
-    </div>
+    </aside>
   );
 };

--- a/apps/docs.blocksense.network/components/DeployedContracts/proxyContractsColumns.tsx
+++ b/apps/docs.blocksense.network/components/DeployedContracts/proxyContractsColumns.tsx
@@ -141,7 +141,7 @@ const DataFeedLink = ({ row, placeholderId }: RowWrapper) => {
   return (
     <Badge
       variant="outline"
-      className={`justify-center border-solid border-slate-200 ${placeholderValue && 'cursor-pointer'} m-0 text-primary-600 bold font-medium whitespace-nowrap`}
+      className={`justify-center border-solid border-slate-200 ${placeholderValue && 'cursor-pointer'} m-0 text-primary-600 bold font-medium whitespace-nowrap hover:bg-neutral-50 hover:border-gray-600`}
     >
       {placeholderValue ? (
         <Link href={feedPageUrl}>{row.getValue(placeholderId!)}</Link>

--- a/apps/docs.blocksense.network/components/sol-contracts/ContractAddress.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/ContractAddress.tsx
@@ -42,7 +42,7 @@ export const ContractAddress = ({
       <Tooltip contentClassName="bg-gray-900 text-white">
         {hasAbbreviation && <Tooltip.Content>{address}</Tooltip.Content>}
         {network ? (
-          <code>
+          <code className="hover:underline">
             <Link
               href={explorerAddressUrls[
                 network as keyof typeof explorerAddressUrls

--- a/apps/docs.blocksense.network/components/ui/badge.tsx
+++ b/apps/docs.blocksense.network/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2.5 py-0.5 mr-4 mt-4 mb-4 text-sm font-semibold transition-colors focus:ring-1 focus:ring-gray-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border border-gray-200 rounded-md',
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 mr-4 mt-4 mb-4 text-sm font-semibold transition-colors hover:bg-neutral-50 hover:border-gray-600 focus:ring-1 focus:ring-gray-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border border-gray-200 rounded-md',
   {
     variants: {
       variant: {


### PR DESCRIPTION
In reference to: [PR #429](https://github.com/blocksense-network/blocksense/pull/429)

Ui related changes **before** and **after**:

**Before:**
![image](https://github.com/user-attachments/assets/815654db-c787-40f6-bf3f-ea343242f9a5)

**After:**
![image](https://github.com/user-attachments/assets/bcd8cbd7-1bf4-4dfd-be70-708ad4e6b616)

**Instructions to test:**

Please, check the [deployment](https://docsblocksensenetwork-e5x4tqpgo-blocksense.vercel.app/docs/contracts/deployed-contracts) for the updates container into this last-minute PR.