### PR TITLE
feat(docs.ws): Modify Nextra titles

### DIFF
--- a/apps/docs.blocksense.network/blocksense-theme/noto.css
+++ b/apps/docs.blocksense.network/blocksense-theme/noto.css
@@ -12,7 +12,7 @@ h3,
 h4,
 h5,
 h6 {
-  @apply font-noto-sans-bold;
+  @apply font-noto-sans-bold text-gray-900;
   line-height: normal;
 }
 

--- a/apps/docs.blocksense.network/components/sol-contracts/AnchorLinkTitle.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/AnchorLinkTitle.tsx
@@ -19,7 +19,7 @@ const titleStyles = {
 const accordionStyles = 'text-gray-900';
 
 const borderStyles =
-  'nx-border-b nx-border-neutral-200/70 contrast-more:nx-border-neutral-400 dark:nx-border-primary-100/10 contrast-more:dark:nx-border-neutral-400  py-4';
+  'nx-border-b nx-border-neutral-200/70 contrast-more:nx-border-neutral-400 dark:nx-border-primary-100/10 contrast-more:dark:nx-border-neutral-400  py-3';
 
 export const AnchorLinkTitle = ({
   title,

--- a/libs/ts/docs-theme/src/mdx-components.tsx
+++ b/libs/ts/docs-theme/src/mdx-components.tsx
@@ -55,7 +55,7 @@ function HeadingLink({
           ? 'nx-sr-only'
           : cn(
               {
-                h2: 'nx-mt-8 nx-border-b nx-pb-2 nx-text-3xl nx-border-neutral-200/70 contrast-more:nx-border-neutral-400 dark:nx-border-primary-100/10 contrast-more:dark:nx-border-neutral-400',
+                h2: 'nx-mt-6 nx-text-3xl',
                 h3: 'nx-mt-6 nx-text-2xl',
                 h4: 'nx-mt-6 nx-text-xl',
                 h5: 'nx-mt-6 nx-text-lg',


### PR DESCRIPTION
In most docs, there is no plenty of separators and different styles for titles, most of them are even without border. 
This PR makes them equal and preserve their custom behavior only for titles inside 'Reference documentation'.