### PR TITLE
feat(docs.ws): Update Nextra pagination and reduce space around main content

### DIFF
--- a/apps/docs.blocksense.network/blocksense-theme/dark.css
+++ b/apps/docs.blocksense.network/blocksense-theme/dark.css
@@ -99,3 +99,23 @@
 .dark .nextra-breadcrumb__link--active {
   @apply text-neutral-300 underline underline-offset-4;
 }
+
+.dark .pagination__link:hover {
+  @apply text-neutral-300;
+}
+
+.dark .pagination__link--prev {
+  @apply text-gray-300;
+}
+
+.dark .pagination__link--prev:hover {
+  @apply text-white;
+}
+
+.dark .pagination__link--next {
+  @apply text-blue-500;
+}
+
+.dark .pagination__link--next:hover {
+  @apply text-blue-700;
+}

--- a/apps/docs.blocksense.network/blocksense-theme/nextra.css
+++ b/apps/docs.blocksense.network/blocksense-theme/nextra.css
@@ -75,3 +75,19 @@ mark {
 .nextra-breadcrumb__link--active {
   @apply underline underline-offset-4;
 }
+
+.pagination__link {
+  @apply text-gray-900;
+}
+
+.pagination__link:hover {
+  @apply text-gray-800;
+}
+
+.pagination__link--prev {
+  @apply text-gray-500;
+}
+
+.pagination__link--next {
+  @apply text-blue-500;
+}

--- a/libs/ts/nextra-theme-docs/src/components/pagination.tsx
+++ b/libs/ts/nextra-theme-docs/src/components/pagination.tsx
@@ -7,12 +7,13 @@ import { useConfig, useThemeConfig } from '../stores';
 
 const classes = {
   link: cn(
+    'pagination__link',
     'x:focus-visible:nextra-focus x:text-gray-600 x:dark:text-gray-400',
     'x:hover:text-gray-800 x:dark:hover:text-gray-200',
     'x:contrast-more:text-gray-700 x:contrast-more:dark:text-gray-100',
-    'x:flex x:max-w-[50%] x:items-center x:gap-1 x:py-4 x:text-base x:font-medium x:transition-colors x:[word-break:break-word] x:md:text-lg',
+    'x:flex x:max-w-[50%] x:items-center x:gap-1 x:py-4 x:text-sm x:font-medium x:transition-colors x:[word-break:break-word]',
   ),
-  icon: cn('x:inline x:shrink-0'),
+  icon: cn('pagination__icon', 'x:inline x:shrink-0'),
 };
 
 export const Pagination: FC = () => {
@@ -30,6 +31,7 @@ export const Pagination: FC = () => {
   return (
     <div
       className={cn(
+        'pagination',
         'x:mb-8 x:flex x:items-center x:border-t x:pt-8 nextra-border',
         'x:print:hidden',
       )}
@@ -38,11 +40,17 @@ export const Pagination: FC = () => {
         <NextLink
           href={prev.route}
           title={prev.title}
-          className={cn(classes.link, 'x:pe-4')}
+          className={cn(
+            classes.link,
+            'pagination__link--prev x:pe-4 x:dark:text-gray-600/75',
+          )}
         >
           <ArrowRightIcon
             height="20"
-            className={cn(classes.icon, 'x:ltr:rotate-180')}
+            className={cn(
+              classes.icon,
+              'pagination__icon--prev x:ltr:rotate-180',
+            )}
           />
           {prev.title}
         </NextLink>
@@ -51,12 +59,18 @@ export const Pagination: FC = () => {
         <NextLink
           href={next.route}
           title={next.title}
-          className={cn(classes.link, 'x:ps-4 x:ms-auto x:text-end')}
+          className={cn(
+            classes.link,
+            'pagination__link--next x:ps-4 x:ms-auto x:text-end',
+          )}
         >
           {next.title}
           <ArrowRightIcon
             height="20"
-            className={cn(classes.icon, 'x:rtl:rotate-180')}
+            className={cn(
+              classes.icon,
+              'pagination__icon--next x:rtl:rotate-180',
+            )}
           />
         </NextLink>
       )}

--- a/libs/ts/nextra-theme-docs/src/mdx-components/wrapper.client.tsx
+++ b/libs/ts/nextra-theme-docs/src/mdx-components/wrapper.client.tsx
@@ -45,7 +45,7 @@ export const ClientWrapper: MDXWrapper = ({
       <article
         className={cn(
           'x:w-full x:min-w-0 x:break-words x:min-h-[calc(100vh-var(--nextra-navbar-height))]',
-          'x:text-slate-700 x:dark:text-slate-200 x:pb-8 x:px-6 x:pt-4 x:md:px-12',
+          'x:text-slate-700 x:dark:text-slate-200 x:px-6 x:pb-8 x:pt-4',
           themeContext.typesetting === 'article' &&
             'nextra-body-typesetting-article',
         )}


### PR DESCRIPTION
After Nextra 4 migration these are the next items to be updated in order to improve the layout.
- [x] Reduced horizontal space around main content, so we will have more space after:
 https://github.com/blocksense-network/blocksense/pull/852
- [x] Applied BEM naming conventions to pagination classes  
- [x] Added relevant styles for pagination, matching breadcrumb styles  
- [x] Implemented states for pagination link, relative to light and dark modes.
- [x] Reduced the size of pagination links, so they will be relative to those into the breadcrumb.

**Before:**
![image](https://github.com/user-attachments/assets/dc51911f-d6c0-4195-8542-39d1d1cf32e1)

**After:**
![image](https://github.com/user-attachments/assets/ff699303-a42c-4117-8d2d-698ca26fd556)

**Before:**
![image](https://github.com/user-attachments/assets/9034ab0a-47b1-47f4-891b-6bd9634b64cf)

**After:**
![image](https://github.com/user-attachments/assets/63f837bf-b631-46e8-beb3-499498eab37f)

