### PR TITLE
feat(sequencer): Remove unnecessary clones

### DIFF
--- a/apps/sequencer/bin/sequencer_runner.rs
+++ b/apps/sequencer/bin/sequencer_runner.rs
@@ -69,7 +69,7 @@ pub async fn prepare_sequencer_state(
             &feeds_config,
         ))),
         reports: Arc::new(RwLock::new(AllFeedsReports::new())),
-        providers: providers.clone(),
+        providers,
         log_handle,
         reporters: init_shared_reporters(sequencer_config, metrics_prefix),
         feed_id_allocator: Arc::new(RwLock::new(Some(feed_id_allocator))),

--- a/apps/sequencer/src/feeds/feeds_slots_manager.rs
+++ b/apps/sequencer/src/feeds/feeds_slots_manager.rs
@@ -326,7 +326,7 @@ mod tests {
                 &feeds_config,
             ))),
             reports: all_feeds_reports_arc,
-            providers: providers.clone(),
+            providers,
             log_handle,
             reporters: init_shared_reporters(&sequencer_config, metrics_prefix),
             feed_id_allocator: Arc::new(RwLock::new(None)),

--- a/apps/sequencer/src/providers/eth_send_utils.rs
+++ b/apps/sequencer/src/providers/eth_send_utils.rs
@@ -251,21 +251,19 @@ pub async fn eth_batch_send_to_all_contracts<
 
     let collected_futures = FuturesUnordered::new();
 
-    for (net, p) in
-        <HashMap<std::string::String, Arc<tokio::sync::Mutex<RpcProvider>>> as Clone>::clone(
-            &providers,
-        )
-        .into_iter()
-    {
+    for (net, p) in providers.iter() {
         let updates = updates.clone();
         let timeout = p.lock().await.transcation_timeout_secs as u64;
+
+        let net = net.clone();
+        let provider = p.clone();
         collected_futures.push(spawn(async move {
             let result = actix_web::rt::time::timeout(
                 Duration::from_secs(timeout),
-                eth_batch_send_to_contract(net.clone(), p.clone(), updates, feed_type),
+                eth_batch_send_to_contract(net.clone(), provider.clone(), updates, feed_type),
             )
             .await;
-            (result, net.clone(), p.clone())
+            (result, net, provider)
         }));
     }
 


### PR DESCRIPTION
The provider clones are unnecessary, since the original variable is dead (not used again) after the call.

The map clone is unnecessary, if just the network and provider are cloned before the `async move` operator.

There is no functional change.

`cargo test` still passes.