### PR TITLE
[docs.ws]: Update the `ABI Drawer` for mobile

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/ABIModal/ABIModal.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/ABIModal/ABIModal.tsx
@@ -93,7 +93,7 @@ export const ABIModal = ({ abi, name = '' }: ABIModalProps) => {
       </DrawerTrigger>
       <DrawerContent>
         <DrawerHeader>
-          <section className="flex items-center justify-between px-4 py-2">
+          <section className="flex items-center justify-between text-left pl-2 pb-2">
             <DrawerTitle>{title}</DrawerTitle>
             <FormatButton
               isFormatted={isFormatted}
@@ -102,13 +102,13 @@ export const ABIModal = ({ abi, name = '' }: ABIModalProps) => {
           </section>
           <DrawerDescription />
         </DrawerHeader>
-        <div className="max-h-96 overflow-y-scroll pb-6">
+        <ScrollArea className="border border-neutral-200 dark:border-neutral-600 rounded-md mx-4 mb-4">
           <CodeBlock
             code={getABI()}
             lang="json"
-            themes={{ light: 'github-light', dark: 'vitesse-dark' }}
+            themes={shikiDefaultThemes.jsonThemes}
           />
-        </div>
+        </ScrollArea>
       </DrawerContent>
     </Drawer>
   );

--- a/apps/docs.blocksense.network/components/ui/drawer.tsx
+++ b/apps/docs.blocksense.network/components/ui/drawer.tsx
@@ -42,12 +42,12 @@ const DrawerContent = React.forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[6px] border border-neutral-200 bg-zinc-50 dark:bg-neutral-900 dark:border-neutral-600',
+        'fixed inset-x-1.5 bottom-0 z-50 flex h-[52vh] flex-col rounded-t-[4px] border border-neutral-200 bg-zinc-50 dark:bg-neutral-900 dark:border-neutral-600',
         className,
       )}
       {...props}
     >
-      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      <div className="mx-auto h-1 w-[100px] rounded-full bg-muted" />
       {children}
     </DrawerPrimitive.Content>
   </DrawerPortal>
@@ -59,7 +59,7 @@ const DrawerHeader = ({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn('grid gap-1.5 p-4 text-center sm:text-left', className)}
+    className={cn('grid gap-1 p-2 text-center sm:text-left', className)}
     {...props}
   />
 );
@@ -83,7 +83,7 @@ const DrawerTitle = React.forwardRef<
   <DrawerPrimitive.Title
     ref={ref}
     className={cn(
-      'text-lg font-semibold leading-none tracking-tight',
+      'text-md font-semibold leading-none tracking-tight',
       className,
     )}
     {...props}


### PR DESCRIPTION
This PR aims to update the `ABI Drawer` component for mobile to enhance overall content visibility, improve the arrangement of the header content, remove unnecessary white spaces, and refine the `UI`.
The `ABI header` position remains fixed, regardless of the selected option: `Format` or `Compact` mode.

* **Before :**

![Screenshot from 2025-02-05 14-04-48](https://github.com/user-attachments/assets/1f709498-de91-4d39-b078-6f6f8fd29865)

![Screenshot from 2025-02-05 14-04-54](https://github.com/user-attachments/assets/998c699e-208e-473e-ad8a-f687f84f0046)

* **After :**

![Screenshot from 2025-02-06 16-42-04](https://github.com/user-attachments/assets/cc48149b-7448-43cc-be0a-2c9facac0ed1)

![Screenshot from 2025-02-06 16-42-13](https://github.com/user-attachments/assets/880c40db-2950-4936-82a3-9b349f0a4da1)