### PR TITLE
[docs.ws]: Switching themes in `CodeBlock`

### DIFF
--- a/apps/docs.blocksense.network/components/common/CodeBlock.tsx
+++ b/apps/docs.blocksense.network/components/common/CodeBlock.tsx
@@ -1,14 +1,18 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { codeToHtml, ShikiTransformer } from 'shiki';
+import { useTheme } from 'nextra-theme-docs';
 
 import { CopyButton } from '@/components/common/CopyButton';
 
 type CodeBlockProps = {
   code: string;
   lang?: string;
-  theme?: string;
+  themes?: {
+    light: string;
+    dark: string;
+  };
   copy?: {
     hasCopyButton: boolean;
     disabled: boolean;
@@ -19,19 +23,30 @@ type CodeBlockProps = {
 export const CodeBlock = ({
   code = '',
   lang = 'text',
-  theme = 'material-theme-lighter',
+  themes = {
+    light: 'material-theme-lighter',
+    dark: 'vitesse-dark',
+  },
   copy = { hasCopyButton: true, disabled: false },
   transformers = [],
 }: CodeBlockProps) => {
   const [html, setHtml] = useState('');
+  const { theme, systemTheme } = useTheme();
+
+  const currentTheme = useMemo(() => {
+    if (theme === 'system') {
+      return systemTheme === 'light' ? themes.light : themes.dark;
+    }
+    return theme === 'light' ? themes.light : themes.dark;
+  }, [theme, systemTheme, themes]);
 
   useEffect(() => {
     codeToHtml(code, {
       lang,
-      theme,
+      theme: currentTheme,
       transformers,
-    }).then((htmlString: string) => setHtml(htmlString));
-  }, [code, theme, html]);
+    }).then(setHtml);
+  }, [code, lang, currentTheme, transformers]);
 
   return (
     <div className="relative">

--- a/apps/docs.blocksense.network/components/sol-contracts/ABIModal/ABIModal.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/ABIModal/ABIModal.tsx
@@ -64,7 +64,11 @@ export const ABIModal = ({ abi, name = '' }: ABIModalProps) => {
           </DialogHeader>
           <ScrollArea>
             <aside className="scroll-area">
-              <CodeBlock code={getABI()} lang="json" theme="github-light" />
+              <CodeBlock
+                code={getABI()}
+                lang="json"
+                themes={{ light: 'github-light', dark: 'vitesse-dark' }}
+              />
             </aside>
           </ScrollArea>
         </DialogContent>
@@ -91,7 +95,11 @@ export const ABIModal = ({ abi, name = '' }: ABIModalProps) => {
           <DialogDescription />
         </DialogHeader>
         <div className="max-h-96 overflow-y-scroll pb-6">
-          <CodeBlock code={getABI()} lang="json" theme="github-light" />
+          <CodeBlock
+            code={getABI()}
+            lang="json"
+            themes={{ light: 'github-light', dark: 'vitesse-dark' }}
+          />
         </div>
       </DrawerContent>
     </Drawer>


### PR DESCRIPTION
Implemented theme switching in the `CodeBlock` component (used for code snippets across the react components) using `shiki`, supporting three modes: `system`, `dark`, and `light`. The theme automatically switches when the app's theme is changed from `nextra` and is optimized with `useMemo`.

Default themes:
- Light: `material-theme-lighter`
- Dark: `vitesse-dark`

## Screenshots:

**System:**
![image](https://github.com/user-attachments/assets/2aa61cd8-6817-4424-b3f0-c9e1ebaff4f8)

**Dark:**
![image](https://github.com/user-attachments/assets/f35c6771-b17e-44f0-b846-b5c793ca622b)

**Light:**
![image](https://github.com/user-attachments/assets/ac51848b-ad55-4a93-9854-6e458925d772)