### PR TITLE
feat(sequencer/feeds): Dynamically registered feed_processors added to feeds_slots_manager

### DIFF
--- a/apps/sequencer/src/feeds/feed_workers.rs
+++ b/apps/sequencer/src/feeds/feed_workers.rs
@@ -12,6 +12,8 @@ use tokio::sync::mpsc;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
 
+use super::feeds_slots_manager::FeedsSlotsManagerCmds;
+
 type BatchedVotesChannel = (
     UnboundedSender<HashMap<String, String>>,
     UnboundedReceiver<HashMap<String, String>>,
@@ -25,12 +27,14 @@ pub async fn prepare_app_workers(
     sequencer_state: Data<SequencerState>,
     sequencer_config: &SequencerConfig,
     voting_receive_channel: UnboundedReceiver<(String, String)>,
+    feeds_slots_manager_cmd_recv: UnboundedReceiver<FeedsSlotsManagerCmds>,
 ) -> FuturesUnordered<JoinHandle<Result<(), Error>>> {
     let (batched_votes_send, batched_votes_recv): BatchedVotesChannel = mpsc::unbounded_channel();
 
     let feeds_slots_manager_loop_fut = feeds_slots_manager_loop(
         sequencer_state.clone(),
         sequencer_state.voting_send_channel.clone(),
+        feeds_slots_manager_cmd_recv,
     )
     .await;
 

--- a/apps/sequencer/src/sequencer_state.rs
+++ b/apps/sequencer/src/sequencer_state.rs
@@ -1,4 +1,5 @@
 use crate::feeds::feed_allocator::ConcurrentAllocator;
+use crate::feeds::feeds_slots_manager::FeedsSlotsManagerCmds;
 use crate::providers::provider::SharedRpcProviders;
 use crate::reporters::reporter::SharedReporters;
 use config::AllFeedsConfig;
@@ -21,5 +22,6 @@ pub struct SequencerState {
     pub feeds_config: Arc<RwLock<AllFeedsConfig>>,
     pub sequencer_config: Arc<RwLock<SequencerConfig>>,
     pub feed_aggregate_history: Arc<RwLock<FeedAggregateHistory>>,
+    pub feeds_slots_manager_cmd_send: mpsc::UnboundedSender<FeedsSlotsManagerCmds>,
     // pub voting_recv_channel: Arc<RwLock<mpsc::UnboundedReceiver<(String, String)>>>,
 }


### PR DESCRIPTION
This is a follow up PR of [PR-492](https://github.com/blocksense-network/blocksense/pull/492) with the necessary changes to register the feed_processor tasks of newly registered feeds into feeds_slots_manager.