### PR TITLE
feat(sequencer): Fix quorum percentage and filter small updates on chain

### DIFF
--- a/apps/cli/src/spin_manifest.rs
+++ b/apps/cli/src/spin_manifest.rs
@@ -208,7 +208,7 @@ mod test {
         "secs_since_epoch": 0,
         "nanos_since_epoch": 0
       },
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "script": "cmc"
     },
     {
@@ -231,7 +231,7 @@ mod test {
         "secs_since_epoch": 0,
         "nanos_since_epoch": 0
       },
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "script": "yahoo"
     }]
 }

--- a/apps/sequencer/src/feeds/feed_slots_processor.rs
+++ b/apps/sequencer/src/feeds/feed_slots_processor.rs
@@ -111,7 +111,7 @@ impl FeedSlotsProcessor {
             }
         } else {
             let total_votes_count = values.len() as f32;
-            let required_votes_count = quorum_percentage * (num_valid_reporters as f32);
+            let required_votes_count = quorum_percentage * 0.01f32 * (num_valid_reporters as f32);
             let is_quorum_reached = required_votes_count <= total_votes_count;
             let mut skip_publishing = false;
             if !is_quorum_reached {
@@ -278,8 +278,7 @@ impl FeedSlotsProcessor {
             let feed_id = self.key;
             info!(
                 "Skipping publishing for feed_id = {} change is lower then threshold of {} %",
-                feed_id,
-                skip_publish_if_less_then_percentage * 100.0f64
+                feed_id, skip_publish_if_less_then_percentage
             );
             return Ok(());
         }
@@ -338,7 +337,7 @@ impl FeedSlotsProcessor {
                 let a = f64::abs(*last);
                 let b = f64::abs(candidate_value);
                 let diff = f64::abs(last - candidate_value);
-                diff < skip_publish_if_less_then_percentage * f64::max(a, b)
+                diff * 100.0f64 < skip_publish_if_less_then_percentage * f64::max(a, b)
             }
             _ => false,
         };
@@ -555,16 +554,14 @@ mod tests {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
     use tokio::sync::RwLock;
     use utils::test_env::get_test_private_key_path;
-    const QUORUM_PERCENTAGE: f32 = 0.001;
-    const SKIP_PUBLISH_IF_LESS_THEN_PERCENTAGE: f32 = 1.0f32;
 
     #[tokio::test]
     async fn test_feed_slots_processor_loop() {
         // setup
         let name = "test_feed";
         let report_interval_ms = 1000; // 1 second interval
-        let quorum_percentage = QUORUM_PERCENTAGE;
-        let skip_publish_if_less_then_percentage = SKIP_PUBLISH_IF_LESS_THEN_PERCENTAGE;
+        let quorum_percentage = 100.0; // 100%
+        let skip_publish_if_less_then_percentage = 10.0; // 10%
         let first_report_start_time = SystemTime::now();
         let feed_metadata = FeedMetaData::new(
             name,
@@ -667,18 +664,11 @@ mod tests {
         // voting will be 3 seconds long
         let voting_wait_duration_ms = 3000;
 
-        let _feed = FeedMetaData::new_oneshot(
-            "TestFeed".to_string(),
-            voting_wait_duration_ms,
-            QUORUM_PERCENTAGE,
-            voting_start_time,
-        );
-
         let name = "test_feed";
         let feed_metadata = FeedMetaData::new_oneshot(
             name.to_string(),
             voting_wait_duration_ms,
-            QUORUM_PERCENTAGE,
+            100.0, // 100%
             voting_start_time,
         );
         let feed_metadata_arc = Arc::new(RwLock::new(feed_metadata));
@@ -789,8 +779,8 @@ mod tests {
         // setup
         let name = "test_feed_with_quorum";
         let report_interval_ms = 100; // 0.1 second interval
-        let quorum_percentage = 0.6f32;
-        let skip_publish_if_less_then_percentage = SKIP_PUBLISH_IF_LESS_THEN_PERCENTAGE;
+        let quorum_percentage = 60.0f32;
+        let skip_publish_if_less_then_percentage = 10.0f32; // 10%
         let first_report_start_time = SystemTime::now();
         let feed_metadata = FeedMetaData::new(
             name,
@@ -890,8 +880,8 @@ mod tests {
         // setup
         let name = "test_feed_low_diviation";
         let report_interval_ms = 100; // 0.1 second interval
-        let quorum_percentage = QUORUM_PERCENTAGE;
-        let skip_publish_if_less_then_percentage = 0.1f32;
+        let quorum_percentage = 100.0f32; //100%
+        let skip_publish_if_less_then_percentage = 10.0f32; // 10%
         let first_report_start_time = SystemTime::now();
         let feed_metadata = FeedMetaData::new(
             name,
@@ -1001,8 +991,8 @@ mod tests {
         // setup
         let name = "test_feed_low_diviation_2";
         let report_interval_ms = 100; // 0.1 second interval
-        let quorum_percentage = QUORUM_PERCENTAGE;
-        let skip_publish_if_less_then_percentage = 0.1f32;
+        let quorum_percentage = 100.0f32; // 100%
+        let skip_publish_if_less_then_percentage = 10.0f32; // 10%
         let first_report_start_time = SystemTime::now();
         let feed_metadata = FeedMetaData::new(
             name,

--- a/apps/sequencer/tests/sequencer_config.json
+++ b/apps/sequencer/tests/sequencer_config.json
@@ -7,10 +7,10 @@
   "providers": {
   },
   "feeds" : [
-    {"id": 0, "name": "DOGE/USD", "report_interval_ms": 60000, "quorum_percentage": 0.6, "first_report_start_time": {"secs_since_epoch":0, "nanos_since_epoch": 0}},
-    {"id": 1, "name": "BTS/USD", "report_interval_ms": 30000, "quorum_percentage": 0.6, "first_report_start_time": {"secs_since_epoch":0, "nanos_since_epoch": 0}},
-    {"id": 2, "name": "ETH/USD", "report_interval_ms": 60000, "quorum_percentage": 0.6, "first_report_start_time": {"secs_since_epoch":0, "nanos_since_epoch": 0}},
-    {"id": 3, "name": "SHIB/USD", "report_interval_ms": 20000, "quorum_percentage": 0.6, "first_report_start_time": {"secs_since_epoch":0, "nanos_since_epoch": 0}}
+    {"id": 0, "name": "DOGE/USD", "report_interval_ms": 60000, "quorum_percentage": 60.0, "first_report_start_time": {"secs_since_epoch":0, "nanos_since_epoch": 0}},
+    {"id": 1, "name": "BTS/USD", "report_interval_ms": 30000, "quorum_percentage": 60.0, "first_report_start_time": {"secs_since_epoch":0, "nanos_since_epoch": 0}},
+    {"id": 2, "name": "ETH/USD", "report_interval_ms": 60000, "quorum_percentage": 60.0, "first_report_start_time": {"secs_since_epoch":0, "nanos_since_epoch": 0}},
+    {"id": 3, "name": "SHIB/USD", "report_interval_ms": 20000, "quorum_percentage": 60.0, "first_report_start_time": {"secs_since_epoch":0, "nanos_since_epoch": 0}}
   ],
   "reporters":[]
 }

--- a/apps/sequencer_tests/bin/sequencer_tests.rs
+++ b/apps/sequencer_tests/bin/sequencer_tests.rs
@@ -91,7 +91,7 @@ async fn spawn_sequencer(eth_networks_ports: [i32; 2]) -> thread::JoinHandle<()>
         .clone();
     feed.id = 1;
     feed.report_interval_ms = 3000;
-    feed.quorum_percentage = 0.001;
+    feed.quorum_percentage = 0.1;
 
     let feeds = json!({
         "feeds": [

--- a/config/feeds_config.json
+++ b/config/feeds_config.json
@@ -7,7 +7,7 @@
       "description": "FOXY / USD",
       "decimals": 18,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -32,7 +32,7 @@
       "description": "PERP / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -57,7 +57,7 @@
       "description": "MEME / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -82,7 +82,7 @@
       "description": "SOL / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -107,8 +107,8 @@
       "description": "WSTETH / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
-      "skip_publish_if_less_then_percentage": 0.001,
+      "quorum_percentage": 100,
+      "skip_publish_if_less_then_percentage": 0.1,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -133,7 +133,7 @@
       "description": "TAO / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -158,7 +158,7 @@
       "description": "SAND / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -183,7 +183,7 @@
       "description": "JPM / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Equities",
       "script": "YahooFinance",
       "pair": {
@@ -207,7 +207,7 @@
       "description": "TRX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -232,7 +232,7 @@
       "description": "SUSD / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -257,7 +257,7 @@
       "description": "FTT / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -282,7 +282,7 @@
       "description": "CHZ / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -307,7 +307,7 @@
       "description": "LINA / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -332,7 +332,7 @@
       "description": "IMX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -357,7 +357,7 @@
       "description": "FLOW / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -382,7 +382,7 @@
       "description": "TIA / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -407,7 +407,7 @@
       "description": "ILS / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -431,7 +431,7 @@
       "description": "DPX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -456,7 +456,7 @@
       "description": "WING / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -481,7 +481,7 @@
       "description": "STORJ / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -506,7 +506,7 @@
       "description": "SUI / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -531,8 +531,8 @@
       "description": "PAXG / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
-      "skip_publish_if_less_then_percentage": 0.01,
+      "quorum_percentage": 100,
+      "skip_publish_if_less_then_percentage": 1,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -557,7 +557,7 @@
       "description": "VET / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -582,7 +582,7 @@
       "description": "AVAIL / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -607,7 +607,7 @@
       "description": "AXL / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -632,7 +632,7 @@
       "description": "BAL / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -657,7 +657,7 @@
       "description": "DPI / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -682,7 +682,7 @@
       "description": "ALCX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -707,7 +707,7 @@
       "description": "SHIB / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -732,7 +732,7 @@
       "description": "BONK / USD",
       "decimals": 18,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -757,7 +757,7 @@
       "description": "ANKR / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -782,7 +782,7 @@
       "description": "BTC / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -807,7 +807,7 @@
       "description": "MAV / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -832,7 +832,7 @@
       "description": "DAI / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -857,7 +857,7 @@
       "description": "BSW / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -882,7 +882,7 @@
       "description": "QUICK / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -907,7 +907,7 @@
       "description": "1INCH / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -932,7 +932,7 @@
       "description": "MLN / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -957,7 +957,7 @@
       "description": "COQ / USD",
       "decimals": 18,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -982,7 +982,7 @@
       "description": "TUSD / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1007,7 +1007,7 @@
       "description": "MRNA / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Equities",
       "script": "YahooFinance",
       "pair": {
@@ -1031,7 +1031,7 @@
       "description": "USDE / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1056,7 +1056,7 @@
       "description": "CFX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1081,7 +1081,7 @@
       "description": "WBTC / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1106,7 +1106,7 @@
       "description": "XVS / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1131,7 +1131,7 @@
       "description": "BETH / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1156,7 +1156,7 @@
       "description": "UST / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "YahooFinance",
       "pair": {
@@ -1180,7 +1180,7 @@
       "description": "ETH / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1205,7 +1205,7 @@
       "description": "DASH / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1230,7 +1230,7 @@
       "description": "MXN / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -1254,7 +1254,7 @@
       "description": "GME / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Equities",
       "script": "YahooFinance",
       "pair": {
@@ -1278,7 +1278,7 @@
       "description": "REEF / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1303,7 +1303,7 @@
       "description": "SXP / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1328,7 +1328,7 @@
       "description": "WTI / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Commodities",
       "script": "YahooFinance",
       "pair": {
@@ -1352,7 +1352,7 @@
       "description": "NZD / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -1376,7 +1376,7 @@
       "description": "WIF / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1401,7 +1401,7 @@
       "description": "XRP / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1426,7 +1426,7 @@
       "description": "ATOM / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1451,7 +1451,7 @@
       "description": "USDP / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1476,7 +1476,7 @@
       "description": "MASK / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1501,7 +1501,7 @@
       "description": "XLM / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1526,7 +1526,7 @@
       "description": "CAKE / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1551,7 +1551,7 @@
       "description": "GBP / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -1575,7 +1575,7 @@
       "description": "KAVA / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1600,7 +1600,7 @@
       "description": "XMR / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1625,7 +1625,7 @@
       "description": "EURC / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1650,7 +1650,7 @@
       "description": "XAG / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Commodities",
       "script": "YahooFinance",
       "pair": {
@@ -1674,7 +1674,7 @@
       "description": "FET / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1699,7 +1699,7 @@
       "description": "AXS / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1724,7 +1724,7 @@
       "description": "DOT / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1749,7 +1749,7 @@
       "description": "QNT / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1774,7 +1774,7 @@
       "description": "DYDX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1799,7 +1799,7 @@
       "description": "MNT / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1824,7 +1824,7 @@
       "description": "UMA / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1849,7 +1849,7 @@
       "description": "ZERO / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1874,7 +1874,7 @@
       "description": "ULTI / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1899,7 +1899,7 @@
       "description": "STX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1924,7 +1924,7 @@
       "description": "CAD / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -1948,7 +1948,7 @@
       "description": "KSM / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1973,7 +1973,7 @@
       "description": "JTO / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -1998,7 +1998,7 @@
       "description": "USDz / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2023,7 +2023,7 @@
       "description": "GRT / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2048,7 +2048,7 @@
       "description": "GMT / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2073,7 +2073,7 @@
       "description": "GOOGL / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Equities",
       "script": "YahooFinance",
       "pair": {
@@ -2097,7 +2097,7 @@
       "description": "XAI / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2122,7 +2122,7 @@
       "description": "ALPACA / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2147,7 +2147,7 @@
       "description": "MAGIC / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2172,7 +2172,7 @@
       "description": "XAVA / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2197,7 +2197,7 @@
       "description": "PFE / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Equities",
       "script": "YahooFinance",
       "pair": {
@@ -2221,7 +2221,7 @@
       "description": "QI / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2246,7 +2246,7 @@
       "description": "BADGER / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2271,7 +2271,7 @@
       "description": "FLOKI / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2296,7 +2296,7 @@
       "description": "ZK / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2321,7 +2321,7 @@
       "description": "LIT / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2346,7 +2346,7 @@
       "description": "XOF / USD",
       "decimals": 18,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "",
       "script": "YahooFinance",
       "pair": {
@@ -2370,7 +2370,7 @@
       "description": "XTZ / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2395,7 +2395,7 @@
       "description": "MOVR / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2420,7 +2420,7 @@
       "description": "AMZN / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Equities",
       "script": "YahooFinance",
       "pair": {
@@ -2444,7 +2444,7 @@
       "description": "TRY / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -2468,7 +2468,7 @@
       "description": "DOGE / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2493,7 +2493,7 @@
       "description": "NFLX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Equities",
       "script": "YahooFinance",
       "pair": {
@@ -2517,7 +2517,7 @@
       "description": "SEK / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -2541,7 +2541,7 @@
       "description": "MEW / USD",
       "decimals": 18,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2566,7 +2566,7 @@
       "description": "MATIC / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2591,7 +2591,7 @@
       "description": "ZIL / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2616,7 +2616,7 @@
       "description": "USDS / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2641,7 +2641,7 @@
       "description": "ZAR / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -2665,7 +2665,7 @@
       "description": "THB / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -2689,7 +2689,7 @@
       "description": "EOS / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2714,7 +2714,7 @@
       "description": "RSR / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2739,7 +2739,7 @@
       "description": "UNI / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2764,7 +2764,7 @@
       "description": "AAPL / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Equities",
       "script": "YahooFinance",
       "pair": {
@@ -2788,7 +2788,7 @@
       "description": "RDNT / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2813,7 +2813,7 @@
       "description": "HIGH / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2838,7 +2838,7 @@
       "description": "KES / USD",
       "decimals": 18,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "",
       "script": "YahooFinance",
       "pair": {
@@ -2862,7 +2862,7 @@
       "description": "APE / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2887,7 +2887,7 @@
       "description": "BCH / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2912,7 +2912,7 @@
       "description": "CUSD / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2937,7 +2937,7 @@
       "description": "COMP / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2962,7 +2962,7 @@
       "description": "ZEC / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -2987,7 +2987,7 @@
       "description": "ENS / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3012,7 +3012,7 @@
       "description": "KRW / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -3036,7 +3036,7 @@
       "description": "TSLA / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Equities",
       "script": "YahooFinance",
       "pair": {
@@ -3060,7 +3060,7 @@
       "description": "MAVIA / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3085,7 +3085,7 @@
       "description": "ADA / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3110,7 +3110,7 @@
       "description": "GHST / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3135,7 +3135,7 @@
       "description": "AMPL / USD",
       "decimals": 18,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3160,7 +3160,7 @@
       "description": "GNS / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3185,7 +3185,7 @@
       "description": "USDe / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3210,7 +3210,7 @@
       "description": "GNO / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3235,7 +3235,7 @@
       "description": "DODO / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3260,7 +3260,7 @@
       "description": "USDC / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3285,7 +3285,7 @@
       "description": "STG / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3310,7 +3310,7 @@
       "description": "AERO / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3335,7 +3335,7 @@
       "description": "POL / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3360,7 +3360,7 @@
       "description": "ORDI / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3385,7 +3385,7 @@
       "description": "NULS / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3410,7 +3410,7 @@
       "description": "sUSDe / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3435,7 +3435,7 @@
       "description": "BAT / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3460,7 +3460,7 @@
       "description": "PEPE / USD",
       "decimals": 18,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3485,7 +3485,7 @@
       "description": "FIL / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3510,7 +3510,7 @@
       "description": "YFI / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3535,7 +3535,7 @@
       "description": "XCN / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3560,7 +3560,7 @@
       "description": "LDO / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3585,7 +3585,7 @@
       "description": "USDD / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3610,7 +3610,7 @@
       "description": "ARB / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3635,7 +3635,7 @@
       "description": "MSFT / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Equities",
       "script": "YahooFinance",
       "pair": {
@@ -3659,7 +3659,7 @@
       "description": "USDV / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3684,7 +3684,7 @@
       "description": "MKR / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3709,7 +3709,7 @@
       "description": "CRV / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3734,7 +3734,7 @@
       "description": "CHF / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -3758,7 +3758,7 @@
       "description": "IOTX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3783,7 +3783,7 @@
       "description": "GMX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3808,7 +3808,7 @@
       "description": "SHV / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Equities",
       "script": "YahooFinance",
       "pair": {
@@ -3832,7 +3832,7 @@
       "description": "REN / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3857,7 +3857,7 @@
       "description": "MIM / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3882,7 +3882,7 @@
       "description": "BUSD / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3907,7 +3907,7 @@
       "description": "USD+ / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3932,7 +3932,7 @@
       "description": "SPELL / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3957,7 +3957,7 @@
       "description": "C98 / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -3982,7 +3982,7 @@
       "description": "USDM / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4007,7 +4007,7 @@
       "description": "AUSD / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4032,7 +4032,7 @@
       "description": "QQQ / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Equities",
       "script": "YahooFinance",
       "pair": {
@@ -4056,7 +4056,7 @@
       "description": "OM / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4081,7 +4081,7 @@
       "description": "BRL / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -4105,7 +4105,7 @@
       "description": "BLUR / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4130,7 +4130,7 @@
       "description": "WIN / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4155,7 +4155,7 @@
       "description": "BOO / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4180,7 +4180,7 @@
       "description": "IDR / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -4204,7 +4204,7 @@
       "description": "JUP / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4229,7 +4229,7 @@
       "description": "INJ / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4254,7 +4254,7 @@
       "description": "DGB / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4279,7 +4279,7 @@
       "description": "FORTH / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4304,7 +4304,7 @@
       "description": "KNC / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4329,7 +4329,7 @@
       "description": "PYUSD / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4354,7 +4354,7 @@
       "description": "CRVUSD / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4379,7 +4379,7 @@
       "description": "INR / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -4403,7 +4403,7 @@
       "description": "XAU / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Commodities",
       "script": "YahooFinance",
       "pair": {
@@ -4427,7 +4427,7 @@
       "description": "XPT / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Commodities",
       "script": "YahooFinance",
       "pair": {
@@ -4451,7 +4451,7 @@
       "description": "CELO / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4476,7 +4476,7 @@
       "description": "COP / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Fiat",
       "script": "YahooFinance",
       "pair": {
@@ -4500,7 +4500,7 @@
       "description": "CSPX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "",
       "script": "YahooFinance",
       "pair": {
@@ -4524,7 +4524,7 @@
       "description": "GLMR / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4549,7 +4549,7 @@
       "description": "SEI / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4574,7 +4574,7 @@
       "description": "mSOL / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "YahooFinance",
       "pair": {
@@ -4598,7 +4598,7 @@
       "description": "ALPHA / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4623,7 +4623,7 @@
       "description": "JPY / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -4647,7 +4647,7 @@
       "description": "BNB / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4672,7 +4672,7 @@
       "description": "SPY / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Equities",
       "script": "YahooFinance",
       "pair": {
@@ -4696,7 +4696,7 @@
       "description": "ICP / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4721,7 +4721,7 @@
       "description": "RPL / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4746,7 +4746,7 @@
       "description": "VAI / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4771,7 +4771,7 @@
       "description": "WLD / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4796,7 +4796,7 @@
       "description": "SATS / USD",
       "decimals": 18,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4821,7 +4821,7 @@
       "description": "GHO / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4846,7 +4846,7 @@
       "description": "WEMIX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4871,7 +4871,7 @@
       "description": "ALGO / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4896,7 +4896,7 @@
       "description": "BAND / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4921,7 +4921,7 @@
       "description": "OGN / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4946,7 +4946,7 @@
       "description": "SNX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -4971,7 +4971,7 @@
       "description": "MS / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Equities",
       "script": "YahooFinance",
       "pair": {
@@ -4995,7 +4995,7 @@
       "description": "ENJ / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5020,7 +5020,7 @@
       "description": "AVAX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5045,7 +5045,7 @@
       "description": "FDUSD / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5070,7 +5070,7 @@
       "description": "SUSHI / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5095,7 +5095,7 @@
       "description": "LTC / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5120,7 +5120,7 @@
       "description": "TBTC / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5145,7 +5145,7 @@
       "description": "STRK / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5170,7 +5170,7 @@
       "description": "LINK / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5195,7 +5195,7 @@
       "description": "USD0 / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5220,7 +5220,7 @@
       "description": "DEGEN / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5245,7 +5245,7 @@
       "description": "ZRO / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5270,7 +5270,7 @@
       "description": "CHR / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5295,7 +5295,7 @@
       "description": "SGD / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -5319,7 +5319,7 @@
       "description": "THETA / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5344,7 +5344,7 @@
       "description": "CVX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5369,7 +5369,7 @@
       "description": "SRM / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5394,7 +5394,7 @@
       "description": "AAVE / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5419,7 +5419,7 @@
       "description": "ONT / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5444,7 +5444,7 @@
       "description": "MOG / USD",
       "decimals": 18,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5469,7 +5469,7 @@
       "description": "OP / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5494,7 +5494,7 @@
       "description": "CZK / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "",
       "script": "YahooFinance",
       "pair": {
@@ -5518,7 +5518,7 @@
       "description": "CNY / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -5542,7 +5542,7 @@
       "description": "FRAX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5567,7 +5567,7 @@
       "description": "NVDA / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Equities",
       "script": "YahooFinance",
       "pair": {
@@ -5591,7 +5591,7 @@
       "description": "LUSD / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5616,7 +5616,7 @@
       "description": "BEAM / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5641,7 +5641,7 @@
       "description": "PENDLE / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5666,7 +5666,7 @@
       "description": "SLP / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5691,7 +5691,7 @@
       "description": "ASTR / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5716,7 +5716,7 @@
       "description": "IBTA / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "",
       "script": "YahooFinance",
       "pair": {
@@ -5740,7 +5740,7 @@
       "description": "COIN / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Equities",
       "script": "YahooFinance",
       "pair": {
@@ -5764,7 +5764,7 @@
       "description": "VELO / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5789,7 +5789,7 @@
       "description": "ETC / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5814,7 +5814,7 @@
       "description": "JOE / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5839,7 +5839,7 @@
       "description": "FXS / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5864,7 +5864,7 @@
       "description": "USDT / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5889,7 +5889,7 @@
       "description": "MBOX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5914,7 +5914,7 @@
       "description": "ONE / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5939,7 +5939,7 @@
       "description": "MIMATIC / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5964,7 +5964,7 @@
       "description": "TRB / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -5989,7 +5989,7 @@
       "description": "FTM / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -6014,7 +6014,7 @@
       "description": "RUNE / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -6039,7 +6039,7 @@
       "description": "META / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Equities",
       "script": "YahooFinance",
       "pair": {
@@ -6063,7 +6063,7 @@
       "description": "NEAR / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -6088,7 +6088,7 @@
       "description": "APT / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -6113,7 +6113,7 @@
       "description": "PLN / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -6137,7 +6137,7 @@
       "description": "PHP / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -6161,7 +6161,7 @@
       "description": "KLAY / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -6186,7 +6186,7 @@
       "description": "PYTH / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -6211,7 +6211,7 @@
       "description": "ZRX / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -6236,7 +6236,7 @@
       "description": "METIS / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -6261,7 +6261,7 @@
       "description": "MANA / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -6286,7 +6286,7 @@
       "description": "EUR / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Forex",
       "script": "YahooFinance",
       "pair": {
@@ -6310,7 +6310,7 @@
       "description": "ONG / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -6335,7 +6335,7 @@
       "description": "HBAR / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {
@@ -6360,7 +6360,7 @@
       "description": "WOO / USD",
       "decimals": 8,
       "report_interval_ms": 300000,
-      "quorum_percentage": 1,
+      "quorum_percentage": 100,
       "type": "Crypto",
       "script": "CoinMarketCap",
       "pair": {

--- a/libs/config/src/lib.rs
+++ b/libs/config/src/lib.rs
@@ -93,7 +93,7 @@ impl FeedConfig {
 
 impl Validated for FeedConfig {
     fn validate(&self, context: &str) -> anyhow::Result<()> {
-        let range_percentage = 0.0f32..=1.0f32;
+        let range_percentage = 0.0f32..=100.0f32;
         if self.report_interval_ms == 0 {
             anyhow::bail!(
                 "{}: report_interval_ms for feed {} with id {} cannot be set to 0",
@@ -105,22 +105,28 @@ impl Validated for FeedConfig {
         if !range_percentage.contains(&self.quorum_percentage) {
             anyhow::bail!(
                 "{}: quorum_percentage for feed {} with id {} must be between {} and {}",
-                range_percentage.start(),
-                range_percentage.end(),
                 context,
                 self.name,
-                self.id
+                self.id,
+                range_percentage.start(),
+                range_percentage.end(),
             );
         }
         if !range_percentage.contains(&self.skip_publish_if_less_then_percentage) {
             anyhow::bail!(
             "{}: skip_publish_if_less_then_percentage for feed {} with id {} must be between {} and {}",
-            range_percentage.start(),
-            range_percentage.end(),
             context,
             self.name,
-            self.id
+            self.id,
+            range_percentage.start(),
+            range_percentage.end(),
         );
+        }
+        if self.skip_publish_if_less_then_percentage > 0.0f32 {
+            info!(
+                "{}: Skipping updates in feed {} with id {} that deviate less then {} %",
+                context, self.name, self.id, self.skip_publish_if_less_then_percentage,
+            );
         }
         Ok(())
     }

--- a/libs/feed_registry/src/registry.rs
+++ b/libs/feed_registry/src/registry.rs
@@ -49,11 +49,11 @@ impl FeedMetaDataRegistry {
 
 pub fn new_feeds_meta_data_reg_with_test_data() -> FeedMetaDataRegistry {
     let start = SystemTime::now();
-    let skip_publish_if_less_then_percentage = 0.0f32;
+    let skip_publish_if_less_then_percentage = 0.0f32; // 0%
     let fmd1 = FeedMetaData::new(
         "DOGE/USD",
         60000,
-        0.6,
+        60.0f32, // 60%
         skip_publish_if_less_then_percentage,
         start,
         "Numerical".to_string(),
@@ -63,7 +63,7 @@ pub fn new_feeds_meta_data_reg_with_test_data() -> FeedMetaDataRegistry {
     let fmd2 = FeedMetaData::new(
         "BTS/USD",
         30000,
-        0.6,
+        60.0f32, // 60%
         skip_publish_if_less_then_percentage,
         start,
         "Numerical".to_string(),
@@ -73,7 +73,7 @@ pub fn new_feeds_meta_data_reg_with_test_data() -> FeedMetaDataRegistry {
     let fmd3 = FeedMetaData::new(
         "ETH/USD",
         60000,
-        0.6,
+        60.0f32, // 60%
         skip_publish_if_less_then_percentage,
         start,
         "Numerical".to_string(),
@@ -341,9 +341,6 @@ mod tests {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
     use tokio::sync::RwLock;
 
-    const QUORUM_PERCENTAGE: f32 = 0.001;
-    const SKIP_PUBLISH_IF_LESS_THEN_PERCENTAGE: f32 = 0.01f32;
-
     #[tokio::test]
     async fn basic_test() {
         let fmdr = new_feeds_meta_data_reg_with_test_data();
@@ -485,7 +482,7 @@ mod tests {
         let feed = FeedMetaData::new_oneshot(
             "TestFeed".to_string(),
             voting_wait_duration_ms,
-            QUORUM_PERCENTAGE,
+            10.0f32, // 10%
             voting_start_time,
         );
 
@@ -575,14 +572,14 @@ mod tests {
         let oneshot_feed = FeedMetaData::new_oneshot(
             "TestFeed".to_string(),
             voting_wait_duration_ms,
-            QUORUM_PERCENTAGE,
+            10.0f32, // 10%
             voting_start_time,
         );
         let regular_feed = FeedMetaData::new(
             "TestFeed",
             voting_wait_duration_ms,
-            QUORUM_PERCENTAGE,
-            SKIP_PUBLISH_IF_LESS_THEN_PERCENTAGE,
+            10.0f32, // 10%
+            1.0f32,  // 1%
             current_system_time,
             "Numeric".to_string(),
             "Average".to_string(),


### PR DESCRIPTION
Currently, 1% threshold is applied for all feeds. I am not sure, if this is OK