### PR TITLE
chore(flake.lock): Update all Flake inputs (2024-11-03)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1729741221,
-        "narHash": "sha256-8AHZZXs1lFkERfBY0C8cZGElSo33D/et7NKEpLRmvzo=",
+        "lastModified": 1730504891,
+        "narHash": "sha256-Fvieht4pai+Wey7terllZAKOj0YsaDP0e88NYs3K/Lo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "f235b656ee5b2bfd6d94c3bfd67896a575d4a6ed",
+        "rev": "8658adcdad49b8f2c6cbf0cc3cb4b4db988f7638",
         "type": "github"
       },
       "original": {
@@ -146,11 +146,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729929784,
-        "narHash": "sha256-xQNXJ/lRD41r6T+KokIk7Z61MHMNFhZGGMo9iOpLHqY=",
+        "lastModified": 1730551965,
+        "narHash": "sha256-pZjOiaIW3AZinSmTCubFgoxRQzqmHFiOkHBJYZ1RdnA=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "fa53082e82e90bd378cf850ca3d2b6892eebc77e",
+        "rev": "d3bb56ceaeef625712b050bd9343dbdb01bf37b1",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729942962,
-        "narHash": "sha256-xzt7tb4YUw6VZXSCGw4sukirJSfYsIcFyvmhK5KMiKw=",
+        "lastModified": 1730190761,
+        "narHash": "sha256-o5m5WzvY6cGIDupuOvjgNSS8AN6yP2iI9MtUC6q/uos=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "58cd832497f9c87cb4889744b86aba4284fd0474",
+        "rev": "3979285062d6781525cded0f6c4ff92e71376b55",
         "type": "github"
       },
       "original": {
@@ -326,11 +326,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1729924178,
-        "narHash": "sha256-ZhDqOYZwx0kYg1vPrmZ2fJm/wem739eNSSK+GlzdeqA=",
+        "lastModified": 1730529264,
+        "narHash": "sha256-5gC0y6cKXKQvumK4jOhKyjVsYqQ7EOcWKNtKB8UiP74=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "e831b4d256526cc56bd37c7c579842866410bebc",
+        "rev": "fff718e230e40b8202d7be6223c13492bb0010a8",
         "type": "github"
       },
       "original": {
@@ -388,11 +388,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727826117,
-        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -580,11 +580,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729104314,
-        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
+        "lastModified": 1730302582,
+        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
+        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
         "type": "github"
       },
       "original": {
@@ -630,11 +630,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724947644,
-        "narHash": "sha256-MHHrHasTngp7EYQOObHJ1a/IsRF+wodHqOckhH6uZbk=",
+        "lastModified": 1730229744,
+        "narHash": "sha256-2W//PmgocN9lplDJ7WoiP9EcrfUxqvtxplCAqlwvquY=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "dba4367b9a9d9615456c430a6d6af716f6e84cef",
+        "rev": "d70658494391994c7b32e8fe5610dae76737e4df",
         "type": "github"
       },
       "original": {
@@ -786,11 +786,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730333459,
-        "narHash": "sha256-mOzvp2Uy7KAkReZLvL5japMXbBSMoDAUEXn+UU9RwSA=",
+        "lastModified": 1730613029,
+        "narHash": "sha256-LVYNwhtLfiSuv7htPTeK+VkJUwNi7qQf0VgUMXlx4Dw=",
         "owner": "metacraft-labs",
         "repo": "nix-blockchain-development",
-        "rev": "c7a5f4fdcc9a69a2152ce696dac899b79991dae0",
+        "rev": "575c83c326ac2f8d9285fdfab799eaf9edddaccc",
         "type": "github"
       },
       "original": {
@@ -814,11 +814,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1729979773,
-        "narHash": "sha256-FWW4FuCaXl5mCNv3DJmOuabXkQTsQZcww8C875HQ7s0=",
+        "lastModified": 1730499294,
+        "narHash": "sha256-RxV89z3TwhQT0Wue42aSPh3O7hXGbAFYHHNSnW9h6P8=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "7f30633d2739705dd0d6dabd95a92cdab6e19017",
+        "rev": "93122446d6001f9789d05e565f73bebfa3f53b50",
         "type": "github"
       },
       "original": {
@@ -881,11 +881,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729982130,
-        "narHash": "sha256-HmLLQbX07rYD0RXPxbf3kJtUo66XvEIX9Y+N5QHQ9aY=",
+        "lastModified": 1730589595,
+        "narHash": "sha256-QI//TRTTmkUM0bz+KhdanRcwzlYib6PjMTvhC3dwUWA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "2eb472230a5400c81d9008014888b4bff23bcf44",
+        "rev": "146629a54364f6b54e7f3d15c44fea69ed0bf476",
         "type": "github"
       },
       "original": {
@@ -908,11 +908,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729339656,
-        "narHash": "sha256-smV7HQ/OqZeRguQxNjsb3uQDwm0p6zKDbSDbPCav/oY=",
+        "lastModified": 1730479402,
+        "narHash": "sha256-79NLeNjpCa4mSasmFsE3QA6obURezF0TUO5Pm+1daog=",
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "cc96df7c3747c61c584d757cfc083922b4f4b33e",
+        "rev": "5fb215a1564baa74ce04ad7f903d94ad6617e17a",
         "type": "github"
       },
       "original": {
@@ -933,11 +933,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1729400108,
-        "narHash": "sha256-aKCdN1LjqHMIyVX44ETMkWCH1olh1Rd+AaKLFUDHMuA=",
+        "lastModified": 1730169047,
+        "narHash": "sha256-CmvRSsW97XVrc0WrE2v/acRsfdRhFiFKRwg7PmfYKPc=",
         "owner": "nix-community",
         "repo": "nixd",
-        "rev": "d3c7e560bb8034926628099a04deb26afd575e1f",
+        "rev": "20290ee46699f7c62528d8f44bab1aeac7c8fcf1",
         "type": "github"
       },
       "original": {
@@ -964,11 +964,11 @@
     },
     "nixos-2405": {
       "locked": {
-        "lastModified": 1729691686,
-        "narHash": "sha256-BAuPWW+9fa1moZTU+jFh+1cUtmsuF8asgzFwejM4wac=",
+        "lastModified": 1730327045,
+        "narHash": "sha256-xKel5kd1AbExymxoIfQ7pgcX6hjw9jCgbiBjiUfSVJ8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "32e940c7c420600ef0d1ef396dc63b04ee9cad37",
+        "rev": "080166c15633801df010977d9d7474b4a6c549d7",
         "type": "github"
       },
       "original": {
@@ -1086,11 +1086,11 @@
         "vscode-server": "vscode-server"
       },
       "locked": {
-        "lastModified": 1730332866,
-        "narHash": "sha256-c9MBTU3BS2DQoUNzRZH0kQRJ6hPmjTimN4jwXZJ31QY=",
+        "lastModified": 1730611250,
+        "narHash": "sha256-KWmPixi40ODtp8RoXdVS7Rbf8SHzu+MKAEsgVQslQsk=",
         "owner": "metacraft-labs",
         "repo": "nixos-modules",
-        "rev": "e4bd3f5ba05a5f0faf7420568f1039a1b9b2fec5",
+        "rev": "97a76f692d09fd898944127780fb5681c1afe25a",
         "type": "github"
       },
       "original": {
@@ -1193,11 +1193,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1729665710,
-        "narHash": "sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4=",
+        "lastModified": 1730200266,
+        "narHash": "sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
         "type": "github"
       },
       "original": {
@@ -1325,11 +1325,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1729845655,
-        "narHash": "sha256-6I3gJLnOLnUIWFUlEnvC0FdzX8Xwu+y3Vo0q4VB6Wbk=",
+        "lastModified": 1730463978,
+        "narHash": "sha256-9X/n9cC50NGVQVcfhOZPd26XGPR7GRxZhCo6z0Fclbo=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "f4466718b838de706d74e2c13f20a41c034d87a5",
+        "rev": "d1fbfc676bf91f44de6a19c86435ac4dbd390549",
         "type": "github"
       },
       "original": {
@@ -1347,11 +1347,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730255392,
-        "narHash": "sha256-9pydem8OVxa0TwjUai1PJe0yHAJw556CWCEwyoAq8Ik=",
+        "lastModified": 1730601085,
+        "narHash": "sha256-Sgax33jGuvVHTjl1P78IwzlhAGyOxtx5Q26inKja8S4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7509d76ce2b3d22b40bd25368b45c0a9f7f36c89",
+        "rev": "8d1b40f8dfd7539aaa3de56e207e22b3cc451825",
         "type": "github"
       },
       "original": {
@@ -1363,11 +1363,11 @@
     "spectrum": {
       "flake": false,
       "locked": {
-        "lastModified": 1720264467,
-        "narHash": "sha256-xzM92n3Q9L90faJIJrkrTtTx+JqCGRHMkHWztkV4PuY=",
+        "lastModified": 1729945407,
+        "narHash": "sha256-iGNMamNOAnVTETnIVqDWd6fl74J8fLEi1ejdZiNjEtY=",
         "ref": "refs/heads/main",
-        "rev": "fb59d42542049f586c84b0f8bb86ff3be338e9d3",
-        "revCount": 674,
+        "rev": "f1d94ee7029af18637dbd5fdf4749621533693fa",
+        "revCount": 764,
         "type": "git",
         "url": "https://spectrum-os.org/git/spectrum"
       },
@@ -1480,11 +1480,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729613947,
-        "narHash": "sha256-XGOvuIPW1XRfPgHtGYXd5MAmJzZtOuwlfKDgxX5KT3s=",
+        "lastModified": 1730321837,
+        "narHash": "sha256-vK+a09qq19QNu2MlLcvN4qcRctJbqWkX7ahgPZ/+maI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "aac86347fb5063960eccb19493e0cadcdb4205ca",
+        "rev": "746901bb8dba96d154b66492a29f5db0693dbfcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

Update all flake inputs. Details:

```
• Updated input 'mcl-blockchain':
    'github:metacraft-labs/nix-blockchain-development/c7a5f4fdcc9a69a2152ce696dac899b79991dae0?narHash=sha256-mOzvp2Uy7KAkReZLvL5japMXbBSMoDAUEXn%2BUU9RwSA%3D' (2024-10-31)
  → 'github:metacraft-labs/nix-blockchain-development/575c83c326ac2f8d9285fdfab799eaf9edddaccc?narHash=sha256-LVYNwhtLfiSuv7htPTeK%2BVkJUwNi7qQf0VgUMXlx4Dw%3D' (2024-11-03)
• Updated input 'mcl-blockchain/nixos-modules':
    'github:metacraft-labs/nixos-modules/e4bd3f5ba05a5f0faf7420568f1039a1b9b2fec5?narHash=sha256-c9MBTU3BS2DQoUNzRZH0kQRJ6hPmjTimN4jwXZJ31QY%3D' (2024-10-31)
  → 'github:metacraft-labs/nixos-modules/97a76f692d09fd898944127780fb5681c1afe25a?narHash=sha256-KWmPixi40ODtp8RoXdVS7Rbf8SHzu%2BMKAEsgVQslQsk%3D' (2024-11-03)
• Updated input 'mcl-blockchain/nixos-modules/crane':
    'github:ipetkov/crane/f235b656ee5b2bfd6d94c3bfd67896a575d4a6ed?narHash=sha256-8AHZZXs1lFkERfBY0C8cZGElSo33D/et7NKEpLRmvzo%3D' (2024-10-24)
  → 'github:ipetkov/crane/8658adcdad49b8f2c6cbf0cc3cb4b4db988f7638?narHash=sha256-Fvieht4pai%2BWey7terllZAKOj0YsaDP0e88NYs3K/Lo%3D' (2024-11-01)
• Updated input 'mcl-blockchain/nixos-modules/devenv':
    'github:cachix/devenv/fa53082e82e90bd378cf850ca3d2b6892eebc77e?narHash=sha256-xQNXJ/lRD41r6T%2BKokIk7Z61MHMNFhZGGMo9iOpLHqY%3D' (2024-10-26)
  → 'github:cachix/devenv/d3bb56ceaeef625712b050bd9343dbdb01bf37b1?narHash=sha256-pZjOiaIW3AZinSmTCubFgoxRQzqmHFiOkHBJYZ1RdnA%3D' (2024-11-02)
• Updated input 'mcl-blockchain/nixos-modules/disko':
    'github:nix-community/disko/58cd832497f9c87cb4889744b86aba4284fd0474?narHash=sha256-xzt7tb4YUw6VZXSCGw4sukirJSfYsIcFyvmhK5KMiKw%3D' (2024-10-26)
  → 'github:nix-community/disko/3979285062d6781525cded0f6c4ff92e71376b55?narHash=sha256-o5m5WzvY6cGIDupuOvjgNSS8AN6yP2iI9MtUC6q/uos%3D' (2024-10-29)
• Updated input 'mcl-blockchain/nixos-modules/fenix':
    'github:nix-community/fenix/e831b4d256526cc56bd37c7c579842866410bebc?narHash=sha256-ZhDqOYZwx0kYg1vPrmZ2fJm/wem739eNSSK%2BGlzdeqA%3D' (2024-10-26)
  → 'github:nix-community/fenix/fff718e230e40b8202d7be6223c13492bb0010a8?narHash=sha256-5gC0y6cKXKQvumK4jOhKyjVsYqQ7EOcWKNtKB8UiP74%3D' (2024-11-02)
• Updated input 'mcl-blockchain/nixos-modules/fenix/rust-analyzer-src':
    'github:rust-lang/rust-analyzer/f4466718b838de706d74e2c13f20a41c034d87a5?narHash=sha256-6I3gJLnOLnUIWFUlEnvC0FdzX8Xwu%2By3Vo0q4VB6Wbk%3D' (2024-10-25)
  → 'github:rust-lang/rust-analyzer/d1fbfc676bf91f44de6a19c86435ac4dbd390549?narHash=sha256-9X/n9cC50NGVQVcfhOZPd26XGPR7GRxZhCo6z0Fclbo%3D' (2024-11-01)
• Updated input 'mcl-blockchain/nixos-modules/flake-parts':
    'github:hercules-ci/flake-parts/3d04084d54bedc3d6b8b736c70ef449225c361b1?narHash=sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0%3D' (2024-10-01)
  → 'github:hercules-ci/flake-parts/506278e768c2a08bec68eb62932193e341f55c90?narHash=sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS%2Bb4tfNFCwE%3D' (2024-11-01)
• Updated input 'mcl-blockchain/nixos-modules/git-hooks-nix':
    'github:cachix/git-hooks.nix/3c3e88f0f544d6bb54329832616af7eb971b6be6?narHash=sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ%2B/nVtALHIciX/BI%3D' (2024-10-16)
  → 'github:cachix/git-hooks.nix/af8a16fe5c264f5e9e18bcee2859b40a656876cf?narHash=sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU%3D' (2024-10-30)
• Updated input 'mcl-blockchain/nixos-modules/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/dba4367b9a9d9615456c430a6d6af716f6e84cef?narHash=sha256-MHHrHasTngp7EYQOObHJ1a/IsRF%2BwodHqOckhH6uZbk%3D' (2024-08-29)
  → 'github:hercules-ci/hercules-ci-effects/d70658494391994c7b32e8fe5610dae76737e4df?narHash=sha256-2W//PmgocN9lplDJ7WoiP9EcrfUxqvtxplCAqlwvquY%3D' (2024-10-29)
• Updated input 'mcl-blockchain/nixos-modules/microvm':
    'github:astro/microvm.nix/7f30633d2739705dd0d6dabd95a92cdab6e19017?narHash=sha256-FWW4FuCaXl5mCNv3DJmOuabXkQTsQZcww8C875HQ7s0%3D' (2024-10-26)
  → 'github:astro/microvm.nix/93122446d6001f9789d05e565f73bebfa3f53b50?narHash=sha256-RxV89z3TwhQT0Wue42aSPh3O7hXGbAFYHHNSnW9h6P8%3D' (2024-11-01)
• Updated input 'mcl-blockchain/nixos-modules/microvm/spectrum':
    'git+https://spectrum-os.org/git/spectrum?ref=refs/heads/main&rev=fb59d42542049f586c84b0f8bb86ff3be338e9d3' (2024-07-06)
  → 'git+https://spectrum-os.org/git/spectrum?ref=refs/heads/main&rev=f1d94ee7029af18637dbd5fdf4749621533693fa' (2024-10-26)
• Updated input 'mcl-blockchain/nixos-modules/nix-darwin':
    'github:LnL7/nix-darwin/2eb472230a5400c81d9008014888b4bff23bcf44?narHash=sha256-HmLLQbX07rYD0RXPxbf3kJtUo66XvEIX9Y%2BN5QHQ9aY%3D' (2024-10-26)
  → 'github:LnL7/nix-darwin/146629a54364f6b54e7f3d15c44fea69ed0bf476?narHash=sha256-QI//TRTTmkUM0bz%2BKhdanRcwzlYib6PjMTvhC3dwUWA%3D' (2024-11-02)
• Updated input 'mcl-blockchain/nixos-modules/nix2container':
    'github:nlewo/nix2container/cc96df7c3747c61c584d757cfc083922b4f4b33e?narHash=sha256-smV7HQ/OqZeRguQxNjsb3uQDwm0p6zKDbSDbPCav/oY%3D' (2024-10-19)
  → 'github:nlewo/nix2container/5fb215a1564baa74ce04ad7f903d94ad6617e17a?narHash=sha256-79NLeNjpCa4mSasmFsE3QA6obURezF0TUO5Pm%2B1daog%3D' (2024-11-01)
• Updated input 'mcl-blockchain/nixos-modules/nixd':
    'github:nix-community/nixd/d3c7e560bb8034926628099a04deb26afd575e1f?narHash=sha256-aKCdN1LjqHMIyVX44ETMkWCH1olh1Rd%2BAaKLFUDHMuA%3D' (2024-10-20)
  → 'github:nix-community/nixd/20290ee46699f7c62528d8f44bab1aeac7c8fcf1?narHash=sha256-CmvRSsW97XVrc0WrE2v/acRsfdRhFiFKRwg7PmfYKPc%3D' (2024-10-29)
• Updated input 'mcl-blockchain/nixos-modules/nixos-2405':
    'github:NixOS/nixpkgs/32e940c7c420600ef0d1ef396dc63b04ee9cad37?narHash=sha256-BAuPWW%2B9fa1moZTU%2BjFh%2B1cUtmsuF8asgzFwejM4wac%3D' (2024-10-23)
  → 'github:NixOS/nixpkgs/080166c15633801df010977d9d7474b4a6c549d7?narHash=sha256-xKel5kd1AbExymxoIfQ7pgcX6hjw9jCgbiBjiUfSVJ8%3D' (2024-10-30)
• Updated input 'mcl-blockchain/nixos-modules/nixpkgs-unstable':
    'github:NixOS/nixpkgs/2768c7d042a37de65bb1b5b3268fc987e534c49d?narHash=sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4%3D' (2024-10-23)
  → 'github:NixOS/nixpkgs/807e9154dcb16384b1b765ebe9cd2bba2ac287fd?narHash=sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU%3D' (2024-10-29)
• Updated input 'mcl-blockchain/nixos-modules/treefmt-nix':
    'github:numtide/treefmt-nix/aac86347fb5063960eccb19493e0cadcdb4205ca?narHash=sha256-XGOvuIPW1XRfPgHtGYXd5MAmJzZtOuwlfKDgxX5KT3s%3D' (2024-10-22)
  → 'github:numtide/treefmt-nix/746901bb8dba96d154b66492a29f5db0693dbfcc?narHash=sha256-vK%2Ba09qq19QNu2MlLcvN4qcRctJbqWkX7ahgPZ/%2BmaI%3D' (2024-10-30)
• Updated input 'mcl-blockchain/rust-overlay':
    'github:oxalica/rust-overlay/7509d76ce2b3d22b40bd25368b45c0a9f7f36c89?narHash=sha256-9pydem8OVxa0TwjUai1PJe0yHAJw556CWCEwyoAq8Ik%3D' (2024-10-30)
  → 'github:oxalica/rust-overlay/8d1b40f8dfd7539aaa3de56e207e22b3cc451825?narHash=sha256-Sgax33jGuvVHTjl1P78IwzlhAGyOxtx5Q26inKja8S4%3D' (2024-11-03)
```
