### PR TITLE
feat(docs.ws): Modify the title for the home page and update description

### DIFF
--- a/apps/docs.blocksense.network/pages/index.mdx
+++ b/apps/docs.blocksense.network/pages/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Main
+title: Home
 ---
 import { Main } from '../components/Main/Main';
 

--- a/apps/docs.blocksense.network/theme.config.tsx
+++ b/apps/docs.blocksense.network/theme.config.tsx
@@ -21,14 +21,14 @@ export default {
   },
   useNextSeoProps() {
     return {
-      titleTemplate: 'Blocksense - %s',
+      titleTemplate: 'Blocksense | %s',
     };
   },
   head: (
     <>
       <meta
         name="description"
-        content="Blocksense is the ZK rollup for scaling oracle data to infinity. Everyone will be able to create secure oracles in minutes."
+        content="Blocksense is the ZK rollup for scaling oracle data to infinity. Soon everyone will be able to create secure oracles in minutes."
       />
       <link rel="icon" href="/images/blocksense-favicon.png" type="image/png" />
       {fonts.map(font => (


### PR DESCRIPTION
In reference to this [PR #502](https://github.com/blocksense-network/blocksense/pull/502).

We need to update the title on browser tabs for the Home page with something else, more meaningful.
In addition, the separator between the brand name and page title is changed, as presented below:

![image](https://github.com/user-attachments/assets/ab8919e0-1ecb-4640-90f7-5a93291d9977)

Also, we needed to update the meta description of all pages to match exactly the same on the public [Blocksense](https://blocksense.network/) website. We're doing that for simplicity and for easy modification.

When the marketing team is coming up with a new description with better keywords, we will replace it everywhere with the same content. Right now, let's keep it the same across all company related websites. 
