### PR TITLE
[docs.ws]: Hide `reporter` and `sequencer` pages from docs.ws

### DIFF
--- a/apps/docs.blocksense.network/pages/docs/architecture/_meta.json
+++ b/apps/docs.blocksense.network/pages/docs/architecture/_meta.json
@@ -1,6 +1,12 @@
 {
   "index": "Overview",
-  "reporter": "Reporter",
-  "sequencer": "Sequencer",
+  "reporter":  {
+    "title":"Reporter",
+    "display": "hidden"
+  },
+  "sequencer": {
+    "title":"Sequencer",
+    "display": "hidden"
+  },
   "blockchain-integration": "Blockchain Integration"
 }


### PR DESCRIPTION
**Before:**
![Image 9 10 24 at 15 39](https://github.com/user-attachments/assets/080714c2-67f4-4fab-9ab6-f227f436af7f)

**After:**
![Image 9 10 24 at 15 39 (1)](https://github.com/user-attachments/assets/86d9778e-7d24-407a-9551-c79fbb117572)
