### PR TITLE
feat(docs.ws): Optimize Nextra layout positioning

### DIFF
--- a/apps/docs.blocksense.network/blocksense-theme/base.css
+++ b/apps/docs.blocksense.network/blocksense-theme/base.css
@@ -13,10 +13,6 @@
   outline: none;
 }
 
-main {
-  margin-top: 20px;
-}
-
 #__next {
   margin-top: calc(-1 * var(--nextra-navbar-height));
 }
@@ -299,4 +295,10 @@ main {
   padding-right: 23px;
   line-height: 48px;
   margin-right: 20px;
+}
+
+.announcement,
+.error-404,
+.error-500 {
+  margin-top: calc(1 * var(--nextra-navbar-height) / 2);
 }

--- a/libs/ts/docs-theme/src/components/breadcrumb.tsx
+++ b/libs/ts/docs-theme/src/components/breadcrumb.tsx
@@ -11,7 +11,7 @@ export function Breadcrumb({
   activePath: Item[];
 }): ReactElement {
   return (
-    <div className="nextra-breadcrumb nx-mt-12 nx-flex nx-items-center nx-gap-1 nx-overflow-hidden nx-text-sm">
+    <div className="nextra-breadcrumb nx-mt-18 nx-flex nx-items-center nx-gap-1 nx-overflow-hidden nx-text-sm">
       {activePath.map((item, index) => {
         const isLink = !item.children || item.withIndexPage;
         const isActive = index === activePath.length - 1;

--- a/libs/ts/docs-theme/src/index.tsx
+++ b/libs/ts/docs-theme/src/index.tsx
@@ -93,12 +93,12 @@ const Body = ({
     <article
       className={cn(
         classes.main,
-        'nextra-content nx-flex nx-min-h-[calc(100vh-var(--nextra-navbar-height))] nx-min-w-0 nx-justify-center nx-pb-8 nx-pr-[calc(env(safe-area-inset-right)-1.5rem)]',
+        'nextra-content nx-flex nx-min-h-[calc(100vh-var(--nextra-navbar-height))] nx-min-w-0 nx-justify-center nx-pr-[calc(env(safe-area-inset-right)-1.5rem)]',
         themeContext.typesetting === 'article' &&
           'nextra-body-typesetting-article',
       )}
     >
-      <main className="nx-w-full nx-min-w-0 nx-max-w-6xl nx-px-5 nx-pt-4 md:nx-px-12">
+      <main className="nx-w-full nx-min-w-0 nx-max-w-6xl nx-px-5 md:nx-px-12">
         {breadcrumb}
         {body}
       </main>

--- a/libs/ts/docs-theme/src/nx-utilities/nx-layout-and-positioning.css
+++ b/libs/ts/docs-theme/src/nx-utilities/nx-layout-and-positioning.css
@@ -189,6 +189,9 @@
 .nx-mt-16 {
   margin-top: 4rem;
 }
+.nx-mt-18 {
+  margin-top: 5rem;
+}
 .nx-mt-2 {
   margin-top: 0.5rem;
 }


### PR DESCRIPTION
For quite some time we observed strange behavior for Nextra layout positioning, which you may see presented below:
(the layout is using different colors to represent the problem):

![image](https://github.com/user-attachments/assets/56fb3e80-e494-411b-b713-aa0c14da678e)

We needed to apply different changes, so we will fix this layout positioning problem and to not break anything else on the layout, because modifications in these elements, could affect the entire website.
After these changes we may observe the same distances, as we want to all sides. 

Example below for top and bottom:
![image](https://github.com/user-attachments/assets/62bb4dc8-5367-478c-a526-e83a1caf562a)
![image](https://github.com/user-attachments/assets/4248c685-65c6-47d1-90bd-a16fbf9cce2a)


