### PR TITLE
feat(sequencer): Set gas limit to 20M

### DIFF
--- a/apps/sequencer/src/http_handlers/admin.rs
+++ b/apps/sequencer/src/http_handlers/admin.rs
@@ -60,7 +60,7 @@ async fn get_key_from_contract(
     let tx = TransactionRequest::default()
         .to(*addr)
         .from(wallet.address())
-        .with_gas_limit(2e5 as u128)
+        .with_gas_limit(2e7 as u128)
         .with_max_fee_per_gas(base_fee + base_fee)
         .with_max_priority_fee_per_gas(1e9 as u128)
         .with_chain_id(provider.get_chain_id().await?)

--- a/apps/sequencer/src/providers/eth_send_utils.rs
+++ b/apps/sequencer/src/providers/eth_send_utils.rs
@@ -80,7 +80,7 @@ pub async fn deploy_contract(
 
     let tx = TransactionRequest::default()
         .from(wallet.address())
-        .with_gas_limit(2e5 as u128)
+        .with_gas_limit(2e7 as u128)
         .with_max_fee_per_gas(base_fee + base_fee)
         .with_max_priority_fee_per_gas(max_priority_fee_per_gas)
         .with_chain_id(chain_id)
@@ -188,7 +188,7 @@ pub async fn eth_batch_send_to_contract<
     let tx = TransactionRequest::default()
         .to(contract_address)
         .from(wallet.address())
-        .with_gas_limit(2e5 as u128)
+        .with_gas_limit(2e7 as u128)
         .with_max_fee_per_gas(base_fee + base_fee)
         .with_max_priority_fee_per_gas(max_priority_fee_per_gas)
         .with_chain_id(chain_id)


### PR DESCRIPTION
This is so that our batch of 250 feeds fits in a single transaction (we estimated 12.5M).