### PR TITLE
feat(sequencer): Make result easier to search

### DIFF
--- a/apps/sequencer/src/providers/eth_send_utils.rs
+++ b/apps/sequencer/src/providers/eth_send_utils.rs
@@ -278,12 +278,12 @@ pub async fn eth_batch_send_to_all_contracts<
             Ok(res) => match res {
                 (Ok(x), net, _provider) => match x {
                     Ok(y) => {
-                        all_results += &format!("success from network {} -> {:?}", net, y);
+                        all_results += &format!("result from network {}: Ok -> {:?}", net, y);
                     }
                     Err(error_message) => {
-                        warn!("Network responded with error: {error_message}");
+                        warn!("Network {net} responded with error: {error_message}");
                         all_results +=
-                            &format!("error from network {} -> {:?}", net, error_message);
+                            &format!("result from network {}: Err -> {:?}", net, error_message);
                     }
                 },
                 (Err(e), net, provider) => {


### PR DESCRIPTION
Related to #604. This should have been the solution from the beginning, but I was eager to see whether I can push a new deployment. Addressing the wishlist from the previous PR:

1. "success from network" and "error from network" should be combined again, for easier search -> "result from network: {ok, error}".
2. "Network responded with error" should contain the network name -> "Network {network} responded with error".