### PR TITLE
feat(explorer.ws): Setup base style structure for Block explorer 

### DIFF
--- a/apps/explorer.blocksense.network/globals.css
+++ b/apps/explorer.blocksense.network/globals.css
@@ -1,0 +1,1 @@
+@import "@/blocksense-theme/base.css";

--- a/apps/explorer.blocksense.network/src/app/layout.tsx
+++ b/apps/explorer.blocksense.network/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import "@/styles/globals.css";
+import "@/../globals.css";
 
 import { GeistSans } from "geist/font/sans";
 import { type Metadata } from "next";

--- a/apps/explorer.blocksense.network/src/blocksense-theme/base.css
+++ b/apps/explorer.blocksense.network/src/blocksense-theme/base.css
@@ -1,0 +1,104 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  *,
+  ::before,
+  ::after {
+    box-sizing: border-box;
+    border: none;
+  }
+
+  *:focus {
+    outline: none;
+  }
+
+  * {
+    @apply border-2;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(229, 231, 235, 0.6) transparent;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+  }
+
+  .bg-card {
+    border: 1px solid;
+    @apply border-slate-200 max-w-96 mt-10;
+  }
+
+  .tabs {
+    @apply shadow-md;
+  }
+
+  table {
+    @apply bg-white;
+  }
+
+  table tr {
+    @apply border-b border-gray-200;
+  }
+
+  table th {
+    @apply font-bold text-slate-700;
+  }
+
+  .bg-card,
+  .tabs,
+  .cn-table,
+  table {
+    @apply border border-slate-200;
+  }
+
+  [role="dialog"] pre {
+    border: none;
+  }
+
+  pre {
+    @apply border border-gray-200 rounded-lg p-5;
+    contain: paint;
+    word-break: break-word;
+    white-space: pre-wrap;
+  }
+
+  pre code {
+    @apply bg-transparent min-w-full;
+    line-height: 1.25rem;
+    display: grid;
+    padding: 0 !important;
+  }
+
+  pre code span {
+    @apply font-mono not-italic;
+  }
+
+  html[data-word-wrap] pre .line {
+    @apply inline-block;
+  }
+
+  pre .nextra-copy-icon {
+    animation: 0.3s forwards fade-in;
+  }
+
+  @keyframes fade-in {
+    0% {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @media (prefers-color-scheme: dark),
+    (prefers-color-scheme: light),
+    (prefers-color-scheme: no-preference) {
+    body {
+      @apply bg-white text-black !important;
+    }
+    .next-error-h1 {
+      @apply border-r border-gray-500 !important;
+    }
+  }
+}

--- a/apps/explorer.blocksense.network/src/styles/globals.css
+++ b/apps/explorer.blocksense.network/src/styles/globals.css
@@ -1,3 +1,0 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;

--- a/apps/explorer.blocksense.network/tailwind.config.ts
+++ b/apps/explorer.blocksense.network/tailwind.config.ts
@@ -1,14 +1,85 @@
 import { type Config } from "tailwindcss";
 import { fontFamily } from "tailwindcss/defaultTheme";
 
-export default {
-  content: ["./src/**/*.tsx"],
+const config: Config = {
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+    "./src/**/*.{js,ts,jsx,tsx}",
+    "./@/**/*.{js,ts,jsx,tsx}",
+  ],
   theme: {
+    container: {
+      center: true,
+      padding: "2rem",
+      screens: {
+        "2xl": "1400px",
+      },
+    },
     extend: {
       fontFamily: {
         sans: ["var(--font-geist-sans)", ...fontFamily.sans],
       },
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      keyframes: {
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+      },
+      boxShadow: {
+        sm: "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)",
+      },
     },
   },
   plugins: [],
-} satisfies Config;
+};
+
+export default config;


### PR DESCRIPTION
We need to setup, structure similar to the one already implemented for docs.blocksense.network.

Changes included:
- Updated:` layout.tsx` and `globals.css`
- Add `blocksense-theme` specific styles for Block Explorer.
> NOTE: We cannot completely share the blocksense-theme directly from docs.ws, because it contains Nextra specific styles and overrides, non related with the explorer. 
- Update[ tailwind config ](https://tailwindcss.com/docs/configuration)based on what we already have.