### PR TITLE
fix(docs.ws): Search results are not enough visible with Nextra 4 and Pagefind

### DIFF
--- a/apps/docs.blocksense.network/blocksense-theme/dark.css
+++ b/apps/docs.blocksense.network/blocksense-theme/dark.css
@@ -67,3 +67,11 @@
 .dark .nextra-sidebar button:hover {
   @apply text-white transition duration-300 ease-in-out;
 }
+
+.dark .x\:text-base {
+  @apply text-white;
+}
+
+.dark mark {
+  @apply text-blue-500 font-bold;
+}

--- a/apps/docs.blocksense.network/blocksense-theme/nextra.css
+++ b/apps/docs.blocksense.network/blocksense-theme/nextra.css
@@ -19,3 +19,11 @@
 .nextra-filetree {
   @apply shadow-md;
 }
+
+.x\:text-base {
+  @apply text-black;
+}
+
+mark {
+  @apply text-blue-700 font-bold;
+}


### PR DESCRIPTION
The purpose of this task is to fix the white-on-white behavior on hover and improve the readability of the matched terms.

**Issue:** 
![image](https://github.com/user-attachments/assets/bce5a2c7-e0a3-484a-a497-aeb1093c637a)

It's deceivengly unusal that it's fine on dark theme, but the readability of the matching string is also bad.

This PR introduces a short fix for this problem, because styling with server component is a dangerous game to play.

After reviewing many options, including the edit of the search component itself, the changes listed into this PR are safe and sound.

**After:**

![image](https://github.com/user-attachments/assets/f4376ed1-eaf9-4bd6-98c7-3dfc1eb61fc1)

![image](https://github.com/user-attachments/assets/876c706d-4c23-428a-9151-8f6efb70de7d)


