### PR TITLE
[docs.ws]: Fix `ABI` modal size

### DIFF
--- a/apps/docs.blocksense.network/blocksense-theme/base.css
+++ b/apps/docs.blocksense.network/blocksense-theme/base.css
@@ -100,10 +100,6 @@ main > h1 {
 }
 
 @layer components {
-  .scroll-area .signature__code {
-    @apply p-1;
-  }
-
   .announcement__icon,
   .error-404__icon,
   .error-500__icon {

--- a/apps/docs.blocksense.network/components/sol-contracts/ABIModal/ABIModal.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/ABIModal/ABIModal.tsx
@@ -61,7 +61,7 @@ export const ABIModal = ({ abi, name = '' }: ABIModalProps) => {
             <TriggerButton tooltipContent={title} />
           </section>
         </DialogTrigger>
-        <DialogContent className="h-4/6 max-w-screen-md">
+        <DialogContent className="max-w-screen-md">
           <DialogHeader>
             <section className="flex items-center justify-between px-2 pt-2 pb-0">
               <DialogTitle>{title}</DialogTitle>
@@ -72,14 +72,12 @@ export const ABIModal = ({ abi, name = '' }: ABIModalProps) => {
             </section>
             <DialogDescription />
           </DialogHeader>
-          <ScrollArea>
-            <aside className="scroll-area">
-              <CodeBlock
-                code={getABI()}
-                lang="json"
-                themes={shikiDefaultThemes.jsonThemes}
-              />
-            </aside>
+          <ScrollArea className="border border-neutral-200 dark:border-neutral-600 rounded-lg">
+            <CodeBlock
+              code={getABI()}
+              lang="json"
+              themes={shikiDefaultThemes.jsonThemes}
+            />
           </ScrollArea>
         </DialogContent>
       </Dialog>

--- a/apps/docs.blocksense.network/components/ui/dialog.tsx
+++ b/apps/docs.blocksense.network/components/ui/dialog.tsx
@@ -36,9 +36,9 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[68vh] translate-x-[-50%] translate-y-[-50%] gap-4 border border-neutral-200 bg-zinc-50 p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-xs-lg overflow-y-auto dark:bg-neutral-900 dark:border-neutral-600',
+        'fixed top-[15%] max-h-[70%] left-1/2 transform -translate-x-1/2 z-50 grid w-full max-w-lg gap-4 border border-neutral-200 bg-zinc-50 p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-xs-lg dark:bg-neutral-900 dark:border-neutral-600',
         className,
-        'h-auto min-h-[20%] max-h-[68vh] flex flex-col scroll-smooth',
+        'h-auto flex flex-col scroll-smooth',
       )}
       {...props}
     >


### PR DESCRIPTION

The `ABI` modal on desktop currently changes its size and position dynamically, especially when switching between `Format` and `Compact` modes. This results in inconsistent modal dimensions across different cases. To improve the user experience, the modal should have a fixed header on desktop to maintain visual stability.

This PR aims to fix the `ABI` header position, regardless of the selected option: `Format` or `Compact` mode. The height of the content varies depending on the selected option, `Format` or `Compact` mode.

* **Before :**

![B1](https://github.com/user-attachments/assets/e5dd5bcb-ed29-47e3-874c-90fc3596a974)

![B2](https://github.com/user-attachments/assets/0c81c623-16ce-49a0-9573-14d799329f71)

* **After :**

![A1](https://github.com/user-attachments/assets/a956db00-805b-4533-b969-4816bbe0ec5d)

![A2](https://github.com/user-attachments/assets/b5e6a5bb-a4e3-4420-8424-c772611c309c)




