### PR TITLE
feat(docs.ws): Nextra support for mermaid styling while switching themes

### DIFF
--- a/apps/docs.blocksense.network/app/docs/contracts/integration-guide/using-data-feeds/chainlink-proxy/page.mdx
+++ b/apps/docs.blocksense.network/app/docs/contracts/integration-guide/using-data-feeds/chainlink-proxy/page.mdx
@@ -20,17 +20,11 @@ For a complete list of functions and parameters for the CLAggregatorAdapter cont
 ---
 config:
     rightAngles: true
-    theme: neutral
-    primaryColor: "#d0d0d0"
-    signalColor: "FF0000"
-    signalTextColor: "#808080"
 ---
 flowchart TD
-  classDef clientNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
-  classDef proxyNode,dataNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
+  classDef clientNode display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
+  classDef proxyNode,dataNode display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
   classDef proxyNode:hover,dataNode:hover fill:#fafafa,color:#0000EE,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace, text-decoration: underline, text-underline-offset: 4px;
-
-  linkStyle default fill:none,stroke-width:1px,stroke:#1c1917
 
   A[Client] -->|get feed's data| CP[CLAggregatorAdapter]
   CP -->|reads from| DFS[HistoricalDataFeedStore]

--- a/apps/docs.blocksense.network/app/docs/contracts/integration-guide/using-data-feeds/feed-registry/page.mdx
+++ b/apps/docs.blocksense.network/app/docs/contracts/integration-guide/using-data-feeds/feed-registry/page.mdx
@@ -20,14 +20,10 @@ For a complete list of functions and parameters for the CLFeedRegistryAdapter co
 ---
 config:
     rightAngles: true
-    theme: neutral
-    primaryColor: "#d0d0d0"
-    signalColor: "FF0000"
-    signalTextColor: "#808080"
 ---
 flowchart TD
-  classDef clientNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
-  classDef feedNode,dataNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
+  classDef clientNode display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
+  classDef feedNode,dataNode display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
   classDef feedNode:hover,dataNode:hover fill:#fafafa,color:#0000EE,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace, text-decoration: underline, text-underline-offset: 4px;
 
   linkStyle default fill:none,stroke-width:1px,stroke:#1c1917

--- a/apps/docs.blocksense.network/app/docs/contracts/overview/page.mdx
+++ b/apps/docs.blocksense.network/app/docs/contracts/overview/page.mdx
@@ -23,17 +23,11 @@ This diagram illustrates the role of smart contracts in ensuring data integrity 
 ---
 config:
     rightAngles: true
-    theme: neutral
-    primaryColor: "#d0d0d0"
-    signalColor: "FF0000"
-    signalTextColor: "#808080"
 ---
 graph TD
-    classDef clientNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
-    classDef feedNode,proxyNode,dataNode fill:#fafafa,color:#0c0a09,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
+    classDef clientNode display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
+    classDef feedNode,proxyNode,dataNode display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace;
     classDef feedNode:hover,proxyNode:hover,dataNode:hover fill:#fafafa,color:#0000EE,stroke:#e4e4e7,stroke-width:1px,shadow:2px 2px 5px #888888, display:block, padding:0rem 3rem, font-size: 0.875rem, font-family:'Fira Code', monospace, text-decoration: underline, text-underline-offset: 4px;
-
-    linkStyle default fill:none,stroke-width:1px,stroke:#1c1917
 
     A[Client] -->|invoke| E
     A -->|invoke| B


### PR DESCRIPTION
In the current documentation website, [Mermaid diagrams ](https://nextra.site/docs/advanced/mermaid)lack proper theming support. This causes diagrams to look inconsistent or hard to read when switching between light and dark modes.

With this [PR](https://github.com/blocksense-network/blocksense/pull/804):

Mermaid diagrams automatically adapt to your site’s theme, whether it’s light, dark, or system.
The <Mermaid> component dynamically applies theme-specific styles, ensuring that diagrams remain legible and blend visually with the rest of the website. Hover effect from the previous implementation is preserved, because it fits in all modes. The same cannot be applied for node strokes and backgrounds. 

As a conclusion - We no longer need to manually adjust styles when switching between modes.