### PR TITLE
feat(sequencer): Add names to tokio tasks

### DIFF
--- a/apps/sequencer/src/feeds/feed_slots_processor.rs
+++ b/apps/sequencer/src/feeds/feed_slots_processor.rs
@@ -45,9 +45,11 @@ impl FeedSlotsProcessor {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn start_loop(
         &self,
         sequencer_state: Data<SequencerState>,
+        feed_id: u32,
         feed: Arc<RwLock<FeedMetaData>>,
         history: Arc<RwLock<FeedAggregateHistory>>,
         feed_metrics: Option<Arc<RwLock<FeedsMetrics>>>,
@@ -70,6 +72,7 @@ impl FeedSlotsProcessor {
         };
 
         let feed_slots_time_tracker = SlotTimeTracker::new(
+            format!("feed_processor_{feed_id}"),
             Duration::from_millis(report_interval_ms),
             first_report_start_time,
         );
@@ -360,6 +363,7 @@ mod tests {
             feed_slots_processor
                 .start_loop(
                     sequencer_state,
+                    feed_id,
                     feed_metadata_arc_clone,
                     history,
                     None,
@@ -467,6 +471,7 @@ mod tests {
             feed_slots_processor
                 .start_loop(
                     sequencer_state,
+                    feed_id,
                     feed_metadata_arc_clone,
                     feed_aggregate_history,
                     None,

--- a/apps/sequencer/src/feeds/votes_result_sender.rs
+++ b/apps/sequencer/src/feeds/votes_result_sender.rs
@@ -1,6 +1,5 @@
 use crate::providers::eth_send_utils::eth_batch_send_to_all_contracts;
 use crate::sequencer_state::SequencerState;
-use actix_web::rt::spawn;
 use actix_web::web::Data;
 use feed_registry::types::Repeatability::Periodic;
 use std::collections::HashMap;
@@ -16,26 +15,48 @@ pub async fn votes_result_sender_loop<
     mut batched_votes_recv: UnboundedReceiver<HashMap<K, V>>,
     sequencer_state: Data<SequencerState>,
 ) -> tokio::task::JoinHandle<Result<(), Error>> {
-    spawn(async move {
-        loop {
-            let recvd = batched_votes_recv.recv().await;
-            match recvd {
-                Some(updates) => {
-                    info!("sending updates to contract:");
-                    let sequencer_state = sequencer_state.clone();
-                    spawn(async move {
-                        match eth_batch_send_to_all_contracts(sequencer_state, updates, Periodic)
-                            .await
-                        {
-                            Ok(res) => info!("Sending updates complete {}.", res),
-                            Err(err) => error!("ERROR Sending updates {}", err),
-                        };
-                    });
+    tokio::task::Builder::new()
+        .name("votes_result_sender")
+        .spawn_local(async move {
+            let mut batch_count = 0;
+            loop {
+                let recvd = batched_votes_recv.recv().await;
+                match recvd {
+                    Some(updates) => {
+                        info!("sending updates to contract:");
+                        let sequencer_state = sequencer_state.clone();
+                        async_send_to_contracts(sequencer_state, updates, batch_count);
+                    }
+                    None => {
+                        error!("Sender got RecvError");
+                    }
                 }
-                None => {
-                    error!("Sender got RecvError");
+                batch_count += 1;
+                if batch_count >= 1000000 {
+                    batch_count = 0;
                 }
             }
-        }
-    })
+        })
+        .expect("Failed to spawn votes result sender!")
+}
+
+fn async_send_to_contracts<
+    K: Debug + Clone + std::string::ToString + 'static,
+    V: Debug + Clone + std::string::ToString + 'static,
+>(
+    sequencer_state: Data<SequencerState>,
+    updates: HashMap<K, V>,
+    batch_count: usize,
+) {
+    let sender = tokio::task::Builder::new()
+        .name(format!("batch_sender_{batch_count}").as_str())
+        .spawn_local(async move {
+            match eth_batch_send_to_all_contracts(sequencer_state, updates, Periodic).await {
+                Ok(res) => info!("Sending updates complete {}.", res),
+                Err(err) => error!("ERROR Sending updates {}", err),
+            };
+        });
+    if let Err(err) = sender {
+        error!("Failed to spawn batch sender {batch_count} due to {err}!");
+    }
 }

--- a/apps/sequencer/src/metrics_collector.rs
+++ b/apps/sequencer/src/metrics_collector.rs
@@ -1,22 +1,25 @@
-use actix_web::rt::spawn;
 use actix_web::rt::time;
 use prometheus::metrics_collector::gather_and_dump_metrics;
 use std::io::Error;
 use tokio::time::Duration;
 
-use tracing::{error, trace};
+use tracing::{error, info, trace};
 
 pub async fn metrics_collector_loop() -> tokio::task::JoinHandle<Result<(), Error>> {
-    spawn(async move {
-        let mut interval = time::interval(Duration::from_millis(60000));
-        loop {
-            match gather_and_dump_metrics() {
-                Ok(output) => trace!("Dumping metrics for fun and profit: {}", output),
-                Err(e) => {
-                    error!("Error getting metrics: {}", e.to_string());
-                }
-            };
-            interval.tick().await;
-        }
-    })
+    tokio::task::Builder::new()
+        .name("metrics_collector")
+        .spawn_local(async move {
+            info!("Starting metrics collector loop...");
+            let mut interval = time::interval(Duration::from_millis(60000));
+            loop {
+                match gather_and_dump_metrics() {
+                    Ok(output) => trace!("Dumping metrics for fun and profit: {}", output),
+                    Err(e) => {
+                        error!("Error getting metrics: {}", e.to_string());
+                    }
+                };
+                interval.tick().await;
+            }
+        })
+        .expect("Failed to spawn metrics collector loop!")
 }


### PR DESCRIPTION
(drive-by: replace some trace! with debug! as trace is never shown)

This should help with the debugging of hang-ups.

To run `tokio-console` on `gpu-server-001` (or wherever the sequencer is deployed):

```
nix-shell -p tokio-console
```

This will open a new shell. Inside it, call `tokio-console`:

```
tokio-console
```

Before:

<img src="https://github.com/user-attachments/assets/16112f9d-46d1-42d4-bbb6-0cc173e6b728" width="400">

After:

<img src="https://github.com/user-attachments/assets/c436371d-4f9a-4639-8912-e5bb1684e8ab" width="400">
