### PR TITLE
feat(sequencer): Add option to peg stable coins per provider

### DIFF
--- a/apps/sequencer/src/feeds/feed_slots_processor.rs
+++ b/apps/sequencer/src/feeds/feed_slots_processor.rs
@@ -149,6 +149,8 @@ impl FeedSlotsProcessor {
                             feed_id,
                             skip_publish_if_less_then_percentage,
                             always_publish_heartbeat_ms,
+                            peg_to_value: None,
+                            peg_tolerance_percentage: 0.0f64,
                         };
                         let update = VotedFeedUpdate {
                             feed_id,

--- a/libs/data_feeds/src/feeds_processing.rs
+++ b/libs/data_feeds/src/feeds_processing.rs
@@ -159,18 +159,24 @@ mod tests {
             feed_id,
             skip_publish_if_less_then_percentage: 0.0f64,
             always_publish_heartbeat_ms: None,
+            peg_to_value: None,
+            peg_tolerance_percentage: 0.0f64,
         };
 
         let one_percent_threshold = PublishCriteria {
             feed_id,
             skip_publish_if_less_then_percentage: 1.0f64,
             always_publish_heartbeat_ms: None,
+            peg_to_value: None,
+            peg_tolerance_percentage: 0.0f64,
         };
 
         let always_publish_every_second = PublishCriteria {
             feed_id,
             skip_publish_if_less_then_percentage: 1000.0f64,
             always_publish_heartbeat_ms: Some(1000_u128),
+            peg_to_value: None,
+            peg_tolerance_percentage: 0.0f64,
         };
 
         // No history

--- a/nix/modules/sequencer/sequencer-opts.nix
+++ b/nix/modules/sequencer/sequencer-opts.nix
@@ -89,6 +89,16 @@ let
         default = 3600000;
         description = mdDoc "Interval to always publuish updates if there is not enough change";
       };
+      peg_to_value = mkOption {
+        type = types.nullOr types.float;
+        default = null;
+        description = mdDoc "This option is designed for stable coins. They get pegged to this value, if the reported value falls in a percentage window around the pegged value";
+      };
+      peg_tolerance_percentage = mkOption {
+        type = types.float;
+        default = 0.0;
+        description = mdDoc "This option is designed for stable coins. Defines a tolerance window around the pegged value.";
+      };
     };
   };
 

--- a/nix/test-environments/example-setup-01.nix
+++ b/nix/test-environments/example-setup-01.nix
@@ -83,8 +83,22 @@ in
             }
             {
               feed_id = 47;
-              skip_publish_if_less_then_percentage = 0.01;
+              skip_publish_if_less_then_percentage = 0.1;
               always_publish_heartbeat_ms = 360000;
+            }
+            {
+              feed_id = 131;
+              skip_publish_if_less_then_percentage = 0.1;
+              always_publish_heartbeat_ms = 360000;
+              peg_to_value = 1.00;
+              peg_tolerance_percentage = 0.2;
+            }
+            {
+              feed_id = 236;
+              skip_publish_if_less_then_percentage = 0.5;
+              always_publish_heartbeat_ms = 360000;
+              peg_to_value = 1.00;
+              peg_tolerance_percentage = 0.1;
             }
           ];
           impersonated_anvil_account = impersonationAddress;


### PR DESCRIPTION
Add option to peg stable coins per provider

We want to be able to update a stable coin feed when depegging event occurs and keep the value pagged during the normal time. Some history

In March 2023, two leading stablecoins, USDC and DAI, depegged because of the collapse of three US banks: Silicon Valley Bank (SVB), Signature Bank, and Silvergate Bank. USDC issuer Circle disclosed that $3.3 billion of the cash reserves used to collaterize the stablecoin were held at SVB. As a result, USDC temporarily lost its peg, dropping over 12% in a single day.


