### PR TITLE
[docs.ws]: Integrate url links in mermaid diagram in smart contracts overview page

### DIFF
--- a/apps/docs.blocksense.network/pages/docs/contracts/index.mdx
+++ b/apps/docs.blocksense.network/pages/docs/contracts/index.mdx
@@ -26,9 +26,8 @@ config:
 ---
 graph TD
     classDef clientNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
-    classDef feedNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
-    classDef proxyNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
-    classDef dataNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
+    classDef feedNode,proxyNode,dataNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
+    classDef feedNode:hover,proxyNode:hover,dataNode:hover fill:#fafafa,color:#0000EE,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace, text-decoration: underline, text-underline-offset: 4px;
 
     linkStyle default fill:none,stroke-width:1px,stroke:#1c1917
 

--- a/apps/docs.blocksense.network/pages/docs/contracts/integration-guide/using-data-feeds/chainlink-proxy.mdx
+++ b/apps/docs.blocksense.network/pages/docs/contracts/integration-guide/using-data-feeds/chainlink-proxy.mdx
@@ -22,7 +22,9 @@ config:
     signalTextColor: "#808080"
 ---
 flowchart TD
-  classDef node fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem,font-size: 0.875rem, font-family:'Fira Code', monospace;
+  classDef clientNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
+  classDef proxyNode,dataNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
+  classDef proxyNode:hover,dataNode:hover fill:#fafafa,color:#0000EE,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace, text-decoration: underline, text-underline-offset: 4px;
 
   linkStyle default fill:none,stroke-width:1px,stroke:#1c1917
 
@@ -32,7 +34,9 @@ flowchart TD
   click CP "/docs/contracts/reference-documentation/ChainlinkProxy" "Go to ChainlinkProxy"
   click DFS "/docs/contracts/reference-documentation/HistoricDataFeedStoreV2" "Go to HistoricDataFeedStoreV2"
 
-  class A,CP,DFS node
+  class A clientNode
+  class CP proxyNode
+  class DFS dataNode
 ```
 
 For a complete list of functions and parameters for the ChainlinkProxy contract, see the [Chainlink Proxy Reference Documentation](../../reference-documentation/ChainlinkProxy.mdx).

--- a/apps/docs.blocksense.network/pages/docs/contracts/integration-guide/using-data-feeds/feed-registry.mdx
+++ b/apps/docs.blocksense.network/pages/docs/contracts/integration-guide/using-data-feeds/feed-registry.mdx
@@ -23,7 +23,9 @@ config:
     signalTextColor: "#808080"
 ---
 flowchart TD
-  classDef node fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
+  classDef clientNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
+  classDef feedNode,dataNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
+  classDef feedNode:hover,dataNode:hover fill:#fafafa,color:#0000EE,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace, text-decoration: underline, text-underline-offset: 4px;
 
   linkStyle default fill:none,stroke-width:1px,stroke:#1c1917
 
@@ -33,7 +35,9 @@ flowchart TD
   click FR "/docs/contracts/reference-documentation/FeedRegistry" "Go to FeedRegistry"
   click DFS "/docs/contracts/reference-documentation/HistoricDataFeedStoreV2" "Go to HistoricDataFeedStoreV2"
 
-  class A,FR,DFS node
+  class A clientNode
+  class FR feedNode
+  class DFS dataNode
 ```
 
 <Callout type="info" emoji="💡">


### PR DESCRIPTION
Once we go public I’ll replace the links with the correct once:

``` mdx
    click B "https://github.com/blocksense-network/blocksense/blob/main/libs/ts/contracts/contracts/chainlink-proxies/registries/FeedRegistry.sol" "Go to FeedRegistry"
    click C "https://github.com/blocksense-network/blocksense/blob/main/libs/ts/contracts/contracts/UpgradeableProxy.sol" "Go to UpgradeableProxy"
    click D "https://github.com/blocksense-network/blocksense/blob/main/libs/ts/contracts/contracts/HistoricDataFeedStoreV2.sol" "Go to HistoricDataFeedStoreV2"
    click E "https://github.com/blocksense-network/blocksense/blob/main/libs/ts/contracts/contracts/chainlink-proxies/ChainlinkProxy.sol" "Go to ChainlinkProxy" 
```