### PR TITLE
[config(nix/pre-commit-hook/prettier)]: Pass args explicitly

### DIFF
--- a/nix/shells/pkg-sets/pre-commit.nix
+++ b/nix/shells/pkg-sets/pre-commit.nix
@@ -11,6 +11,15 @@
     };
     cargo-check.enable = true;
     rustfmt.enable = true;
-    prettier.enable = true;
+    prettier = {
+      enable = true;
+      args = [
+        "--check"
+        "--list-different=false"
+        "--log-level=warn"
+        "--ignore-unknown"
+        "--write"
+      ];
+    };
   };
 }


### PR DESCRIPTION
### What's New?

We've updated Prettier to use the `--check` and `--log-level=warn` flags. This ensures that Prettier returns an error when unformatted files are detected, and those files are listed and formatted. See the example below:

![image](https://github.com/user-attachments/assets/7e9b08b3-8037-40ca-81e2-9e995fe076d7)

### The Problem

A bug was identified in the linter step within the CI. @yordanmadzhunkov noted that running `pre-commit run --all` locally didn't flag any issues, but the CI job encountered a [problem](https://github.com/blocksense-network/blocksense/actions/runs/11144908915/job/30973250436?pr=497). Upon running the command locally, I found that while it passed, there were unformatted files that had not been listed.

Reference: [Issue Comment](https://github.com/blocksense-network/blocksense/pull/497#issuecomment-2388787753)

### The Solution

We manage our pre-commit hooks using this [Nix script](https://github.com/blocksense-network/blocksense/blob/main/nix/shells/pkg-sets/pre-commit.nix), which generates the `.pre-commit-config.yaml` configuration. Prettier was initially configured with the following entry: `prettier --ignore-unknown --list-different --write`.

After testing, I discovered that the `--list-different` flag wasn't listing unformatted files. However, using the `--check` flag causes Prettier to return an error when unformatted files are detected, while also listing those files.

I updated the Prettier configuration as follows:

```nix
prettier = {
  enable = true;  # Enables the Prettier hook during pre-commit.
  args = [
    "--check"  # Verifies if files are formatted correctly and returns an error if not.
    "--list-different=false"  # Disables the 'list-different' flag, as it's redundant with 'check'.
    "--log-level=warn"  # Sets log level to 'warn' to list changed files.
    "--ignore-unknown"  # Explicitly passes this argument, though it's in the entrypoint.
    "--write"  # Ensures files are written after formatting, even though it's already in the entrypoint.
  ];
};
```

The arguments in `args` override the existing entry configuration.

### How to Test

1. Checkout the branch.
2. Unformat a file formated my prettier (*.ts / *.yml / etc. ).
3. Run `pre-commit run --all` or `yarn format:write`.
4. Review the output to confirm that unformatted files are detected and listed.