### PR TITLE
feat(docs.ws):  Update Nextra sidebar component based on wider content elements

### DIFF
--- a/libs/ts/nextra-theme-docs/src/components/sidebar.tsx
+++ b/libs/ts/nextra-theme-docs/src/components/sidebar.tsx
@@ -393,7 +393,7 @@ export const Sidebar: FC<{ toc: Heading[] }> = ({ toc }) => {
   return (
     <>
       {includePlaceholder && hideSidebar && (
-        <div className="x:max-xl:hidden x:h-0 x:w-64 x:shrink-0" />
+        <div className="x:max-xl:hidden x:h-0 x:w-68 x:shrink-0" />
       )}
       <aside
         id={sidebarControlsId}
@@ -403,7 +403,7 @@ export const Sidebar: FC<{ toc: Heading[] }> = ({ toc }) => {
           'x:max-md:hidden x:flex x:flex-col',
           'x:h-[calc(100dvh-var(--nextra-menu-height))]',
           'x:top-(--nextra-navbar-height) x:shrink-0',
-          isExpanded ? 'x:w-64' : 'x:w-20',
+          isExpanded ? 'x:w-68' : 'x:w-20',
           hideSidebar ? 'x:hidden' : 'x:sticky',
         )}
       >


### PR DESCRIPTION
We needed to extend a bit Nextra sidebar container after Nextra 4 migration, when it has wider elements.

**Before:**
![image](https://github.com/user-attachments/assets/087c0cfb-229a-45ba-853c-c8a54647aa96)

**After:**
![image](https://github.com/user-attachments/assets/8f1f3a85-c3ac-4ec3-a6ec-6f85d83ba6e4)
