### PR TITLE
chore(sequencer/config): Code refactors to improve readability/maintainability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8419,6 +8419,7 @@ dependencies = [
  "serde 1.0.210",
  "serde_json",
  "tracing",
+ "utils",
 ]
 
 [[package]]
@@ -10604,6 +10605,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 name = "utils"
 version = "0.1.1"
 dependencies = [
+ "anyhow",
  "console-subscriber",
  "dirs 5.0.1",
  "hex",

--- a/apps/reporter/bin/launch_reporter.rs
+++ b/apps/reporter/bin/launch_reporter.rs
@@ -1,9 +1,12 @@
 use data_feeds::orchestrator::{get_validated_reporter_config, orchestrator};
 use std::env;
 
-use utils::build_info::{
-    BLOCKSENSE_VERSION, GIT_BRANCH, GIT_DIRTY, GIT_HASH, GIT_HASH_SHORT, GIT_TAG,
-    VERGEN_CARGO_DEBUG, VERGEN_CARGO_FEATURES, VERGEN_CARGO_OPT_LEVEL, VERGEN_RUSTC_SEMVER,
+use utils::{
+    build_info::{
+        BLOCKSENSE_VERSION, GIT_BRANCH, GIT_DIRTY, GIT_HASH, GIT_HASH_SHORT, GIT_TAG,
+        VERGEN_CARGO_DEBUG, VERGEN_CARGO_FEATURES, VERGEN_CARGO_OPT_LEVEL, VERGEN_RUSTC_SEMVER,
+    },
+    constants::{FEEDS_CONFIG_DIR, FEEDS_CONFIG_FILE},
 };
 
 use feed_registry::registry::get_validated_feeds_config;
@@ -29,8 +32,7 @@ async fn main() -> std::io::Result<()> {
                 println!("optimizations => {VERGEN_CARGO_OPT_LEVEL}");
                 println!("compiler => {VERGEN_RUSTC_SEMVER}");
 
-                let feeds_config_file =
-                    get_config_file_path("FEEDS_CONFIG_DIR", "feeds_config.json");
+                let feeds_config_file = get_config_file_path(FEEDS_CONFIG_DIR, FEEDS_CONFIG_FILE);
                 let _reporter_config = get_validated_reporter_config();
                 let _feeds_config = get_validated_feeds_config(&feeds_config_file);
 

--- a/apps/sequencer/bin/sequencer_runner.rs
+++ b/apps/sequencer/bin/sequencer_runner.rs
@@ -13,6 +13,9 @@ use sequencer::reporters::reporter::init_shared_reporters;
 
 use sequencer::http_handlers::admin::{deploy, get_feed_report_interval, get_key, set_log_level};
 use sequencer::http_handlers::data_feeds::{post_report, register_feed};
+use utils::constants::{
+    FEEDS_CONFIG_DIR, FEEDS_CONFIG_FILE, SEQUENCER_CONFIG_DIR, SEQUENCER_CONFIG_FILE,
+};
 use utils::logging::{
     get_log_level, get_shared_logging_handle, init_shared_logging_handle, tokio_console_active,
     SharedLoggingHandle,
@@ -120,11 +123,10 @@ pub async fn prepare_http_servers(
 }
 
 fn get_sequencer_and_feed_configs() -> (SequencerConfig, AllFeedsConfig) {
-    let sequencer_config_file =
-        get_config_file_path("SEQUENCER_CONFIG_DIR", "sequencer_config.json");
+    let sequencer_config_file = get_config_file_path(SEQUENCER_CONFIG_DIR, SEQUENCER_CONFIG_FILE);
     let sequencer_config = get_validated_sequencer_config(&sequencer_config_file)
         .expect("Could not get validated sequencer config");
-    let feeds_config_file = get_config_file_path("FEEDS_CONFIG_DIR", "feeds_config.json");
+    let feeds_config_file = get_config_file_path(FEEDS_CONFIG_DIR, FEEDS_CONFIG_FILE);
     let feeds_config = get_validated_feeds_config(&feeds_config_file);
     (sequencer_config, feeds_config)
 }

--- a/apps/sequencer/src/config.rs
+++ b/apps/sequencer/src/config.rs
@@ -12,26 +12,27 @@ pub fn init_sequencer_config(config_file: &Path) -> Result<SequencerConfig> {
 
     let data = read_file(config_file);
 
-    info!("Using config file: {}", config_file);
+    info!("Using config file: {config_file}");
 
     serde_json::from_str::<SequencerConfig>(data.as_str())
-        .map_err(|e| eyre::eyre!("Config file ({}) is not valid JSON! {}", config_file, e))
+        .map_err(|e| eyre::eyre!("Config file ({config_file}) is not valid JSON! {e}"))
 }
 
 pub fn get_validated_sequencer_config(config_file: &Path) -> Result<SequencerConfig> {
     let sequencer_config = match init_sequencer_config(config_file) {
         Ok(v) => v,
-        Err(e) => eyre::bail!("Failed to get config {} ", e),
+        Err(e) => eyre::bail!("Failed to get config {e} "),
     };
 
     match sequencer_config.validate("SequencerConfig") {
         Ok(_) => Ok(sequencer_config),
-        Err(e) => eyre::bail!("Validation error {} ", e),
+        Err(e) => eyre::bail!("Validation error {e} "),
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use utils::constants::{SEQUENCER_CONFIG_DIR, SEQUENCER_CONFIG_FILE};
     use utils::get_config_file_path;
 
     use super::*;
@@ -41,8 +42,7 @@ mod tests {
 
     #[test]
     fn test_get_validated_sequencer_config_with_error_in_set_endpoint_ports() {
-        let config_file_path =
-            get_config_file_path("SEQUENCER_CONFIG_DIR", "sequencer_config.json");
+        let config_file_path = get_config_file_path(SEQUENCER_CONFIG_DIR, SEQUENCER_CONFIG_FILE);
         let config_file_path = config_file_path
             .to_str()
             .expect("Error converting path to str, needed to read file.");
@@ -50,10 +50,7 @@ mod tests {
         let data = read_file(config_file_path);
         let mut config_json = match serde_json::from_str::<SequencerConfig>(data.as_str()) {
             Ok(c) => c,
-            Err(e) => panic!(
-                "Config file ({}) is not valid JSON! {}",
-                config_file_path, e
-            ),
+            Err(e) => panic!("Config file ({config_file_path}) is not valid JSON! {e}"),
         };
         config_json.main_port = config_json.admin_port; // Set an error in the config - endpoints cannot have same ports.
 

--- a/apps/sequencer/src/feeds/feeds_slots_manager.rs
+++ b/apps/sequencer/src/feeds/feeds_slots_manager.rs
@@ -107,6 +107,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
     use std::time::Duration;
+    use utils::constants::{FEEDS_CONFIG_DIR, FEEDS_CONFIG_FILE};
 
     use tokio::sync::{
         mpsc::{UnboundedReceiver, UnboundedSender},
@@ -126,7 +127,7 @@ mod tests {
         let log_handle = init_shared_logging_handle("INFO", false);
         let sequencer_config =
             init_sequencer_config(&sequencer_config_file).expect("Failed to load config:");
-        let feeds_config_file = get_config_file_path("FEEDS_CONFIG_DIR", "feeds_config.json");
+        let feeds_config_file = get_config_file_path(FEEDS_CONFIG_DIR, FEEDS_CONFIG_FILE);
         let mut feeds_config =
             init_feeds_config(&feeds_config_file).expect("Failed to get config: ");
         let all_feeds_reports = AllFeedsReports::new();

--- a/apps/sequencer/src/providers/eth_send_utils.rs
+++ b/apps/sequencer/src/providers/eth_send_utils.rs
@@ -314,8 +314,7 @@ mod tests {
     };
     use std::collections::HashMap;
     use std::str::FromStr;
-    use tokio::fs::File;
-    use tokio::io::AsyncWriteExt;
+    use utils::test_env::get_test_private_key_path;
 
     fn extract_address(message: &str) -> Option<String> {
         let re = Regex::new(r"0x[a-fA-F0-9]{40}").expect("Invalid regex");
@@ -325,27 +324,18 @@ mod tests {
         None
     }
 
-    async fn create_priv_key(key_path: &str, private_key: &[u8]) {
-        let mut f = File::create(key_path)
-            .await
-            .expect("Could not create key file");
-        f.write(private_key)
-            .await
-            .expect("Failed to write to temp file");
-        f.flush().await.expect("Could not flush temp file");
-    }
-
     #[tokio::test]
     async fn test_deploy_contract_returns_valid_address() {
         // setup
         let anvil = Anvil::new().try_spawn().unwrap();
-        let key_path = "/tmp/priv_key_test";
-        let private_key = b"0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356";
         let network = "ETH131";
-        create_priv_key(key_path, private_key).await;
+        let key_path = get_test_private_key_path();
 
-        let cfg =
-            get_test_config_with_single_provider(network, key_path, anvil.endpoint().as_str());
+        let cfg = get_test_config_with_single_provider(
+            network,
+            key_path.as_path(),
+            anvil.endpoint().as_str(),
+        );
 
         // give some time for cleanup env variables
         let providers =
@@ -381,13 +371,14 @@ mod tests {
 
         // setup
         let anvil = Anvil::new().try_spawn().unwrap();
-        let key_path = "/tmp/priv_key_test";
-        let private_key = b"0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356";
+        let key_path = get_test_private_key_path();
         let network = "ETH333";
-        create_priv_key(key_path, private_key).await;
 
-        let cfg =
-            get_test_config_with_single_provider(network, key_path, anvil.endpoint().as_str());
+        let cfg = get_test_config_with_single_provider(
+            network,
+            key_path.as_path(),
+            anvil.endpoint().as_str(),
+        );
 
         let providers =
             init_shared_rpc_providers(&cfg, Some("test_eth_batch_send_to_oneshot_contract_")).await;
@@ -480,9 +471,7 @@ mod tests {
         /////////////////////////////////////////////////////////////////////
 
         // setup
-        let key_path = "/tmp/priv_key_test";
-        let private_key = b"0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356";
-        create_priv_key(key_path, private_key).await;
+        let key_path = get_test_private_key_path();
 
         let anvil_network1 = Anvil::new().try_spawn().unwrap();
         let network1 = "ETH374";
@@ -490,8 +479,16 @@ mod tests {
         let network2 = "ETH375";
 
         let cfg = get_test_config_with_multiple_providers(vec![
-            (network1, key_path, anvil_network1.endpoint().as_str()),
-            (network2, key_path, anvil_network2.endpoint().as_str()),
+            (
+                network1,
+                key_path.as_path(),
+                anvil_network1.endpoint().as_str(),
+            ),
+            (
+                network2,
+                key_path.as_path(),
+                anvil_network2.endpoint().as_str(),
+            ),
         ]);
 
         let providers =

--- a/apps/sequencer/src/providers/provider.rs
+++ b/apps/sequencer/src/providers/provider.rs
@@ -214,37 +214,29 @@ async fn get_rpc_providers(
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
     use alloy::{
         network::TransactionBuilder, node_bindings::Anvil, primitives::U256,
         rpc::types::eth::request::TransactionRequest,
     };
     use eyre::Result;
+    use utils::test_env::get_test_private_key_path;
 
     use crate::providers::provider::get_rpc_providers;
     use alloy::providers::Provider as AlloyProvider;
     use sequencer_config::get_test_config_with_single_provider;
-
-    use tokio::fs::File;
-    use tokio::io::AsyncWriteExt;
-
-    async fn create_priv_key(key_path: &str, private_key: &[u8]) {
-        let mut f = File::create(key_path)
-            .await
-            .expect("Could not create key file");
-        f.write(private_key)
-            .await
-            .expect("Failed to write to temp file");
-        f.flush().await.expect("Could not flush temp file");
-    }
 
     #[tokio::test]
     async fn basic_test_provider() -> Result<()> {
         let network = "ETH";
 
         let anvil = Anvil::new().try_spawn()?;
+        let key_path = PathBuf::new().join("/tmp").join("key");
 
-        let cfg = get_test_config_with_single_provider(network, "/tmp/key", &anvil.endpoint());
+        let cfg =
+            get_test_config_with_single_provider(network, key_path.as_path(), &anvil.endpoint());
 
         let providers = get_rpc_providers(&cfg, "basic_test_provider_").await;
         let provider = &providers.get(network).unwrap().lock().await.provider;
@@ -279,14 +271,14 @@ mod tests {
     #[tokio::test]
     async fn test_get_wallet_success() {
         let network = "ETH1";
-        // Create a temporary file with a valid private key
-        let private_key = b"0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356";
         let expected_wallet_address = "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955"; // generated as hash of private_key
-        let key_path = "/tmp/key";
+        let key_path = get_test_private_key_path();
 
-        create_priv_key(key_path, private_key).await;
-
-        let cfg = get_test_config_with_single_provider(network, key_path, "http://localhost:8545");
+        let cfg = get_test_config_with_single_provider(
+            network,
+            key_path.as_path(),
+            "http://localhost:8545",
+        );
         let providers = get_rpc_providers(&cfg, "test_get_wallet_success_").await;
 
         // Call the function
@@ -300,13 +292,13 @@ mod tests {
     async fn test_get_rpc_providers_returns_single_provider() {
         // setup
         let network = "ETH2";
-        // Create a temporary file with a valid private key
-        let private_key = b"0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356";
-        let key_path = "/tmp/key";
+        let key_path = get_test_private_key_path();
 
-        create_priv_key(key_path, private_key).await;
-
-        let cfg = get_test_config_with_single_provider(network, key_path, "http://localhost:8545");
+        let cfg = get_test_config_with_single_provider(
+            network,
+            key_path.as_path(),
+            "http://localhost:8545",
+        );
 
         // test
         let binding = init_shared_rpc_providers(

--- a/apps/sequencer_tests/bin/sequencer_tests.rs
+++ b/apps/sequencer_tests/bin/sequencer_tests.rs
@@ -17,6 +17,7 @@ use std::thread;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::time;
 use tokio::time::Duration;
+use utils::constants::{SEQUENCER_CONFIG_DIR, SEQUENCER_CONFIG_FILE};
 use utils::get_config_file_path;
 use utils::read_file;
 
@@ -58,7 +59,7 @@ async fn spawn_sequencer(eth_networks_ports: [i32; 2]) -> thread::JoinHandle<()>
         },
     });
 
-    let config_file_path = get_config_file_path("SEQUENCER_CONFIG_DIR", "sequencer_config.json");
+    let config_file_path = get_config_file_path(SEQUENCER_CONFIG_DIR, SEQUENCER_CONFIG_FILE);
     let config_file_path = config_file_path
         .to_str()
         .expect("Environment variable does not hold a dir path");

--- a/libs/data_feeds/src/orchestrator.rs
+++ b/libs/data_feeds/src/orchestrator.rs
@@ -12,8 +12,11 @@ use prometheus::{
 };
 use sequencer_config::{ReporterConfig, Validated};
 use tokio::sync::{mpsc, Mutex};
-use utils::get_config_file_path;
 use utils::read_file;
+use utils::{
+    constants::{FEEDS_CONFIG_DIR, FEEDS_CONFIG_FILE, REPORTER_CONFIG_DIR, REPORTER_CONFIG_FILE},
+    get_config_file_path,
+};
 
 use tracing::{debug, info};
 
@@ -31,7 +34,7 @@ use feed_registry::{
 };
 
 pub fn init_reporter_config() -> Result<ReporterConfig, anyhow::Error> {
-    let config_file_path = get_config_file_path("REPORTER_CONFIG_DIR", "reporter_config.json");
+    let config_file_path = get_config_file_path(REPORTER_CONFIG_DIR, REPORTER_CONFIG_FILE);
     let config_file_path = config_file_path
         .to_str()
         .expect("Environment variable does not hold a dir path");
@@ -95,7 +98,7 @@ pub async fn orchestrator() {
 
     let reporter_config = init_reporter_config().expect("Config file is not valid JSON!");
 
-    let feeds_config_file = get_config_file_path("FEEDS_CONFIG_DIR", "feeds_config.json");
+    let feeds_config_file = get_config_file_path(FEEDS_CONFIG_DIR, FEEDS_CONFIG_FILE);
     let feeds_registry = init_feeds_config(&feeds_config_file).expect("Failed to get config: ");
 
     let mut connection_cache = HashMap::<DataFeedAPI, Arc<Mutex<dyn DataFeed + Send>>>::new();

--- a/libs/sequencer_config/Cargo.toml
+++ b/libs/sequencer_config/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+utils = {path = "../utils"}
 dirs = "5.0.1"
 serde = { version = "1.0.210", features = ["derive"]}
 anyhow = "1.0.89"

--- a/libs/sequencer_config/src/lib.rs
+++ b/libs/sequencer_config/src/lib.rs
@@ -1,8 +1,7 @@
 use hex::decode;
 use serde::{de, Deserialize, Deserializer, Serialize};
 use std::collections::HashSet;
-use std::fs::File;
-use std::io::Write;
+use std::path::Path;
 use std::time::SystemTime;
 use std::{collections::HashMap, fmt::Debug};
 use tracing::trace;
@@ -189,14 +188,9 @@ impl Validated for SequencerConfig {
 
 pub fn get_test_config_with_single_provider(
     network: &str,
-    private_key_path: &str,
+    private_key_path: &Path,
     url: &str,
 ) -> SequencerConfig {
-    let mut file = File::create(private_key_path)
-        .unwrap_or_else(|_| panic!("Could not create file {}", private_key_path));
-    file.write_all(b"0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356")
-        .unwrap_or_else(|_| panic!("Could not write to file {}", private_key_path));
-
     SequencerConfig {
         main_port: 8877,
         admin_port: 5556,
@@ -206,7 +200,7 @@ pub fn get_test_config_with_single_provider(
         providers: HashMap::from([(
             network.to_string(),
             Provider {
-                private_key_path: private_key_path.to_string(),
+                private_key_path: private_key_path.to_str().expect("Error in private key path").to_string(),
                 url: url.to_string(),
                 contract_address: None,
                 event_contract_address: None,
@@ -220,20 +214,18 @@ pub fn get_test_config_with_single_provider(
 }
 
 pub fn get_test_config_with_multiple_providers(
-    provider_details: Vec<(&str, &str, &str)>,
+    provider_details: Vec<(&str, &Path, &str)>,
 ) -> SequencerConfig {
     let mut providers = HashMap::new();
 
     for (network, private_key_path, url) in provider_details {
-        let mut file = File::create(private_key_path)
-            .unwrap_or_else(|_| panic!("Could not create file {}", private_key_path));
-        file.write_all(b"0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356")
-            .unwrap_or_else(|_| panic!("Could not write to file {}", private_key_path));
-
         providers.insert(
             network.to_string(),
             Provider {
-                private_key_path: private_key_path.to_string(),
+                private_key_path: private_key_path
+                    .to_str()
+                    .expect("Error in private_key_path: ")
+                    .to_string(),
                 url: url.to_string(),
                 contract_address: None,
                 event_contract_address: None,

--- a/libs/utils/Cargo.toml
+++ b/libs/utils/Cargo.toml
@@ -15,6 +15,7 @@ tracing-subscriber = { version = "0.3.18", features = ["json"] }
 once_cell = "1.20.0"
 console-subscriber = "0.4.0"
 dirs = "5.0.1"
+anyhow = "1.0.89"
 
 [build-dependencies]
 # All features enabled

--- a/libs/utils/src/constants.rs
+++ b/libs/utils/src/constants.rs
@@ -1,0 +1,9 @@
+// environment variables holding the config dirs
+pub const FEEDS_CONFIG_DIR: &str = "FEEDS_CONFIG_DIR";
+pub const SEQUENCER_CONFIG_DIR: &str = "SEQUENCER_CONFIG_DIR";
+pub const REPORTER_CONFIG_DIR: &str = "REPORTER_CONFIG_DIR";
+
+// config file names
+pub const FEEDS_CONFIG_FILE: &str = "feeds_config.json";
+pub const SEQUENCER_CONFIG_FILE: &str = "sequencer_config.json";
+pub const REPORTER_CONFIG_FILE: &str = "reporter_config.json";

--- a/libs/utils/src/test_env.rs
+++ b/libs/utils/src/test_env.rs
@@ -1,0 +1,14 @@
+use std::{path::PathBuf, sync::OnceLock};
+
+use crate::write_flush_file;
+
+pub fn get_test_private_key_path() -> &'static PathBuf {
+    static KEY_PATH: OnceLock<PathBuf> = OnceLock::new();
+    KEY_PATH.get_or_init(move || {
+        let key_path = PathBuf::from("/tmp").join("priv_key_test");
+        let private_key =
+            "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356".to_string();
+        write_flush_file(key_path.as_path(), &private_key).expect("Could not create private key");
+        key_path
+    })
+}


### PR DESCRIPTION
Resolved comments from [PR-423](https://github.com/blocksense-network/blocksense/pull/423)

Solved a data race on private key file used in tests. The situation is as follows:
Multiple tests need to setup configuration and have a private key for signing transactions. Since this key's path is the same in all tests and they all create it and then read it, in a a multi-threaded environment this causes a data race. The fix is to have the file created once in a thread safe way with OnceLock and then have all tests use this instance for reading only.