### PR TITLE
refactor(sdk/examples): Improve error reporting

### DIFF
--- a/libs/sdk/examples/cmc/src/lib.rs
+++ b/libs/sdk/examples/cmc/src/lib.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, Error};
 use blocksense_sdk::{
     oracle::{DataFeedResult, DataFeedResultValue, Payload, Settings},
     oracle_component,
@@ -101,7 +101,14 @@ async fn oracle_request(settings: Settings) -> Result<Payload> {
 
     let body = resp.into_body();
     let string = String::from_utf8(body)?;
-    let value: Root = serde_json::from_str(&string)?;
+    let value = match serde_json::from_str::<Root>(&string) {
+        Ok(value) => value,
+        Err(err) => return Result::Err(Error::msg(format!(
+        "Serde failed to parse response from CMC
+Raw response: [{string}].
+Error from serde: [{err}].
+"))),
+    };
     let mut payload: Payload = Payload::new();
 
     for (feed_id, data) in resources.iter() {


### PR DESCRIPTION
This could work for different response errors from our external dependencies.

We should maybe do the same for revolut, but I could not easily test.

In case of missing keys, now we get:

```
Serde failed to parse response from CMC
Raw response: [{
    "status": {
        "timestamp": "2024-10-09T16:55:21.863Z",
        "error_code": 1010,
        "error_message": "You've exceeded your API Key's monthly credit limit. Please contact us at api@coinmarketcap.
com if you need assistance upgrading your plan.",
        "elapsed": 0,
        "credit_count": 0,
        "notice": "You have used 100% of your plan's monthly credit limit."
    }
}].
Error from serde: [missing field `data` at line 10 column 1].
```

... for CMC.

We get this:

```
Serde failed to parse response from YahooFinance
Raw response: [{"message":"Limit Exceeded","hint":"Upgrade for bigger plan at https://financeapi.net/pricing"}].
Error from serde: [missing field `quoteResponse` at line 1 column 95].
```

... for YahooFinance.