### PR TITLE
[docs.ws]: Implement reusable `CodeBlock` component

### DIFF
--- a/apps/docs.blocksense.network/components/common/CodeBlock.tsx
+++ b/apps/docs.blocksense.network/components/common/CodeBlock.tsx
@@ -1,36 +1,37 @@
 'use client';
-import React from 'react';
-import { codeToHtml } from 'shiki';
-import { CopyButton } from './CopyButton';
-import { usePathname } from 'next/navigation';
-import { transformerOverviewLineLink } from '@/src/contract-overview';
+
+import React, { useEffect, useState } from 'react';
+import { codeToHtml, ShikiTransformer } from 'shiki';
+
+import { CopyButton } from '@/components/common/CopyButton';
 
 type CodeBlockProps = {
   code: string;
-  precompiledHtml?: string;
   lang?: string;
   theme?: string;
   copy?: {
     hasCopyButton: boolean;
     disabled: boolean;
   };
+  transformers?: ShikiTransformer[];
 };
 
-// "JIT" in this context refers to the fact that the code block is not precompiled.
-const JitCodeBlock = ({
+export const CodeBlock = ({
   code = '',
   lang = 'text',
   theme = 'material-theme-lighter',
   copy = { hasCopyButton: true, disabled: false },
+  transformers = [],
 }: CodeBlockProps) => {
-  const [html, setHtml] = React.useState('');
+  const [html, setHtml] = useState('');
 
-  React.useEffect(() => {
+  useEffect(() => {
     codeToHtml(code, {
       lang,
       theme,
-    }).then((htmlString: any) => setHtml(htmlString));
-  }, [code]);
+      transformers,
+    }).then((htmlString: string) => setHtml(htmlString));
+  }, [code, theme, html]);
 
   return (
     <div className="relative">
@@ -43,90 +44,7 @@ const JitCodeBlock = ({
         />
       )}
       <div
-        className="signature__code flex-grow"
-        dangerouslySetInnerHTML={{ __html: html }}
-      />
-    </div>
-  );
-};
-
-const PrecompiledCodeBlock = ({
-  code = '',
-  precompiledHtml = '',
-  copy = { hasCopyButton: true, disabled: false },
-}: CodeBlockProps) => {
-  return (
-    <div className="relative">
-      {copy.hasCopyButton && (
-        <CopyButton
-          textToCopy={code}
-          tooltipPosition="left"
-          copyButtonClasses="absolute top-0 right-0 m-2 nx-z-10"
-          disabled={copy.disabled}
-        />
-      )}
-      <div
-        className="signature__code flex-grow"
-        dangerouslySetInnerHTML={{ __html: precompiledHtml }}
-      />
-    </div>
-  );
-};
-
-export const CodeBlock = ({
-  code = '',
-  precompiledHtml = '',
-  lang = 'text',
-  theme = 'material-theme-lighter',
-  copy = { hasCopyButton: true, disabled: false },
-}: CodeBlockProps) => {
-  return precompiledHtml ? (
-    <PrecompiledCodeBlock
-      code={code}
-      precompiledHtml={precompiledHtml}
-      copy={copy}
-    />
-  ) : (
-    <JitCodeBlock code={code} lang={lang} theme={theme} copy={copy} />
-  );
-};
-
-export const OverviewCodeBlock = ({
-  code,
-  lang = 'solidity',
-  theme = 'material-theme-lighter',
-  copy = { hasCopyButton: true, disabled: false },
-}: CodeBlockProps) => {
-  const pathName = usePathname();
-  const [html, setHtml] = React.useState('');
-
-  React.useEffect(() => {
-    codeToHtml(code, {
-      lang,
-      theme,
-      transformers: [
-        transformerOverviewLineLink({
-          routeLink: pathName || '',
-          classes: [
-            'border border-natural-200 rounded-md p-1 hover:bg-stone-100 cursor-pointer',
-          ],
-        }),
-      ],
-    }).then((htmlString: any) => setHtml(htmlString));
-  }, [code]);
-
-  return (
-    <div style={{ position: 'relative' }}>
-      {copy.hasCopyButton && (
-        <CopyButton
-          textToCopy={code}
-          tooltipPosition="left"
-          copyButtonClasses="bg-zinc-50 absolute top-4 right-2 m-2 nx-z-10"
-          disabled={copy.disabled}
-        />
-      )}
-      <div
-        className="signature__code flex-grow"
+        className="signature__code grow"
         dangerouslySetInnerHTML={{ __html: html }}
       />
     </div>

--- a/apps/docs.blocksense.network/components/sol-contracts/ContractOverview.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/ContractOverview.tsx
@@ -1,14 +1,29 @@
-import React from 'react';
+'use client';
 
 import { ContractDocItem } from '@blocksense/sol-reflector';
+import { usePathname } from 'next/navigation';
 
+import { transformerOverviewLineLink } from '@/src/contract-overview';
 import { getOverviewCodeContent } from '@/src/contract-overview';
-import { OverviewCodeBlock } from '../common/CodeBlock';
+import { CodeBlock } from '@/components/common/CodeBlock';
 
 type ContractOverviewProps = {
   contract: ContractDocItem;
 };
 
 export const ContractOverview = ({ contract }: ContractOverviewProps) => {
-  return <OverviewCodeBlock code={getOverviewCodeContent(contract)} />;
+  const pathName = usePathname();
+
+  return (
+    <CodeBlock
+      code={getOverviewCodeContent(contract)}
+      lang="solidity"
+      transformers={[
+        transformerOverviewLineLink({
+          routeLink: pathName,
+          classes: ['p-1 hover:bg-stone-100 cursor-pointer'],
+        }),
+      ]}
+    />
+  );
 };


### PR DESCRIPTION
Implemented a single reusable `CodeBlock` component in `components/common/CodeBlock.tsx` to merge and replace the components:

- PrecompiledCodeBlock
- CodeBlock
- OverviewCodeBlock
- JitCodeBlock

The new `CodeBlock` handles common functionality, styles, and types. It uses props like language, code, transformers, and theme for flexibility.

Usage in:

- ABIModal
- Signature
- ContractOverview

This refactor simplifies the codebase, and improves maintainability.