### PR TITLE
feat(docs.ws): Add missing meta description for docs.ws

### DIFF
--- a/apps/docs.blocksense.network/theme.config.tsx
+++ b/apps/docs.blocksense.network/theme.config.tsx
@@ -35,8 +35,11 @@ export default {
   },
   head: (
     <>
+      <meta
+        name="description"
+        content="Blocksense is the ZK rollup for scaling oracle data to infinity. Everyone will be able to create secure oracles in minutes."
+      />
       <link rel="icon" href="/images/blocksense-favicon.png" type="image/png" />
-
       {fonts.map(font => (
         <link
           key={font}


### PR DESCRIPTION
Lighthouse is complaining about missing meta description for Blocksense documentation website. We're adding it to the safest place possible, which is currently the `theme.config.tsx`
![image](https://github.com/user-attachments/assets/56b0130d-6d3f-42cb-8869-4b742d6e6499)

We're reusing the meta description from the official [blocksense.network](https://blocksense.network/) website.

**After:**

![image](https://github.com/user-attachments/assets/4cc05ca9-da0f-413d-a002-e1d47ff21104)
