### PR TITLE
docs(pw-rnd): Change git clone link from ssh to https

### DIFF
--- a/apps/docs.blocksense.network/app/docs/programming-languages-rnd/noir-plonky2-backend/page.mdx
+++ b/apps/docs.blocksense.network/app/docs/programming-languages-rnd/noir-plonky2-backend/page.mdx
@@ -36,7 +36,7 @@ A simple programming language to write ZK programs, with fast-to-generate, distr
 1. Clone [our repository](https://github.com/blocksense-network/noir/) with SSH:
 
     ```bash copy
-    git clone git@github.com:blocksense-network/noir.git
+    git clone https://github.com/blocksense-network/noir.git
     ```
 
 2. Navigate to the folder `noir`.


### PR DESCRIPTION
With the SSH link you need to setup your SSH keys. With HTTPS you can clone without any configuration needed.