### PR TITLE
[docs.ws]: The `SearchBar`  works correctly

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/AnchorLinkTitle.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/AnchorLinkTitle.tsx
@@ -33,7 +33,10 @@ export const AnchorLinkTitle = ({
     return null;
   }
 
+  const id = `${parentTitle ? `${parentTitle}-` : ''}${title}`;
+
   const elementAttributes: HTMLAttributes<HTMLHeadingElement> = {
+    id,
     className: `${titleStyles[titleLevel]} ${accordion ? accordionStyles : ''} nx-font-semibold nx-text-slate-900 dark:nx-text-slate-100 ${accordion ? '' : borderStyles}`,
     ...(pagefindIgnore && { 'data-pagefind-ignore': true }),
   };
@@ -44,8 +47,8 @@ export const AnchorLinkTitle = ({
     <>
       {title}
       <a
-        href={`#${parentTitle ? `${parentTitle}-` : ''}${title}`}
-        id={`${parentTitle ? `${parentTitle}-` : ''}${title}`}
+        href={`#${id}`}
+        id={id}
         className="subheading-anchor"
         aria-label="Permalink for this section"
       ></a>


### PR DESCRIPTION
When we try to search for certain data in our `search bar` with [`pagefind`](https://pagefind.app/), we don’t get the correct results.
This PR fixes this problem, and now our users should be led to the correct results when a match is found.

* **Before :**
<ins>The URL fragment is incorrect:<ins>

![Screenshot from 2025-02-13 17-09-50](https://github.com/user-attachments/assets/23da1edd-2623-42ef-a5be-c24c40f5ec89)


![Screenshot from 2025-02-13 17-15-55](https://github.com/user-attachments/assets/be208a79-6343-4992-b0ee-90d922affc96)


* **After :**
<ins>The URL fragment is correct:<ins>
![Screenshot from 2025-02-13 18-02-35](https://github.com/user-attachments/assets/57909112-765d-4b68-abe3-224429ea6534)



![Screenshot from 2025-02-13 17-20-51](https://github.com/user-attachments/assets/a3ed5d66-cf37-476e-920e-0dc8c53c467b)
