### PR TITLE
fix(sdk): Start throwing proper errors in the SDK macro.

### DIFF
--- a/libs/sdk/examples/revolut/src/lib.rs
+++ b/libs/sdk/examples/revolut/src/lib.rs
@@ -37,7 +37,7 @@ async fn oracle_request(settings: Settings) -> Result<Payload> {
         // Get the body of the response and parse it using serde_json crate.
         let body = resp.into_body();
         let string = String::from_utf8(body).expect("Our bytes should be valid utf8");
-        let value: Rate = serde_json::from_str(&string).unwrap();
+        let value: Rate = serde_json::from_str(&string)?;
 
         println!("{:?}", value);
 

--- a/libs/sdk/macro/src/lib.rs
+++ b/libs/sdk/macro/src/lib.rs
@@ -23,8 +23,10 @@ pub fn oracle_component(_attr: TokenStream, item: TokenStream) -> TokenStream {
                         match super::#func_name(settings.try_into().expect("cannot convert from Blocksense Oracle settings"))#await_postfix {
                             Ok(payload) => Ok(payload.try_into().expect("cannot convert from Blocksense Oracle payload")),
                             Err(e) => {
-                                eprintln!("{}", e);
-                                Err(self::preamble::blocksense::oracle::oracle_types::Error::Other("err".to_string()))
+                                //TODO(adikov): Potentially include more types of wit Errors and
+                                //implement a from trait for them. This way we can use the
+                                //different Errors in the oracle components implementation.
+                                Err(self::preamble::blocksense::oracle::oracle_types::Error::Other(e.to_string()))
                             },
                         }
                     })


### PR DESCRIPTION
## Description

* Fix a problem with error propagation from wasm components.

- [x] Bug fix

## How to test

1. Throw an error from the revolut example.
2. Run `./scripts/sdk/start-oracle-example.sh revolut`.
3. Check the console for proper error log.