### PR TITLE
feat(docs.ws): Update navbar background and classes for md and lg devices

### DIFF
--- a/libs/ts/docs-theme/src/components/navbar.tsx
+++ b/libs/ts/docs-theme/src/components/navbar.tsx
@@ -91,7 +91,7 @@ export function Navbar({ flatDirectories, items }: NavBarProps): ReactElement {
           'nx-pointer-events-none nx-absolute nx-z-[-1] nx-h-full nx-w-full',
         )}
       />
-      <nav className="nx-bg-white nx-mx-auto nx-flex nx-h-[var(--nextra-navbar-height)] nx-max-w-[90rem] nx-items-center nx-justify-end nx-gap-2 nx-pl-[max(env(safe-area-inset-left),1.5rem)] nx-pr-[max(env(safe-area-inset-right),1.5rem)] dark:nx-bg-black">
+      <nav className="nextra-nav nx-mx-auto nx-flex nx-h-[var(--nextra-navbar-height)] nx-max-w-[90rem] nx-items-center nx-justify-end nx-gap-2 nx-pl-[max(env(safe-area-inset-left),1.5rem)] nx-pr-[max(env(safe-area-inset-right),1.5rem)]">
         {config.logoLink ? (
           <Anchor
             href={typeof config.logoLink === 'string' ? config.logoLink : '/'}

--- a/libs/ts/docs-theme/src/nx-utilities/nx-customizations.css
+++ b/libs/ts/docs-theme/src/nx-utilities/nx-customizations.css
@@ -257,6 +257,16 @@ article details > summary:before {
   height: 1.2em;
 }
 
+.nextra-nav {
+  background-color: white;
+}
+
+@media (min-width: 768px) {
+  .nextra-nav {
+    background-color: transparent;
+  }
+}
+
 @media (min-width: 768px) {
   .nextra-toc > .div,
   .nextra-sidebar-container {


### PR DESCRIPTION
It should be transparent for bigger screens and white for smaller, because it's sticky and should be visible on scroll.
![image](https://github.com/user-attachments/assets/2e79ce99-9334-494f-aef8-d616e2f915b7)

