### PR TITLE
fix(docs.ws): Some shadcn-ui components are losing border on light mode, after Nextra 4 integration

### DIFF
--- a/apps/docs.blocksense.network/components/ui/DataTable/DataTableFacetedFilter.tsx
+++ b/apps/docs.blocksense.network/components/ui/DataTable/DataTableFacetedFilter.tsx
@@ -50,7 +50,7 @@ export function DataTableFacetedFilter<TData, TValue>({
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[200px] p-0 bg-white dark:bg-neutral-900"
+        className="w-[200px] p-0 border border-solid border-neutral-200 bg-white dark:bg-neutral-900 dark:border-neutral-600"
         align="start"
       >
         <Command className="py-2">

--- a/apps/docs.blocksense.network/components/ui/badge.tsx
+++ b/apps/docs.blocksense.network/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2.5 py-0.5 mr-4 mt-4 mb-4 text-sm font-semibold transition-colors hover:bg-neutral-50 hover:border-gray-600 focus:ring-1 focus:ring-gray-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border border-gray-200 rounded-md  dark:bg-neutral-900 dark:border-neutral-600 dark:hover:bg-black',
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 mr-4 mt-4 mb-4 text-sm font-semibold border-neutral-200 transition-colors hover:bg-neutral-50 hover:border-gray-300 focus:ring-1 focus:ring-gray-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border border-gray-200 rounded-md  dark:bg-neutral-900 dark:border-neutral-600 dark:hover:bg-black',
   {
     variants: {
       variant: {

--- a/apps/docs.blocksense.network/components/ui/button.tsx
+++ b/apps/docs.blocksense.network/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors disabled:pointer-events-none disabled:opacity-50 focus:ring-1 focus:ring-gray-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border border-gray-200 rounded-md',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors disabled:pointer-events-none disabled:opacity-50 focus:ring-1 focus:ring-gray-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border border-neutral-200 rounded-md',
   {
     variants: {
       variant: {

--- a/apps/docs.blocksense.network/components/ui/card.tsx
+++ b/apps/docs.blocksense.network/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'rounded-lg border bg-card max-w-96 mt-10 text-card-foreground shadow-sm dark:bg-neutral-900 dark:border-neutral-600 dark:text-white',
+      'rounded-lg border bg-card max-w-96 mt-10 text-card-foreground shadow-sm border-neutral-200 dark:bg-neutral-900 dark:border-neutral-600 dark:text-white',
       className,
     )}
     {...props}

--- a/apps/docs.blocksense.network/components/ui/command.tsx
+++ b/apps/docs.blocksense.network/components/ui/command.tsx
@@ -40,7 +40,7 @@ const CommandInput = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
   <div
-    className="flex items-center border-b px-3 bg-red dark:bg-neutral-900"
+    className="flex items-center border-b px-3 border-neutral-200 bg-white dark:bg-neutral-900 dark:border-neutral-600"
     cmdk-input-wrapper=""
   >
     <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />

--- a/apps/docs.blocksense.network/components/ui/dropdown-menu.tsx
+++ b/apps/docs.blocksense.network/components/ui/dropdown-menu.tsx
@@ -63,7 +63,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:bg-neutral-900 dark:border-neutral-600 dark:text-white',
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground border-neutral-200 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:bg-neutral-900 dark:border-neutral-600 dark:text-white',
         className,
       )}
       {...props}

--- a/apps/docs.blocksense.network/components/ui/input.tsx
+++ b/apps/docs.blocksense.network/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 focus:ring-1 focus:ring-gray-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border-gray-200 dark:bg-neutral-900 dark:border-neutral-600 dark:text-white',
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 focus:ring-1 focus:ring-gray-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border-neutral-200 dark:bg-neutral-900 dark:border-neutral-600 dark:text-white',
           className,
         )}
         ref={ref}

--- a/apps/docs.blocksense.network/components/ui/separator.tsx
+++ b/apps/docs.blocksense.network/components/ui/separator.tsx
@@ -16,7 +16,7 @@ const Separator = React.forwardRef<
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        'shrink-0 bg-border',
+        'shrink-0 bg-border border-neutral-200 dark:border-neutral-600',
         orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
         className,
       )}

--- a/apps/docs.blocksense.network/components/ui/switch.tsx
+++ b/apps/docs.blocksense.network/components/ui/switch.tsx
@@ -9,7 +9,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus:ring-1 focus:ring-neutral-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border-neutral-200 dark:border-neutral-600',
+      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border transition-colors focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus:ring-1 focus:ring-neutral-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border-neutral-200 dark:border-neutral-600',
       className,
     )}
     {...props}

--- a/apps/docs.blocksense.network/components/ui/tabs.tsx
+++ b/apps/docs.blocksense.network/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-xs px-3 py-1.5 mb-2 text-sm font-medium ring-offset-background transition-all disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm focus:ring-1 focus:ring-gray-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border border-gray-200',
+      'inline-flex items-center justify-center whitespace-nowrap rounded-xs px-3 py-1.5 mb-2 text-sm font-medium ring-offset-background transition-all disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm focus:ring-1 focus:ring-gray-300 focus:ring-offset-0 focus:ring-opacity-100 focus:ring-offset-transparent focus:ring-offset-none focus:shadow-sm border border-neutral-200',
       className,
     )}
     {...props}


### PR DESCRIPTION
During the integration of Nextra 4 and development of light/dark modes, some shadcn-ui components are losing their defayult border and appear with black border. 
Examples of such components and this undesired side effect across the documentation):

**Before:**
![image](https://github.com/user-attachments/assets/19c0e87c-4335-49bf-b595-c0eda7dd9d1d)

**After:**
![image](https://github.com/user-attachments/assets/d30b3848-69a9-481e-b618-b04cedeb4b69)



