### PR TITLE
[docs.ws]: Reduce the `width` of the `main` content

### DIFF
--- a/apps/docs.blocksense.network/app/layout.tsx
+++ b/apps/docs.blocksense.network/app/layout.tsx
@@ -89,7 +89,7 @@ const RootLayout: FC<{ children: ReactNode }> = async ({ children }) => {
           type="image/png"
         />
       </NextHead>
-      <body className="md:px-4 lg:px-10 dark:bg-neutral-900 dark:text-neutral-300">
+      <body className="md:px-4 lg:px-30 dark:bg-neutral-900 dark:text-neutral-300">
         <Layout
           navbar={navbar}
           pageMap={pageMap}


### PR DESCRIPTION
We want to create more `free space` on both sides of the `content`. This PR aims to `reduce the width` of the `main content` on `docs.ws`. 

* **Before :**

<ins>`For width >= 768px :`<ins>

![Screenshot from 2025-02-10 16-07-37](https://github.com/user-attachments/assets/1b705a79-3ea2-4ac5-8961-aac07a588a65)

<ins>`For width >= 1024px :`<ins>

![Screenshot from 2025-02-10 16-07-49](https://github.com/user-attachments/assets/6456c4f2-a85e-472c-9e32-c8f2018b604e)

![Screenshot from 2025-02-10 16-34-30](https://github.com/user-attachments/assets/94f22391-be1c-49a8-b773-812a209ad9c9)


* **After :**

<ins>`For width >= 768px :`<ins>

![Screenshot from 2025-02-10 16-52-23](https://github.com/user-attachments/assets/97ab22a2-d35c-4f11-8a82-3338b71d10ab)

<ins>`For width >= 1024px :`<ins>

![Screenshot from 2025-02-10 16-01-49](https://github.com/user-attachments/assets/dd2b8fd5-8a9a-4808-9342-c95914568f47)

![Screenshot from 2025-02-10 16-33-11](https://github.com/user-attachments/assets/95287c01-c1ed-4eb2-8034-e526352f0c98)

