### PR TITLE
[docs.ws]: Fix Diagram Links

### DIFF
--- a/apps/docs.blocksense.network/app/docs/contracts/integration-guide/using-data-feeds/chainlink-proxy/page.mdx
+++ b/apps/docs.blocksense.network/app/docs/contracts/integration-guide/using-data-feeds/chainlink-proxy/page.mdx
@@ -29,8 +29,7 @@ flowchart TD
   A[Client] -->|get feed's data| CP[CLAggregatorAdapter]
   CP -->|reads from| DFS[HistoricalDataFeedStore]
 
-  click CP "/docs/contracts/reference-documentation/CLAggregatorAdapter" "Go to CLAggregatorAdapter"
-  click DFS "/docs/contracts/reference-documentation/HistoricalDataFeedStoreV2" "Go to HistoricalDataFeedStoreV2"
+  click CP "/docs/contracts/reference-documentation/contract/CLAggregatorAdapter" "Go to CLAggregatorAdapter"
 
   class A clientNode
   class CP proxyNode

--- a/apps/docs.blocksense.network/app/docs/contracts/integration-guide/using-data-feeds/feed-registry/page.mdx
+++ b/apps/docs.blocksense.network/app/docs/contracts/integration-guide/using-data-feeds/feed-registry/page.mdx
@@ -31,8 +31,7 @@ flowchart TD
   A[Client] -->|get latest round data| FR[CLFeedRegistryAdapter]
   FR -->|reads from| DFS[HistoricalDataFeedStore]
 
-  click FR "/docs/contracts/reference-documentation/CLFeedRegistryAdapter" "Go to CLFeedRegistryAdapter"
-  click DFS "/docs/contracts/reference-documentation/HistoricalDataFeedStoreV2" "Go to HistoricalDataFeedStoreV2"
+  click FR "/docs/contracts/reference-documentation/contract/CLFeedRegistryAdapter" "Go to CLFeedRegistryAdapter"
 
   class A clientNode
   class FR feedNode

--- a/apps/docs.blocksense.network/app/docs/contracts/overview/page.mdx
+++ b/apps/docs.blocksense.network/app/docs/contracts/overview/page.mdx
@@ -35,10 +35,8 @@ graph TD
     C -->|delegatecall| D[HistoricalDataFeedStore]
     E[CLAggregatorAdapter] -->|staticcall| C
 
-    click B "/docs/contracts/reference-documentation/cl-feed-registry-adapter" "Go to CLFeedRegistryAdapter"
-    click C "/docs/contracts/reference-documentation/upgradeable-proxy" "Go to UpgradeableProxy"
-    click D "/docs/contracts/reference-documentation/historical-data-feed-store-v2" "Go to HistoricalDataFeedStoreV2"
-    click E "/docs/contracts/reference-documentation/cl-aggregator-adapter" "Go to CLAggregatorAdapter"
+    click B "/docs/contracts/reference-documentation/contract/CLFeedRegistryAdapter" "Go to CLFeedRegistryAdapter"
+    click E "/docs/contracts/reference-documentation/contract/CLAggregatorAdapter" "Go to CLAggregatorAdapter"
 
     class A clientNode
     class B,E feedNode


### PR DESCRIPTION
Since we’ve made changes to the `Reference Documentation`, we need to revise the links on pages with Mermaid diagrams and fix the links within them. 

In the next PRs we should also update the `structure of the diagrams`, as there are additional changes: `HistoricalDataFeedStoreV2` and `UpgradableProxy` no longer exist.