### PR TITLE
Make startSlot and slots optional when reading from the contract

### DIFF
--- a/libs/ts/contracts/test/AggregatedDataFeedStore.test.ts
+++ b/libs/ts/contracts/test/AggregatedDataFeedStore.test.ts
@@ -20,6 +20,7 @@ const feeds: Feed[] = [
     round: 6n,
     stride: 1n,
     data: '0x12343267643573',
+    slotsToRead: 1,
   },
   {
     id: 2n,
@@ -194,6 +195,7 @@ describe('AggregatedDataFeedStore', () => {
       round: 1n,
       stride: 31n,
       data: '0x12343267643573',
+      slotsToRead: 1,
     };
     await contract.setFeeds(sequencer, [feed]);
     await contract.checkLatestValue(sequencer, [feed]);


### PR DESCRIPTION
This achieves better gas costs for the most common case - to read the whole round.