### PR TITLE
fix(contracts/multichain-deploy): Add missing safeWebAuthn addresses

### DIFF
--- a/libs/ts/contracts/tasks/multichain-deploy.ts
+++ b/libs/ts/contracts/tasks/multichain-deploy.ts
@@ -260,6 +260,14 @@ const initChain = async (networkName: NetworkName): Promise<NetworkConfig> => {
       simulateTxAccessorAddress: parseEthereumAddress(
         '0x3d4BA2E0884aa488718476ca2FB8Efc291A46199',
       ),
+      safeWebAuthnSharedSignerAddress: parseEthereumAddress(
+        // https://github.com/safe-global/safe-modules-deployments/blob/v2.2.4/src/assets/safe-passkey-module/v0.2.1/safe-webauthn-shared-signer.json#L6gs
+        '0x94a4F6affBd8975951142c3999aEAB7ecee555c2',
+      ),
+      safeWebAuthnSignerFactoryAddress: parseEthereumAddress(
+        // https://github.com/safe-global/safe-modules-deployments/blob/v2.2.4/src/assets/safe-passkey-module/v0.2.1/safe-webauthn-signer-factory.json#L6
+        '0x1d31F259eE307358a26dFb23EB365939E8641195',
+      ),
     },
     threshold: 1,
   };

--- a/libs/ts/contracts/tasks/types.ts
+++ b/libs/ts/contracts/tasks/types.ts
@@ -16,6 +16,8 @@ export interface NetworkConfig {
     fallbackHandlerAddress: EthereumAddress;
     signMessageLibAddress: EthereumAddress;
     simulateTxAccessorAddress: EthereumAddress;
+    safeWebAuthnSharedSignerAddress: EthereumAddress;
+    safeWebAuthnSignerFactoryAddress: EthereumAddress;
   };
   threshold: number;
 }


### PR DESCRIPTION
## Description

The `ContractNetworkConfig` type from `@safe-global/protocol-kit` includes two
Safe WebAuthn addresses which were missing from our config:
https://github.com/safe-global/safe-core-sdk/blob/r45/packages/protocol-kit/src/types/contracts.ts#L123-L129

Set them to the values defined in the safe-modules-deployments repo:
https://github.com/safe-global/safe-modules-deployments/tree/main/src/assets/safe-passkey-module/v0.2.1

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (refactoring already existing functionality)

## Changes

Add missing contract addresses from Safe Protocol's `ContractNetworkConfig`.

## How to test

```
yarn build @blocksense/contracts
```

## Checklist

- [x] The new changes/fixes are tested
- [ ] Documentation is updated
- [x] I have performed a self-review of my own code
- [ ] All newly added code is well commented
