### PR TITLE
feat(docs.ws): Blocksense fonts used accross the project should be preloaded

### DIFF
--- a/apps/docs.blocksense.network/blocksense-theme/font.css
+++ b/apps/docs.blocksense.network/blocksense-theme/font.css
@@ -3,6 +3,7 @@
   src: url('/fonts/noto-sans/NotoSans-Regular.ttf') format('truetype');
   font-weight: 400;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -10,13 +11,7 @@
   src: url('/fonts/NotoSans-Italic.ttf') format('truetype');
   font-weight: 400;
   font-style: italic;
-}
-
-@font-face {
-  font-family: 'Noto Sans Light';
-  src: url('/fonts/NotoSans-Light.ttf') format('truetype');
-  font-weight: 300;
-  font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -24,6 +19,7 @@
   src: url('/fonts/noto-sans/NotoSans-LightItalic.ttf') format('truetype');
   font-weight: 300;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -31,6 +27,7 @@
   src: url('/fonts/noto-sans/NotoSans-Medium.ttf') format('truetype');
   font-weight: 500;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -38,6 +35,7 @@
   src: url('/fonts/noto-sans/NotoSans-SemiBold.ttf') format('truetype');
   font-weight: 600;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -45,6 +43,7 @@
   src: url('/fonts/noto-sans/NotoSans-SemiBoldItalic.ttf') format('truetype');
   font-weight: 600;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -52,6 +51,7 @@
   src: url('/fonts/noto-sans/NotoSans-Thin.ttf') format('truetype');
   font-weight: 100;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -59,6 +59,7 @@
   src: url('/fonts/noto-sans/NotoSans-ThinItalic.ttf') format('truetype');
   font-weight: 100;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -66,6 +67,7 @@
   src: url('/fonts/noto-sans/NotoSans-Bold.ttf') format('truetype');
   font-weight: bold;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -73,6 +75,7 @@
   src: url('/fonts/noto-sans/NotoSans-BoldItalic.ttf') format('truetype');
   font-weight: bold;
   font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
@@ -80,6 +83,7 @@
   src: url('/fonts/noto-sans/NotoSans-ExtraBold.ttf') format('truetype');
   font-weight: bolder;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -87,6 +91,7 @@
   src: url('/fonts/noto-sans/NotoSans-Black.ttf') format('truetype');
   font-weight: bolder;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -94,6 +99,7 @@
   src: url('/fonts/SpaceMono-Bold.ttf') format('truetype');
   font-weight: bold;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -101,4 +107,5 @@
   src: url('/fonts/fira/FiraCode-Regular.ttf') format('truetype');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }

--- a/apps/docs.blocksense.network/theme.config.tsx
+++ b/apps/docs.blocksense.network/theme.config.tsx
@@ -1,6 +1,24 @@
 import { Header } from './components/common/Header';
 import { Footer } from './components/common/Footer';
 
+const fonts = [
+  '/fonts/fira/FiraCode-Regular.ttf',
+  '/fonts/noto-sans/NotoSans-Black.ttf',
+  '/fonts/noto-sans/NotoSans-Bold.ttf',
+  '/fonts/noto-sans/NotoSans-BoldItalic.ttf',
+  '/fonts/noto-sans/NotoSans-ExtraBold.ttf',
+  '/fonts/noto-sans/NotoSans-Italic.ttf',
+  '/fonts/noto-sans/NotoSans-Light.ttf',
+  '/fonts/noto-sans/NotoSans-LightItalic.ttf',
+  '/fonts/noto-sans/NotoSans-Medium.ttf',
+  '/fonts/noto-sans/NotoSans-Regular.ttf',
+  '/fonts/noto-sans/NotoSans-SemiBold.ttf',
+  '/fonts/noto-sans/NotoSans-SemiBoldItalic.ttf',
+  '/fonts/noto-sans/NotoSans-Thin.ttf',
+  '/fonts/noto-sans/NotoSans-ThinItalic.ttf',
+  '/fonts/SpaceMono-Bold.ttf',
+];
+
 export default {
   logo: Header,
   project: {
@@ -16,10 +34,19 @@ export default {
     };
   },
   head: (
-    <link
-      rel="icon"
-      href="/images/blocksense-favicon.png"
-      type="image/png"
-    ></link>
+    <>
+      <link rel="icon" href="/images/blocksense-favicon.png" type="image/png" />
+
+      {fonts.map(font => (
+        <link
+          key={font}
+          rel="preload"
+          href={font}
+          as="font"
+          type="font/ttf"
+          crossOrigin="anonymous"
+        />
+      ))}
+    </>
   ),
 };


### PR DESCRIPTION
We need to preload the fonts so we will avoid Console errors for missing fonts, used across the project **without** side-effects.

![image](https://github.com/user-attachments/assets/6401047d-067d-4965-b81c-168a602fda24)

**After:**

![image](https://github.com/user-attachments/assets/45f12c7d-1c2f-4679-9fac-54e66c52a8b4)
![image](https://github.com/user-attachments/assets/f5bd9379-4801-434c-a9b1-e13c573d9736)


