### PR TITLE
[docs.ws]: Add `GitHub` info page for `unauthorized users`

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/AbsolutePath.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/AbsolutePath.tsx
@@ -14,7 +14,8 @@ export const AbsolutePath = ({ absolutePath }: AbsolutePathProps) => {
   return (
     <Link
       className="absolute-path__link font-semibold text-sm flex gap-2 items-center"
-      href={`${ghContractFolder}${absolutePath}`}
+      // href={`${ghContractFolder}${absolutePath}`} //use it after our repo is public on GitHub
+      href={`/coming-soon`}
     >
       <GitHubIcon className="my-1" />
       {config.github}

--- a/apps/docs.blocksense.network/components/sol-contracts/ContractsFileTree.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/ContractsFileTree.tsx
@@ -10,7 +10,7 @@ type TreeNode = {
 };
 
 export const renderTree = ({ name, children, id, path }: TreeNode) => {
-  const constructedHref = `${ghContractFolder}contracts/${path}`;
+  const constructedHref = `${ghContractFolder}contracts/${path}`; //use it after our repo is public on GitHub
   if (children) {
     return (
       <FileTree.Folder name={name} key={id} defaultOpen>
@@ -18,7 +18,7 @@ export const renderTree = ({ name, children, id, path }: TreeNode) => {
       </FileTree.Folder>
     );
   } else {
-    return <FileTree.File name={name} key={id} href={constructedHref} />;
+    return <FileTree.File name={name} key={id} href={'/coming-soon'} />;
   }
 };
 

--- a/apps/docs.blocksense.network/pages/_meta.json
+++ b/apps/docs.blocksense.network/pages/_meta.json
@@ -10,5 +10,10 @@
     "type": "page",
     "href": "/docs",
     "display": "hidden"
+  },
+  "coming-soon": {
+    "type": "page",
+    "href": "/coming-soon",
+    "display": "hidden"
   }
 }

--- a/apps/docs.blocksense.network/pages/coming-soon.mdx
+++ b/apps/docs.blocksense.network/pages/coming-soon.mdx
@@ -1,0 +1,22 @@
+---
+title: "Coming Soon"
+---
+
+<div style={{ fontFamily:'system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',display: 'flex', flexDirection:'row', justifyContent: 'center', alignItems: 'center', height: '100vh', textAlign: 'center', color:'black' }}>
+  <div style={{lineHeight:'48px', borderRight:'1px solid',paddingRight:'23px', margin:'0 20px 0 0'}}>
+      <svg
+        width="24"
+        height="24"
+        fill="currentColor"
+        viewBox="3 3 18 18"
+        style={{display:'inline-block'}}
+      >
+        <title>GitHub</title>
+        <path d="M12 3C7 3 3 7.13 3 12.23 3 16.31 5.58 19.76 9.15 20.98c.45.08.62-.19.62-.44 0-.22-.01-.94-.01-1.72-2.26.43-2.84-.81-3.02-1.33-.1-.27-.55-1.09-.99-1.31-.34-.18-.82-.64.05-.65.72-.01 1.23.66 1.4.94.82 1.39 2.12 1 2.63.76.08-.6.34-1 .61-1.24-2.2-.23-4.51-1.1-4.51-4.89 0-1.08.39-1.96 1.03-2.65-.1-.23-.45-1.16.1-2.41 0 0 .83-.26 2.73 1.03a9.27 9.27 0 0 1 4.96 0C16.14 6.16 16.97 6.42 16.97 6.42c.55 1.25.2 2.18.1 2.41.64.69 1.03 1.57 1.03 2.65 0 3.8-2.31 4.66-4.51 4.89.35.3.66.9.66 1.81 0 1.31-.01 2.36-.01 2.69 0 .25.17.53.63.44 3.58-1.22 6.15-4.67 6.15-8.75C21 7.13 16.97 3 12 3z" />
+      </svg>
+  </div>
+
+  <div style={{ display: "inline-block" }}>
+      <h2 style={{ fontSize: '14px' ,lineHeight:'28px',fontWeight:'400'}}>We're going public soon!</h2>
+  </div>
+</div>

--- a/apps/docs.blocksense.network/pages/docs/contracts/commands.mdx
+++ b/apps/docs.blocksense.network/pages/docs/contracts/commands.mdx
@@ -2,7 +2,7 @@
 
 ### Display Available Commands
 
-See a complete list of available Hardhat commands and their descriptions in [package.json](https://github.com/blocksense-network/blocksense/blob/main/libs/contracts/package.json).
+See a complete list of available Hardhat commands and their descriptions in [package.json](/coming-soon).
 
 ```bash copy
 yarn hardhat help

--- a/apps/docs.blocksense.network/pages/docs/contracts/guide/chainlink-proxy.mdx
+++ b/apps/docs.blocksense.network/pages/docs/contracts/guide/chainlink-proxy.mdx
@@ -36,7 +36,7 @@ For a complete list of functions and parameters for the ChainlinkProxy contract,
 
 ### Solidity
 
-To consume price data from the Chainlink Proxy, your smart contract should reference [`IAggregator`](https://github.com/blocksense-network/blocksense/blob/main/libs/contracts/contracts/interfaces/IAggregator.sol), which defines the external functions implemented by the Chainlink Proxy.
+To consume price data from the Chainlink Proxy, your smart contract should reference [`IAggregator`](/coming-soon), which defines the external functions implemented by the Chainlink Proxy.
 
 ```solidity showLineNumbers copy filename="ChainlinkProxyConsumer.sol"
 // SPDX-License-Identifier: MIT
@@ -77,7 +77,7 @@ contract ChainlinkProxyConsumer {
 
 <Callout type="info" emoji="💡">
   You can find a working Hardhat project
-  [here](https://github.com/blocksense-network/blocksense/tree/main/libs/contracts).
+  [here](/coming-soon).
   Clone the repo and follow the setup instructions to run the example locally.
 </Callout>
 

--- a/apps/docs.blocksense.network/pages/docs/contracts/guide/feed-registry.mdx
+++ b/apps/docs.blocksense.network/pages/docs/contracts/guide/feed-registry.mdx
@@ -54,7 +54,7 @@ latestRoundData(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 0xA0b86991c6218b36c1
 
 ### Solidity
 
-To consume price data from the Feed Registry, your smart contract should reference [`IFeedRegistry`](https://github.com/blocksense-network/blocksense/blob/main/libs/contracts/contracts/interfaces/IFeedRegistry.sol), which defines the external functions implemented by the Feed Registry.
+To consume price data from the Feed Registry, your smart contract should reference [`IFeedRegistry`](/coming-soon), which defines the external functions implemented by the Feed Registry.
 
 ```solidity showLineNumbers copy filename="RegistryConsumer.sol"
 // SPDX-License-Identifier: MIT
@@ -92,7 +92,7 @@ contract RegistryConsumer {
 
 <Callout type="info" emoji="💡">
   You can find a working Hardhat project
-  [here](https://github.com/blocksense-network/blocksense/tree/main/libs/contracts).
+  [here](/coming-soon).
   Clone the repo and follow the setup instructions to run the example locally.
 </Callout>
 

--- a/apps/docs.blocksense.network/pages/docs/contracts/guide/historic-data-feed.mdx
+++ b/apps/docs.blocksense.network/pages/docs/contracts/guide/historic-data-feed.mdx
@@ -11,7 +11,7 @@ Historic Data Feed Store contract is where all data is stored and where all cont
 
 <Callout type="info" emoji="💡">
   Use [ProxyCall
-  library](https://github.com/blocksense-network/blocksense/tree/main/libs/contracts/contracts/libraries/ProxyCall.sol)
+  library](/coming-soon)
   for easy and gas optimised interaction with the contract.
 </Callout>
 
@@ -172,7 +172,7 @@ In order to retrieve data from the contract, the client must call the `fallback`
 
 <Callout type="info">
   You can find a working Hardhat project
-  [here](https://github.com/blocksense-network/blocksense/tree/main/libs/contracts).
+  [here](/coming-soon).
   Clone the repo and follow the setup instructions to run the example locally.
 </Callout>
 

--- a/apps/docs.blocksense.network/pages/docs/contribution/guide.mdx
+++ b/apps/docs.blocksense.network/pages/docs/contribution/guide.mdx
@@ -2,7 +2,7 @@
 
 ## Guidelines for Contributors
 
-1. Fork the [GitHub](https://github.com/blocksense-network/blocksense) repository.
+1. Fork the [GitHub](/coming-soon) repository.
 2. Create a new branch for your feature or bugfix:
 
 ```bash copy

--- a/libs/docs-theme/src/components/navbar.tsx
+++ b/libs/docs-theme/src/components/navbar.tsx
@@ -166,11 +166,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
         })}
 
         {config.project.link ? (
-          <Anchor
-            className="nx-p-2 nx-text-current"
-            href={config.project.link}
-            newWindow
-          >
+          <Anchor className="nx-p-2 nx-text-current" href={'/coming-soon'}>
             {renderComponent(config.project.icon)}
           </Anchor>
         ) : null}

--- a/libs/docs-theme/src/constants.tsx
+++ b/libs/docs-theme/src/constants.tsx
@@ -203,7 +203,8 @@ export const DEFAULT_THEME: DocsThemeConfig = {
   docsRepositoryBase: 'https://github.com/shuding/nextra',
   editLink: {
     component: function EditLink({ className, filePath, children }) {
-      const editUrl = useGitEditUrl(filePath);
+      // const editUrl = useGitEditUrl(filePath); //use it after our repo is public on GitHub
+      const editUrl = '/coming-soon';
       if (!editUrl) {
         return null;
       }

--- a/libs/docs-theme/src/utils/get-git-issue-url.ts
+++ b/libs/docs-theme/src/utils/get-git-issue-url.ts
@@ -22,9 +22,11 @@ export const getGitIssueUrl = ({
     }`;
   }
   if (repo.resource.includes('github')) {
-    return `${repo.protocol}://${repo.resource}/${repo.owner}/${
-      repo.name
-    }/issues/new?title=${encodeURIComponent(title)}&labels=${labels || ''}`;
+    //use it after our repo is public on GitHub
+    // return `${repo.protocol}://${repo.resource}/${repo.owner}/${
+    //   repo.name
+    // }/issues/new?title=${encodeURIComponent(title)}&labels=${labels || ''}`;
+    return '/coming-soon';
   }
   return '#';
 };


### PR DESCRIPTION
This PR aims to add a custom `Coming Soon` page for users outside of `Blocksense GitHub Organization` as soon as `we're going public`.

**Before:**
![Screenshot from 2024-10-02 17-30-20](https://github.com/user-attachments/assets/a35e410b-d6f5-420a-a2e6-f979e792efc5)

**After:**
![Screenshot from 2024-10-03 12-44-22](https://github.com/user-attachments/assets/b26b0199-b64a-47aa-be64-f27fb3e77da5)
