### PR TITLE
config(CI): Add `[nixos, x86-64-v3]` to `runs-on` to slow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
 
   docs_website:
     timeout-minutes: 360
-    runs-on: self-hosted
+    runs-on: [self-hosted, nixos, x86-64-v3]
 
     steps:
       - uses: actions/checkout@v4
@@ -118,7 +118,7 @@ jobs:
 
   explorer_website:
     timeout-minutes: 360
-    runs-on: self-hosted
+    runs-on: [self-hosted, nixos, x86-64-v3]
 
     steps:
       - uses: actions/checkout@v4
@@ -147,7 +147,7 @@ jobs:
 
   rust:
     timeout-minutes: 360
-    runs-on: self-hosted
+    runs-on: [self-hosted, nixos, x86-64-v3]
 
     steps:
       - uses: actions/checkout@v4
@@ -203,7 +203,7 @@ jobs:
 
   deploy_websites:
     timeout-minutes: 360
-    runs-on: self-hosted
+    runs-on: [self-hosted, nixos, x86-64-v3]
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Currently, our runners are on GPU servers or the Solunska server. Some jobs take too long to execute. The reason they are slow is that they often run on the Solunska server, which has a lot of RAM but an older CPU.

With this PR, we force the slow jobs to run on the GPU servers, improving overall CI times.