### PR TITLE
feat(docs.ws): Alter CopyButton style to match better changes after Nextra 4 migration

### DIFF
--- a/apps/docs.blocksense.network/components/common/CodeBlock.tsx
+++ b/apps/docs.blocksense.network/components/common/CodeBlock.tsx
@@ -59,7 +59,7 @@ export const CodeBlock = ({
         <CopyButton
           textToCopy={code}
           tooltipPosition="left"
-          copyButtonClasses="absolute top-4 right-2 m-2"
+          copyButtonClasses="absolute top-2 right-2 m-2"
           disabled={copy.disabled}
         />
       )}

--- a/apps/docs.blocksense.network/components/common/CopyButton.tsx
+++ b/apps/docs.blocksense.network/components/common/CopyButton.tsx
@@ -35,7 +35,9 @@ export const CopyButton = ({
     : null;
 
   return (
-    <aside className={`signature__copy-button z-5 ${copyButtonClasses}`}>
+    <aside
+      className={`signature__copy-button z-5 border ms-auto rounded-sm border-neutral-200 bg-slate-50 dark:bg-neutral-900 dark:border-neutral-600 flex items-center justify-center w-8 h-8 ${copyButtonClasses}`}
+    >
       <Tooltip position={tooltipPosition}>
         <Tooltip.Content>
           <span>{isCopied ? 'Copied' : 'Copy'}</span>
@@ -44,13 +46,13 @@ export const CopyButton = ({
           <ImageWrapper
             src="/icons/check.svg"
             alt="Copied"
-            className="relative w-5 h-5 invert"
+            className="w-4 h-4 invert"
           />
         ) : (
           <ImageWrapper
             src="/icons/clipboard.svg"
             alt="Clipboard"
-            className="relative w-5 h-5 cursor-pointer invert"
+            className="w-4 h-4 cursor-pointer invert"
             onClick={onCopy}
           />
         )}

--- a/apps/docs.blocksense.network/components/common/Tooltip.tsx
+++ b/apps/docs.blocksense.network/components/common/Tooltip.tsx
@@ -57,7 +57,9 @@ export const Tooltip = ({
           )}
         >
           {content?.props.children}
-          <div className={`absolute ${arrowClasses[position]} border-solid`} />
+          <div
+            className={`absolute ${arrowClasses[position]} invert border-solid`}
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
Before Nextra 4 migration, copy button was transparent. Since we're supporting light/system/dark modes, we needed a background. Changes included into this PR:

- [x] Adjust the position of the CopyButton within the CodeBlock  
- [x] Update the style of the CopyButton  
- [x] Modify the tooltip component to prevent the arrow from being black on dark themes  
- [x] Set the copy button size to `w-8 h-8` for better appearance  
- [x] Adjust the icon size to `w-4 h-4` within the button  
- [x] Ensure previous `w-5 h-5` ratio is corrected  
- [x] Avoid using `w-10 h-10` as it is too large if we sticked to `w-5 and h-5`
