### PR TITLE
config(nix/test-environments/example-setup-01): Change sequencer log level to `info`

### DIFF
--- a/nix/test-environments/example-setup-01.nix
+++ b/nix/test-environments/example-setup-01.nix
@@ -72,7 +72,7 @@ in
         "ea30af86b930d539c55677b05b4a5dad9fce1f758ba09d152d19a7d6940f8d8a8a8fb9f90d38a19e988d721cddaee4567d2e"
       ];
 
-      log-level = "debug";
+      log-level = "info";
     };
 
     reporters = {


### PR DESCRIPTION
Debug is currently too verbose and it's useless. In practice, we always change it to info, so we might as well commit this.