### PR TITLE
feat(docs.ws): Add focus states for elements after Nextra 4 migration

### DIFF
--- a/apps/docs.blocksense.network/blocksense-theme/base.css
+++ b/apps/docs.blocksense.network/blocksense-theme/base.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @import './variables.css';
+@import './states/focus.css';
 @import './font/font-face.css';
 @import './font/typography.css';
 @import './nextra.css';
@@ -9,10 +10,6 @@
 ::before,
 ::after {
   box-sizing: border-box;
-}
-
-*:focus {
-  outline: none;
 }
 
 .invert {

--- a/apps/docs.blocksense.network/blocksense-theme/states/focus.css
+++ b/apps/docs.blocksense.network/blocksense-theme/states/focus.css
@@ -1,0 +1,119 @@
+@import 'tailwindcss';
+
+*:focus,
+:focus-visible {
+  border: 1px solid var(--focus-border-color);
+  border-radius: 0.5rem;
+  outline: none;
+  outline-offset: 0;
+}
+
+button:focus:not(:focus-visible),
+a:focus:not(:focus-visible),
+input:focus:not(:focus-visible),
+textarea:focus:not(:focus-visible),
+ul:focus:not(:focus-visible),
+ol:focus:not(:focus-visible),
+.card:focus:not(:focus-visible),
+select:focus:not(:focus-visible),
+fieldset:focus:not(:focus-visible),
+details:focus:not(:focus-visible),
+summary:focus:not(:focus-visible),
+.callout:focus:not(:focus-visible) {
+  outline: none;
+}
+
+button:focus,
+a:focus,
+input:focus,
+textarea:focus,
+select:focus,
+fieldset:focus,
+.details:focus,
+.summary:focus,
+.card:focus,
+.callout:focus {
+  border-radius: 0.375rem;
+}
+
+input:focus,
+textarea:focus,
+select:focus,
+fieldset:focus {
+  border: 1px solid var(--focus-border-color);
+  border-radius: 0.375rem;
+}
+
+ul:focus,
+ol:focus {
+  outline: 1px solid var(--focus-border-color);
+  outline-offset: var(--focus-outline-offset);
+  border-radius: 0.375rem;
+}
+
+.card:focus,
+.card:focus-visible {
+  box-shadow: 0 0 0 4px var(--focus-border-color);
+  border-radius: 0.75rem;
+}
+
+details:focus,
+details:focus-visible,
+summary:focus,
+summary:focus-visible {
+  outline: 1px solid var(--focus-border-color);
+  outline-offset: 2px;
+}
+
+.callout:focus,
+.callout:focus-visible {
+  outline: 1px solid var(--focus-border-color);
+  outline-offset: 3px;
+  border-radius: 0.5rem;
+}
+
+.nextra-navbar ul li a:focus,
+.nextra-navbar ol li a:focus {
+  display: inline-block;
+  border: 1px solid var(--transparent-color);
+  padding: 0.25rem 0.5rem;
+  transition:
+    border-color 0.2s ease-in-out,
+    background-color 0.2s ease-in-out;
+}
+
+.nextra-navbar ul li a:active,
+.nextra-navbar ol li a:active {
+  border: 1px solid var(--focus-border-color);
+  outline: none;
+}
+
+.nextra-navbar ul li button:focus-visible,
+.nextra-navbar ol li button:focus-visible {
+  display: inline-block;
+  border: 1px solid var(--transparent-color);
+  border-radius: inherit;
+  padding: 0.25rem 0.5rem;
+  transition:
+    border-color 0.2s ease-in-out,
+    background-color 0.2s ease-in-out;
+}
+
+.nextra-navbar ul li a.x\\:focus-visible\\:nextra-focus,
+.nextra-navbar ol li a.x\\:focus-visible\\:nextra-focus,
+.nextra-navbar ul li a.x\\:focus\\:nextra-focus,
+.nextra-navbar ol li a.x\\:focus\\:nextra-focus {
+  border-color: var(--focus-border-color);
+}
+
+.link_button:focus,
+.link_button:focus-visible {
+  border: 1px solid var(--focus-border-color);
+  outline: none;
+}
+
+.nextra-filetree ul > li button:focus,
+.nextra-filetree ul > li button:focus-visible {
+  border: 1px solid var(--transparent-color);
+  outline: none;
+}

--- a/apps/docs.blocksense.network/blocksense-theme/variables.css
+++ b/apps/docs.blocksense.network/blocksense-theme/variables.css
@@ -26,4 +26,8 @@
   --breakpoint-xl: 1280px;
   --breakpoint-2xl: 1536px;
   --breakpoint-3xl: 1920px;
+
+  --focus-border-color: #2fa6ff;
+  --transparent-color: transparent;
+  --focus-outline-offset: 0;
 }

--- a/apps/docs.blocksense.network/components/ui/accordion.tsx
+++ b/apps/docs.blocksense.network/components/ui/accordion.tsx
@@ -13,7 +13,7 @@ const AccordionItem = React.forwardRef<
   <AccordionPrimitive.Item
     ref={ref}
     className={cn(
-      'border-b border-solid border border-slate-200 bg-slate-100 dark:bg-neutral-900 dark:border-neutral-600 px-1 py-0 mb-4',
+      'border-b border-solid border border-neutral-200 bg-slate-100 dark:bg-neutral-900 dark:border-neutral-600 px-1 py-0 mb-4',
       className,
     )}
     {...props}
@@ -29,7 +29,7 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        'accordion-item__trigger flex flex-1 items-center h-[36px] pb-[0.5rem] justify-between font-bold transition-all hover:underline [&[data-state=open]>svg]:rotate-180 focus:ring-0 focus:outline-none focus:border-transparent focus:text-blue-700',
+        'accordion-item__trigger flex flex-1 items-center h-[36px] pb-[0.5rem] justify-between font-bold transition-all hover:underline [&[data-state=open]>svg]:rotate-180 focus:ring-0 focus:outline-none focus:border-none focus:text-blue-700',
         className,
       )}
       {...props}
@@ -48,7 +48,7 @@ const AccordionContent = React.forwardRef<
   <AccordionPrimitive.Content
     ref={ref}
     className={cn(
-      'overflow-hidden text-sm transition-[max-height,opacity,padding] duration-500 ease-in-out',
+      'overflow-hidden text-sm transition-[max-height,opacity,padding] duration-500 ease-in-out border-none bg-transparent',
       'data-[state=closed]:max-h-0 data-[state=closed]:opacity-0 data-[state=closed]:p-0 data-[state=closed]:overflow-hidden',
       'data-[state=open]:max-h-[1540px] data-[state=open]:opacity-100',
       className,


### PR DESCRIPTION
Since we migrated to Nextra 4 and the rebrading process is knocking on the door, we needed to define some basic focus states so the user will be aware where the focus is where if it navigates with keyboard strokes. 
We haven't defined a specific focus states for light and dark, just picked common props that satisfy our needs for both themes.
![image](https://github.com/user-attachments/assets/5566cf7b-b9c7-4a92-b830-1f85e9c73c6a)
![image](https://github.com/user-attachments/assets/8f97abfc-3e96-42c7-961e-790f29f975f9)
 

