### PR TITLE
[docs.ws]: Remove prefix template from tab title

### DIFF
--- a/apps/docs.blocksense.network/app/layout.tsx
+++ b/apps/docs.blocksense.network/app/layout.tsx
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
   },
   title: {
     absolute: '',
-    template: 'Blocksense | %s ',
+    template: '%s',
   },
   icons: {
     icon: [

--- a/apps/docs.blocksense.network/app/page.tsx
+++ b/apps/docs.blocksense.network/app/page.tsx
@@ -5,7 +5,7 @@ import { gettingStartedConfig } from '@/config';
 import { LinkButton } from '@/components/common/LinkButton';
 
 export const metadata: Metadata = {
-  title: 'Blocksense | Home',
+  title: 'Home',
 };
 
 const IndexPage: FC = () => {

--- a/apps/docs.blocksense.network/theme.config.tsx
+++ b/apps/docs.blocksense.network/theme.config.tsx
@@ -21,7 +21,7 @@ export default {
   },
   useNextSeoProps() {
     return {
-      titleTemplate: 'Blocksense | %s',
+      titleTemplate: '%s',
     };
   },
   head: (


### PR DESCRIPTION
Removed `Blocksense |` prefix/template from each page - tab title

**Before:**
![image](https://github.com/user-attachments/assets/0ee97d95-c1c7-41bd-b036-cdb7bf26052e)

**After:**
![image](https://github.com/user-attachments/assets/e408263a-356d-42f1-b43b-25c2f9909e23)
