### PR TITLE
fix(docs.ws): Fix styles of Nextra nav elements outside of the theme

### DIFF
--- a/apps/docs.blocksense.network/blocksense-theme/base.css
+++ b/apps/docs.blocksense.network/blocksense-theme/base.css
@@ -65,9 +65,12 @@ main > h1 {
     @apply mt-2;
   }
 
-  header span,
   footer span {
     @apply font-bold;
+  }
+
+  header span {
+    font-family: var(--font-mono-space-bold);
   }
 
   @media (max-width: 600px) {

--- a/apps/docs.blocksense.network/blocksense-theme/nextra.css
+++ b/apps/docs.blocksense.network/blocksense-theme/nextra.css
@@ -27,3 +27,19 @@
 mark {
   @apply text-blue-700 font-bold;
 }
+
+.nextra-navbar-blur {
+  border-color: var(--transparent-color);
+}
+
+.nextra-search input {
+  @apply bg-white border border-solid border-neutral-200 dark:bg-neutral-900 dark:border-neutral-600;
+}
+
+.nextra-search input:focus,
+.nextra-search input:focus-visible {
+  border-color: var(--focus-border-color);
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}

--- a/apps/docs.blocksense.network/blocksense-theme/variables.css
+++ b/apps/docs.blocksense.network/blocksense-theme/variables.css
@@ -19,6 +19,7 @@
   --font-extra-bold: 'Noto Sans Extra Bold', sans-serif;
   --font-black: 'Noto Sans Black', sans-serif;
   --font-mono: 'Fira Code', monospace;
+  --font-mono-space-bold: 'Space Mono Bold', monospace;
 
   --breakpoint-sm: 640px;
   --breakpoint-md: 768px;


### PR DESCRIPTION
We needed to apply some adjustments so the layout of nav against Nextra 4 will look nicely updated.

**Before:**
![image](https://github.com/user-attachments/assets/8fbd3f44-caf4-49db-adc6-d772d663ddbe)

**After:**
![image](https://github.com/user-attachments/assets/4af182dc-59f3-49eb-9239-083dd5bda86c)
