### PR TITLE
feat(sequencer): Switch debug to trace for verbose logs

### DIFF
--- a/apps/sequencer/src/feeds/votes_result_batcher.rs
+++ b/apps/sequencer/src/feeds/votes_result_batcher.rs
@@ -7,7 +7,7 @@ use std::io::Error;
 // use std::sync::{Arc, RwLock};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::time::Duration;
-use tracing::{debug, error, info, info_span};
+use tracing::{error, info, info_span, trace};
 use utils::time::current_unix_time;
 
 pub async fn votes_result_batcher_loop<
@@ -54,11 +54,11 @@ pub async fn votes_result_batcher_loop<
                         send_to_contract = updates.keys().len() >= max_keys_to_batch;
                     }
                     Ok(None) => {
-                        debug!("Woke up on empty channel. Flushing batched updates.");
+                        trace!("Woke up on empty channel. Flushing batched updates.");
                         send_to_contract = true;
                     }
                     Err(err) => {
-                        debug!(
+                        trace!(
                             "Woke up due to: {}. Flushing batched updates",
                             err.to_string()
                         );

--- a/apps/sequencer/src/metrics_collector.rs
+++ b/apps/sequencer/src/metrics_collector.rs
@@ -4,14 +4,14 @@ use prometheus::metrics_collector::gather_and_dump_metrics;
 use std::io::Error;
 use tokio::time::Duration;
 
-use tracing::{debug, error};
+use tracing::{error, trace};
 
 pub async fn metrics_collector_loop() -> tokio::task::JoinHandle<Result<(), Error>> {
     spawn(async move {
         let mut interval = time::interval(Duration::from_millis(60000));
         loop {
             match gather_and_dump_metrics() {
-                Ok(output) => debug!("{}", output),
+                Ok(output) => trace!("Dumping metrics for fun and profit: {}", output),
                 Err(e) => {
                     error!("Error getting metrics: {}", e.to_string());
                 }


### PR DESCRIPTION
The metrics take about 25% of all logs. Let's make them "trace" level.