### PR TITLE
[base-utils/env-utils]: Split ENV constants from functions.

### DIFF
--- a/libs/base-utils/package.json
+++ b/libs/base-utils/package.json
@@ -43,9 +43,9 @@
       "types": "./dist/types/evm-utils/index.d.ts"
     },
     "./env": {
-      "require": "./dist/cjs/env.cjs",
-      "import": "./dist/esm/env.mjs",
-      "types": "./dist/types/env.d.ts"
+      "require": "./dist/cjs/env/index.cjs",
+      "import": "./dist/esm/env/index.mjs",
+      "types": "./dist/types/env/index.d.ts"
     },
     "./numeric": {
       "require": "./dist/cjs/numeric.cjs",

--- a/libs/base-utils/src/env/constants.ts
+++ b/libs/base-utils/src/env/constants.ts
@@ -1,0 +1,21 @@
+import { join } from 'path';
+import { getEnvString } from '.';
+
+/**
+ * The root directory of the Git repository.
+ */
+export const rootDir = getEnvString('GIT_ROOT');
+
+/**
+ * The root configuration directory.
+ */
+export const configDir = join(rootDir, 'config');
+
+export const configFiles = {
+  ['feeds_config']: join(configDir, 'feeds_config.json'),
+  ['chainlink_compatibility']: join(configDir, 'chainlink_compatibility'),
+  ['evm_contracts_deployment_v1']: join(
+    configDir,
+    'evm_contracts_deployment_v1.json',
+  ),
+};

--- a/libs/base-utils/src/env/functions.spec.ts
+++ b/libs/base-utils/src/env/functions.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { getEnvString } from './env';
+import { getEnvString } from './functions';
 
 describe('getEnvString', () => {
   test('returns the value of an existing environment variable', () => {

--- a/libs/base-utils/src/env/functions.ts
+++ b/libs/base-utils/src/env/functions.ts
@@ -1,25 +1,4 @@
-import { join } from 'path';
-
-import { assertNotNull } from './assert';
-
-/**
- * The root directory of the Git repository.
- */
-export const rootDir = getEnvString('GIT_ROOT');
-
-/**
- * The root configuration directory.
- */
-export const configDir = join(rootDir, 'config');
-
-export const configFiles = {
-  ['feeds_config']: join(configDir, 'feeds_config.json'),
-  ['chainlink_compatibility']: join(configDir, 'chainlink_compatibility'),
-  ['evm_contracts_deployment_v1']: join(
-    configDir,
-    'evm_contracts_deployment_v1.json',
-  ),
-};
+import { assertNotNull } from '../assert';
 
 /**
  * Retrieves the value of an environment variable.

--- a/libs/base-utils/src/env/index.ts
+++ b/libs/base-utils/src/env/index.ts
@@ -1,0 +1,2 @@
+export * from './functions';
+export * from './constants';

--- a/libs/base-utils/src/evm-utils/networks.ts
+++ b/libs/base-utils/src/evm-utils/networks.ts
@@ -7,7 +7,7 @@
 
 import * as S from '@effect/schema/Schema';
 
-import { getEnvString, getOptionalEnvString } from '../env';
+import { getEnvString, getOptionalEnvString } from '../env/functions';
 import { EthereumAddress, TxHash } from './hex-types';
 import { KebabToSnakeCase, kebabToSnakeCase } from '../string';
 import { NumberFromSelfBigIntOrString } from '../numeric';


### PR DESCRIPTION
> This is a curious one. Please note the description bellow

### With this PR we refactor the ENV utils in `@blocksense/env-utils` workspace. We separate the constants from functions, move them to a dedicated folder - `env-utils` and apply changes where needed.. but why?

---

### The Problem

While browsing the [Deployed Contracts](https://docs.blocksense.network/docs/contracts/deployed-contracts) page, @MillaGenova & @RadoslavDimchev  separately encountered a bug where the website attempted to access the `GIT_ROOT` environment variable, leading to the following error:

```
Error: Env variable 'GIT_ROOT' is missing.
```
Exploring in dev mode showed the following:
![image](https://github.com/user-attachments/assets/c68eaa22-d61d-4d90-8197-56225bd90183)

Looking at the call trace, I saw that here
`blocksense/monorepo/apps/docs.blocksense.network/.next/static/chunks/pages/docs/contracts/deployed-contracts.js (19561:1)
we were importing libs/base-utils/dist/esm/env.mjs.`

### The Investigation
- **First red flag:** Why are there files in the `static` folder in the first place? Everything should be handled on the server side, not the client side.
- **Second red flag:** This import is related to environment variables (specifically `GIT_ROOT`), which is tied to the git repository. This kind of environment variable should never be accessed from the client side.

This issue didn’t occur in the previous days, so I started further investigation.

I started by looking at: `blocksense/monorepo/apps/docs.blocksense.network/.next/static/chunks/pages/docs/contracts/deployed-contracts.js (19561:1)`.

Since the deployed contract is an MDX page that we generate, I began my investigation with the generation script — [`generate-deployed-contracts-mdx.ts`](https://github.com/blocksense-network/blocksense/blob/9824b3a5781933f6ba4ac366f05081feeed25b4f/apps/docs.blocksense.network/src/deployed-contracts/generate-deployed-contracts-mdx.ts). My initial idea was to comment out the [content we write to the MDX](https://github.com/blocksense-network/blocksense/blob/9824b3a5781933f6ba4ac366f05081feeed25b4f/apps/docs.blocksense.network/src/deployed-contracts/generate-deployed-contracts-mdx.ts#L70-L74), and, unsurprisingly, everything worked fine.

Next, I looked at the React component used — [DeployedContracts.tsx](https://github.com/blocksense-network/blocksense/blob/9824b3a5781933f6ba4ac366f05081feeed25b4f/apps/docs.blocksense.network/components/DeployedContracts/DeployedContracts.tsx). Nothing unusual in the imports — everything was from within the workspace.

At this point, I shifted my strategy and searched for `@blocksense/base-utils/env` across all files in `apps/docs.blocksense.network`. No results came up, meaning the issue must be coming from a nested import.

Next, I searched for `@blocksense/base-utils`. This time, there were more results. What caught my attention was that there were only two React components that imported it: `coreContractsColumns.tsx` and `ContractAddress.tsx`. Both files import `@blocksense/base-utils/evm-utils`.

Now everything has become clear. It is expected that `evm-utils` uses some ENV utilities, but  why it was suddenly causing problems? Then I remembered — we recently expanded the `evm-utils` module to help generate network RPC-related ENV configurations.

And there it is — [this commit](https://github.com/blocksense-network/blocksense/commit/61d16a945947c5861559980e88ce32284bc0205a) introduces the problem. 

To summarize, the deployment generation script imports components that, in turn, import network utilities for type safety, which depend on ENV functions, specifically requiring the `GIT_ROOT` ENV.


### The Solution

Once the issue was identified, isolating the problematic ENV constants (specifically `GIT_ROOT`, which depends on the git repository) from the environment-related functions that don't require these constants was straightforward.

I decided to create a new directory called `env-utils`, where the constants are stored separately from the functions. This separation ensures that components only import what they need, without pulling in unnecessary ENV dependencies.

After implementing this change, the docs website works smoothly again. To test, open the deployment link bellow and navigate to the Deployed Contracts page

---

I’m open to suggestions for improving this approach. 