### PR TITLE
feat(docs.ws): Add custom 404 and 500 pages for the docs and share the layout

### DIFF
--- a/apps/docs.blocksense.network/blocksense-theme/base.css
+++ b/apps/docs.blocksense.network/blocksense-theme/base.css
@@ -292,7 +292,9 @@ main {
   }
 }
 
-.announcement__icon {
+.announcement__icon,
+.error-404__icon,
+.error-500__icon {
   border-right: 1px solid black;
   padding-right: 23px;
   line-height: 48px;

--- a/apps/docs.blocksense.network/components/common/Announcement.tsx
+++ b/apps/docs.blocksense.network/components/common/Announcement.tsx
@@ -1,26 +1,12 @@
 import React from 'react';
+import { MessageLayout } from './MessageLayout';
 
 export const Announcement = () => {
   return (
-    <div className="announcement flex flex-row justify-center items-center h-full text-center text-black font-sans">
-      <div className="announcement__icon">
-        <svg
-          width="24"
-          height="24"
-          fill="currentColor"
-          viewBox="3 3 18 18"
-          className="inline-block"
-        >
-          <title>GitHub</title>
-          <path d="M12 3C7 3 3 7.13 3 12.23 3 16.31 5.58 19.76 9.15 20.98c.45.08.62-.19.62-.44 0-.22-.01-.94-.01-1.72-2.26.43-2.84-.81-3.02-1.33-.1-.27-.55-1.09-.99-1.31-.34-.18-.82-.64.05-.65.72-.01 1.23.66 1.4.94.82 1.39 2.12 1 2.63.76.08-.6.34-1 .61-1.24-2.2-.23-4.51-1.1-4.51-4.89 0-1.08.39-1.96 1.03-2.65-.1-.23-.45-1.16.1-2.41 0 0 .83-.26 2.73 1.03a9.27 9.27 0 0 1 4.96 0C16.14 6.16 16.97 6.42 16.97 6.42c.55 1.25.2 2.18.1 2.41.64.69 1.03 1.57 1.03 2.65 0 3.8-2.31 4.66-4.51 4.89.35.3.66.9.66 1.81 0 1.31-.01 2.36-.01 2.69 0 .25.17.53.63.44 3.58-1.22 6.15-4.67 6.15-8.75C21 7.13 16.97 3 12 3z" />
-        </svg>
-      </div>
-
-      <div className="announcement__text">
-        <h2 className="announcement__heading text-sm font-bold">
-          We're going public soon!
-        </h2>
-      </div>
-    </div>
+    <MessageLayout
+      className="announcement"
+      title="GitHub"
+      heading="We're going public soon!"
+    />
   );
 };

--- a/apps/docs.blocksense.network/components/common/Error404.tsx
+++ b/apps/docs.blocksense.network/components/common/Error404.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { MessageLayout } from './MessageLayout';
+
+export const Error404 = () => {
+  return (
+    <MessageLayout
+      className="error-404"
+      title="Error 404"
+      hasIcon={false}
+      alternativeContent="404"
+      heading="This page could not be found"
+    />
+  );
+};

--- a/apps/docs.blocksense.network/components/common/Error500.tsx
+++ b/apps/docs.blocksense.network/components/common/Error500.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { MessageLayout } from './MessageLayout';
+
+export const Error500 = () => {
+  return (
+    <MessageLayout
+      className="error-500"
+      title="Error 500"
+      hasIcon={false}
+      alternativeContent="500"
+      heading="Internal Server Error"
+    />
+  );
+};

--- a/apps/docs.blocksense.network/components/common/MessageLayout.tsx
+++ b/apps/docs.blocksense.network/components/common/MessageLayout.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+interface MessageLayoutProps {
+  className: string;
+  title: string;
+  heading: string;
+  hasIcon?: boolean;
+  alternativeContent?: string;
+}
+
+export const MessageLayout = ({
+  className,
+  title,
+  heading,
+  hasIcon = true,
+  alternativeContent,
+}: MessageLayoutProps) => {
+  return (
+    <div
+      className={`${className} flex flex-row justify-center items-center h-full text-center text-black font-sans`}
+    >
+      <div className={`${className}__icon`}>
+        {hasIcon ? (
+          <svg
+            width="24"
+            height="24"
+            fill="currentColor"
+            viewBox="3 3 18 18"
+            className="inline-block"
+          >
+            <title>{title}</title>
+            <path d="M12 3C7 3 3 7.13 3 12.23 3 16.31 5.58 19.76 9.15 20.98c.45.08.62-.19.62-.44 0-.22-.01-.94-.01-1.72-2.26.43-2.84-.81-3.02-1.33-.1-.27-.55-1.09-.99-1.31-.34-.18-.82-.64.05-.65.72-.01 1.23.66 1.4.94.82 1.39 2.12 1 2.63.76.08-.6.34-1 .61-1.24-2.2-.23-4.51-1.1-4.51-4.89 0-1.08.39-1.96 1.03-2.65-.1-.23-.45-1.16.1-2.41 0 0 .83-.26 2.73 1.03a9.27 9.27 0 0 1 4.96 0C16.14 6.16 16.97 6.42 16.97 6.42c.55 1.25.2 2.18.1 2.41.64.69 1.03 1.57 1.03 2.65 0 3.8-2.31 4.66-4.51 4.89.35.3.66.9.66 1.81 0 1.31-.01 2.36-.01 2.69 0 .25.17.53.63.44 3.58-1.22 6.15-4.67 6.15-8.75C21 7.13 16.97 3 12 3z" />
+          </svg>
+        ) : (
+          <span className="alternative-content text-xl font-semibold">
+            {alternativeContent}
+          </span>
+        )}
+      </div>
+
+      <div className={`${className}__text`}>
+        <h1 className={`${className}__heading text-sm font-bold`}>{heading}</h1>
+      </div>
+    </div>
+  );
+};

--- a/apps/docs.blocksense.network/pages/404.mdx
+++ b/apps/docs.blocksense.network/pages/404.mdx
@@ -1,0 +1,7 @@
+---
+title: "404 page"
+---
+
+import { Error404 } from '../components/common/Error404';
+
+<Error404/>

--- a/apps/docs.blocksense.network/pages/500.mdx
+++ b/apps/docs.blocksense.network/pages/500.mdx
@@ -1,0 +1,7 @@
+---
+title: "Error 500 Page"
+---
+
+import { Error500 } from '../components/common/Error500';
+
+<Error500/>

--- a/apps/docs.blocksense.network/pages/_meta.json
+++ b/apps/docs.blocksense.network/pages/_meta.json
@@ -15,5 +15,13 @@
     "type": "page",
     "href": "/coming-soon",
     "display": "hidden"
+  },
+  "404": {
+    "type": "page",
+    "display": "hidden"
+  },
+  "500": {
+    "type": "page",
+    "display": "hidden"
   }
 }


### PR DESCRIPTION
 Add custom 404 and 500 pages for the docs and share the layout with coming-soon page, so they will have common and more cohesive layout.
 
**Before:**

Error 404
![image](https://github.com/user-attachments/assets/a8ee1c5a-6c0a-4db3-8230-642100ee8531)

Error 500
![image](https://github.com/user-attachments/assets/78481b7a-593a-49f7-9444-3ca148c62943)


Coming-soon
![image](https://github.com/user-attachments/assets/403c893b-d783-4d1c-85d1-281fac307ccc)

 **After:**
 
 Error 404
![image](https://github.com/user-attachments/assets/ea5e272f-06a9-48c9-aa90-519868a63bfb)

Error 500
![image](https://github.com/user-attachments/assets/f2e507de-d3c4-46c5-a0b0-df6e8d941f93)

Coming-soon
![image](https://github.com/user-attachments/assets/7de16501-29ce-4245-995b-5a647c14c4dc)
