### PR TITLE
[sol-reflector]: Functions returns in the signature

### DIFF
--- a/libs/ts/sol-reflector/src/utils/signature.ts
+++ b/libs/ts/sol-reflector/src/utils/signature.ts
@@ -41,10 +41,7 @@ export function getSignature(node: ASTNode): Signature | undefined {
         );
       }
 
-      overviewCodeSnippet = res
-        .filter(el => !el.includes('returns'))
-        .join(' ')
-        .concat(';');
+      overviewCodeSnippet = res.join(' ').concat(';');
       codeSnippet = res.join(' ').concat(';');
 
       return {


### PR DESCRIPTION
In the contract overview -> function signature is missing the `returns(...)`

Before:
![image](https://github.com/user-attachments/assets/7b6f3689-4d45-4ddb-82cb-f37882b72651)

After:
![image](https://github.com/user-attachments/assets/9c9eaec1-498e-48c1-a3c9-0a480c21fc6b)
![image](https://github.com/user-attachments/assets/e6507488-64ec-4730-9ea1-7c0f983b39bb)