### PR TITLE
feat(docs.ws): Update and style Nextra 4 breadcrumb component 

### DIFF
--- a/apps/docs.blocksense.network/blocksense-theme/dark.css
+++ b/apps/docs.blocksense.network/blocksense-theme/dark.css
@@ -75,3 +75,27 @@
 .dark mark {
   @apply text-blue-500 font-bold;
 }
+
+.dark .nextra-breadcrumb__item:hover {
+  @apply text-neutral-300;
+}
+
+.dark .nextra-breadcrumb__item--active {
+  @apply text-blue-500;
+}
+
+.dark .nextra-breadcrumb__item--inactive {
+  @apply text-gray-300;
+}
+
+.dark .nextra-breadcrumb__item--active:hover {
+  @apply text-neutral-100;
+}
+
+.dark .nextra-breadcrumb__link {
+  @apply text-white;
+}
+
+.dark .nextra-breadcrumb__link--active {
+  @apply text-neutral-300 underline underline-offset-4;
+}

--- a/apps/docs.blocksense.network/blocksense-theme/font/typography.css
+++ b/apps/docs.blocksense.network/blocksense-theme/font/typography.css
@@ -35,7 +35,7 @@
   }
 
   a {
-    @apply text-blue-700;
+    @apply text-blue-500;
     font-family: var(--font-sans);
   }
 

--- a/apps/docs.blocksense.network/blocksense-theme/nextra.css
+++ b/apps/docs.blocksense.network/blocksense-theme/nextra.css
@@ -25,7 +25,7 @@
 }
 
 mark {
-  @apply text-blue-700 font-bold;
+  @apply text-blue-500 font-bold;
 }
 
 .nextra-navbar {
@@ -50,4 +50,28 @@ mark {
   box-shadow:
     0 4px 6px -1px rgba(0, 0, 0, 0.1),
     0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}
+
+.nextra-breadcrumb__item:hover {
+  @apply text-gray-900;
+}
+
+.nextra-breadcrumb__item--active {
+  @apply text-blue-500;
+}
+
+.nextra-breadcrumb__item--inactive {
+  @apply text-gray-300;
+}
+
+.nextra-breadcrumb__item--active:hover {
+  @apply text-gray-950;
+}
+
+.nextra-breadcrumb__link {
+  @apply text-gray-800 underline underline-offset-4;
+}
+
+.nextra-breadcrumb__link--active {
+  @apply underline underline-offset-4;
 }

--- a/libs/ts/nextra-theme-docs/src/components/breadcrumb.tsx
+++ b/libs/ts/nextra-theme-docs/src/components/breadcrumb.tsx
@@ -34,7 +34,7 @@ export const Breadcrumb: FC<{ activePath: Item[] }> = ({ activePath }) => {
             )}
             <ComponentToUse
               className={cn(
-                'nextra-breadcrumb__item x:transition-colors x:min-w-0 x:max-w-[150px] sm:x:max-w-[200px] md:x:max-w-[250px] x:overflow-hidden x:break-words',
+                'nextra-breadcrumb__item x:py-1 x:transition-colors x:min-w-0 x:max-w-[150px] sm:x:max-w-[200px] md:x:max-w-[250px] x:overflow-hidden x:break-words',
                 isLastItem
                   ? 'nextra-breadcrumb__item--active x:font-bold x:text-gray-700 x:dark:text-gray-100'
                   : 'x:min-w-6 x:overflow-hidden x:font-medium x:dark:text-gray-600/75',


### PR DESCRIPTION
This PR introduces several changes to Nextra Breadcrumb component after Nextra 4 migration.

The breadcrumb component now has several BEM classes that improves maintainability and readability.

- **`nextra-breadcrumb`** – Block for the breadcrumb container.
- **`nextra-breadcrumb__item`** – General breadcrumb item.
- **`nextra-breadcrumb__item--active`** – Highlights the last/current breadcrumb item.
- **`nextra-breadcrumb__icon`** – Styles the arrow separator between breadcrumb items.
- **`nextra-breadcrumb__link`** – Styles clickable breadcrumb links.
- **`nextra-breadcrumb__link--inactive`** – Styles non-clickable breadcrumb items.

### Updated Styles for Light & Dark Modes

Breadcrumb items dynamically adjust colors based on light or dark mode with our own styles.

- **`nextra-breadcrumb__link--active`** in dark mode now has a persistent underline for better accessibility.
- Hover effects have been refined for improved visual clarity.

### Mobile & UX Improvements

- **No more clipping** – Breadcrumb items no longer get cut off on smaller screens.
- **Better spacing** – Added proper alignment and readability across different devices.
- **Overall UX experience** improved with clearer navigation hierarchy.

![image](https://github.com/user-attachments/assets/c03e79d8-7b2f-40eb-9836-f44375875c46)
![image](https://github.com/user-attachments/assets/af410548-ea3a-4073-a724-8e1c04f9eaf8)

![image](https://github.com/user-attachments/assets/0605ee08-4ba4-4bba-bf16-f1ae76861adb)
![image](https://github.com/user-attachments/assets/7621b5f5-7cec-4b79-aad9-b576ead1e037)

