### PR TITLE
[docs.ws]: Add dynamic tab tile for data feed

### DIFF
--- a/apps/docs.blocksense.network/app/docs/data-feeds/feed/[feed]/page.mdx
+++ b/apps/docs.blocksense.network/app/docs/data-feeds/feed/[feed]/page.mdx
@@ -1,11 +1,25 @@
----
-title: 'Data Feed'
----
+import { decodeFeedsConfig } from '@blocksense/config-types/data-feeds-config';
+import DATA_FEEDS from '@blocksense/data-feeds-config-generator/feeds_config';
 
-import React from 'react';
 import DataFeedPage, { generateStaticParams } from '@/components/DataFeeds/[feed]';
 
 export { generateStaticParams };
+
+export async function generateMetadata({ params }) {
+  const { feed: feedId } = await params;
+  let metadata = { title: 'Data Feed' };
+
+  if (feedId) {
+    const feedsConfig = decodeFeedsConfig(DATA_FEEDS);
+    const feed = feedsConfig.feeds.find(feed => feed.id === Number(feedId));
+
+    if (feed) {
+      metadata = { title: `${feed.description} | ID: ${feed.id}` };
+    }
+  }
+
+  return metadata;
+}
 
 export default function FeedPage({ params }) {
   return <DataFeedPage params={params} />;

--- a/apps/docs.blocksense.network/components/DataFeeds/[feed].tsx
+++ b/apps/docs.blocksense.network/components/DataFeeds/[feed].tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import DATA_FEEDS from '@blocksense/data-feeds-config-generator/feeds_config';
 import CONTRACTS_DEPLOYMENT_CONFIG from '@blocksense/data-feeds-config-generator/evm_contracts_deployment_v1';
-import {
-  decodeFeedsConfig,
-  Feed,
-} from '@blocksense/config-types/data-feeds-config';
+import { decodeFeedsConfig } from '@blocksense/config-types/data-feeds-config';
 import {
   CLAggregatorAdapterData,
   decodeDeploymentConfig,


### PR DESCRIPTION
Wrote the name and id `description | ID: id` of each data feed instead of static `Data Feed` string in tab title.

Used Next.js' async [generateMetadata()](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#async-function) with segment props and finding the specific data feed. Same approach as in the contracts, PR - [[docs.ws]: Correct contract param & show in search](https://github.com/blocksense-network/blocksense/pull/829)

After / Before
![image](https://github.com/user-attachments/assets/cdd3b8f6-3ead-4021-b528-d030ddc33164)