### PR TITLE
[docs.ws]: Add tooltips for Data feeds in tables

### DIFF
--- a/apps/docs.blocksense.network/components/DataFeeds/columns.tsx
+++ b/apps/docs.blocksense.network/components/DataFeeds/columns.tsx
@@ -4,6 +4,7 @@ import { ColumnDef } from '@tanstack/react-table';
 
 import { DataTableColumnHeader } from '@/components/ui/DataTable/DataTableColumnHeader';
 import { DataTableBadge } from '@/components/ui/DataTable/DataTableBadge';
+import { Tooltip } from '@/components/common/Tooltip';
 
 type DataFeed = {
   id: number;
@@ -41,7 +42,10 @@ export const columns: ColumnDef<DataFeed>[] = [
       />
     ),
     cell: ({ row }) => (
-      <DataTableBadge>{row.getValue('description')}</DataTableBadge>
+      <Tooltip position="right">
+        <Tooltip.Content>Data Feed Info</Tooltip.Content>
+        <DataTableBadge>{row.getValue('description')}</DataTableBadge>{' '}
+      </Tooltip>
     ),
   },
   {

--- a/apps/docs.blocksense.network/components/DeployedContracts/proxyContractsColumns.tsx
+++ b/apps/docs.blocksense.network/components/DeployedContracts/proxyContractsColumns.tsx
@@ -7,10 +7,11 @@ import { DataTableColumnHeader } from '@/components/ui/DataTable/DataTableColumn
 import { ContractAddress } from '@/components/sol-contracts/ContractAddress';
 import { DataTableBadge } from '@/components/ui/DataTable/DataTableBadge';
 import { NetworkAddressExplorerLink } from '@/components/DeployedContracts/NetworkAddressExplorerLink';
+import { Tooltip } from '@/components/common/Tooltip';
 
 export const proxyColumnsTitles: { [key: string]: string } = {
   description: 'Data Feed Name',
-  id: 'ID',
+  id: 'Id',
   address: 'Blocksense Proxy Address',
   base: 'Base Address',
   quote: 'Quote Address',
@@ -20,18 +21,6 @@ export const proxyColumnsTitles: { [key: string]: string } = {
 
 export const columns: ColumnDef<ProxyContractData>[] = [
   {
-    accessorKey: 'description',
-    header: ({ column }) => (
-      <DataTableColumnHeader
-        column={column}
-        title={proxyColumnsTitles[column.id]}
-      />
-    ),
-    cell: ({ row }) => (
-      <DataTableBadge>{row.getValue('description')}</DataTableBadge>
-    ),
-  },
-  {
     accessorKey: 'id',
     header: ({ column }) => (
       <DataTableColumnHeader
@@ -40,6 +29,21 @@ export const columns: ColumnDef<ProxyContractData>[] = [
       />
     ),
     cell: ({ row }) => <DataTableBadge>{row.getValue('id')}</DataTableBadge>,
+  },
+  {
+    accessorKey: 'description',
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        column={column}
+        title={proxyColumnsTitles[column.id]}
+      />
+    ),
+    cell: ({ row }) => (
+      <Tooltip position="right">
+        <Tooltip.Content>Data Feed Info</Tooltip.Content>
+        <DataTableBadge>{row.getValue('description')}</DataTableBadge>
+      </Tooltip>
+    ),
   },
   {
     accessorKey: 'network',


### PR DESCRIPTION
Also renamed column title `ID` to `Id` in Deployed Contracts and switched the positions of the columns `Id` and `Data Feed Name`