### PR TITLE
[docs.ws]: Remove `invert` class from `NetworkIcon`

### DIFF
--- a/apps/docs.blocksense.network/components/DeployedContracts/NetworkIcon.tsx
+++ b/apps/docs.blocksense.network/components/DeployedContracts/NetworkIcon.tsx
@@ -31,7 +31,7 @@ export const NetworkIcon = ({
       <ImageWrapper
         src={iconPath}
         alt={network}
-        className="relative w-14 h-14 invert"
+        className="relative w-14 h-14"
       />
       <div className="pt-4 font-bold text-xs dark:text-white">
         {capitalizeWords(network)}


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/249adf39-6966-4605-a8b1-6957035a5ed1)

After:
![image](https://github.com/user-attachments/assets/cd837112-cd96-442b-96d6-dbf859c334e1)
