### PR TITLE
[docs.ws]: Add data-pagefind-ignore to AnchorLinkTitle

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/AnchorLinkTitle.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/AnchorLinkTitle.tsx
@@ -1,10 +1,11 @@
-import React, { createElement } from 'react';
+import { createElement, HTMLAttributes } from 'react';
 
 type AnchorLinkTitleProps = {
   title?: string;
   parentTitle?: string;
   titleLevel?: 1 | 2 | 3 | 4 | 5 | 6;
   accordion?: boolean;
+  pagefindIgnore?: boolean;
 };
 
 const titleStyles = {
@@ -26,23 +27,28 @@ export const AnchorLinkTitle = ({
   parentTitle,
   titleLevel,
   accordion,
+  pagefindIgnore = false,
 }: AnchorLinkTitleProps) => {
-  return (
-    titleLevel &&
-    createElement(
-      `h${titleLevel}`,
-      {
-        className: `${titleStyles[titleLevel]} ${accordion ? accordionStyles : ''} nx-font-semibold nx-text-slate-900 dark:nx-text-slate-100 ${accordion ? '' : borderStyles}`,
-      },
-      <>
-        {title}
-        <a
-          href={`#${parentTitle ? `${parentTitle}-` : ''}${title}`}
-          id={`${parentTitle ? `${parentTitle}-` : ''}${title}`}
-          className="subheading-anchor"
-          aria-label="Permalink for this section"
-        ></a>
-      </>,
-    )
+  if (!titleLevel) {
+    return null;
+  }
+
+  const elementAttributes: HTMLAttributes<HTMLHeadingElement> = {
+    className: `${titleStyles[titleLevel]} ${accordion ? accordionStyles : ''} nx-font-semibold nx-text-slate-900 dark:nx-text-slate-100 ${accordion ? '' : borderStyles}`,
+    ...(pagefindIgnore && { 'data-pagefind-ignore': true }),
+  };
+
+  return createElement(
+    `h${titleLevel}`,
+    elementAttributes,
+    <>
+      {title}
+      <a
+        href={`#${parentTitle ? `${parentTitle}-` : ''}${title}`}
+        id={`${parentTitle ? `${parentTitle}-` : ''}${title}`}
+        className="subheading-anchor"
+        aria-label="Permalink for this section"
+      ></a>
+    </>,
   );
 };

--- a/apps/docs.blocksense.network/components/sol-contracts/ContractItemWrapper.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/ContractItemWrapper.tsx
@@ -24,6 +24,7 @@ export const ContractItemWrapper = ({
           title={title}
           parentTitle={parentTitle}
           titleLevel={titleLevel}
+          pagefindIgnore
         />
         <div className="contract-item-wrapper__content">{children}</div>
       </div>


### PR DESCRIPTION
Hide results from titles like “Variables”, “Functions” and etc. Each variable, function... can be found by it’s name.

[Removing individual elements from the index](https://pagefind.app/docs/indexing/#removing-individual-elements-from-the-index) - used attribute `data-pagefind-ignore` to not include the elements in search index.

Added `isDataPagefindIgnore` prop to `AnchorLinkTitle` and used it in `ContractItemWrapper` (reusable component for subtitles in each contract page).

**Before:**
![image](https://github.com/user-attachments/assets/9a2c511b-7594-4813-bbd0-68fab43eda9f)

**After:**
![image](https://github.com/user-attachments/assets/1a0d77e9-f51e-4dfc-9863-b86e26f27983)
