### PR TITLE
ci(gh-actions): Print extra info on the nix build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Nix build Rust workspace
-        run: nix build --impure .#blocksense-rs
+        run: nix build --impure --json -L --accept-flake-config .#blocksense-rs
 
   deploy_websites:
     timeout-minutes: 360


### PR DESCRIPTION
To review the PR observe the rust-nix-build job.

Information about the derivation is added and the warnings relates to `—accept-flake-config` are fixed 
Before 
![IMG_4646](https://github.com/user-attachments/assets/a2c915fd-a27c-4c17-90fc-614bd7ceb059)
After
![IMG_4647](https://github.com/user-attachments/assets/69d1b0bc-8a48-48bc-b743-9f4c8b76e642)
