### PR TITLE
feat(docs.ws): Add GA4 script to docs.ws

### DIFF
--- a/apps/docs.blocksense.network/theme.config.tsx
+++ b/apps/docs.blocksense.network/theme.config.tsx
@@ -54,6 +54,16 @@ export default {
           crossOrigin="anonymous"
         />
       ))}
+      <script
+        async
+        src="https://www.googletagmanager.com/gtag/js?id=G-7S6ERW2H50"
+      ></script>
+      <script>
+        {`window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', 'G-7S6ERW2H50');`}
+      </script>
     </>
   ),
 };


### PR DESCRIPTION
We have setup a GA property and the scope of our work is to add the G-tag script to the theme.config, so the owner of the GA property will test the connection on the website. 