### PR TITLE
[ui]: Migrate Input component to Storybook

### DIFF
--- a/apps/docs.blocksense.network/components/ui/DataTable/DataTableToolbar.tsx
+++ b/apps/docs.blocksense.network/components/ui/DataTable/DataTableToolbar.tsx
@@ -4,7 +4,7 @@ import { X } from 'lucide-react';
 import { Table } from '@tanstack/react-table';
 
 import { Button } from '@blocksense/ui/Button';
-import { Input } from '@/components/common/Input';
+import { Input } from '@blocksense/ui/Input';
 import { DataTableViewOptions } from '@/components/ui/DataTable/DataTableViewOptions';
 import { DataTableFacetedFilter } from '@/components/ui/DataTable/DataTableFacetedFilter';
 import {
@@ -39,7 +39,7 @@ export function DataTableToolbar<TData>({
               value={
                 (table.getColumn(filterCell)?.getFilterValue() as string) ?? ''
               }
-              onChange={event =>
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
                 table.getColumn(filterCell)?.setFilterValue(event.target.value)
               }
               className={`h-8 w-full min-w-[250px] lg:w-[250px] mr-1 lg:mr-2 border-solid border-slate-200 transition-all duration-200`}

--- a/libs/ts/ui/package.json
+++ b/libs/ts/ui/package.json
@@ -5,6 +5,7 @@
     "./style.css": "./dist/style.css",
     ".": "./src/index.tsx",
     "./Button": "./src/components/Button/index.tsx",
+    "./Input": "./src/components/Input/index.tsx",
     "./ImageWrapper": "./src/components/ImageWrapper/index.tsx",
     "./Tooltip": "./src/components/Tooltip/index.tsx",
     "./CopyButton": "./src/components/CopyButton/index.tsx",

--- a/libs/ts/ui/src/components/Input/Input.stories.tsx
+++ b/libs/ts/ui/src/components/Input/Input.stories.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import { Input } from './Input';
+
+const meta: Meta<typeof Input> = {
+  title: 'Components/Input',
+  component: Input,
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['outline', 'filled', 'transparent', 'error'],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg', 'xl'],
+    },
+    placeholder: { control: 'text' },
+    value: { control: 'text' },
+    error: { control: 'boolean' },
+    errorMessage: { control: 'text' },
+    disabled: { control: 'boolean' },
+    className: { control: 'text' },
+    icon: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  args: {
+    variant: 'outline',
+    size: 'md',
+    placeholder: 'Enter text',
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    variant: 'error',
+    size: 'md',
+    placeholder: 'Error input',
+    error: true,
+    errorMessage: 'Invalid input',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    variant: 'outline',
+    size: 'md',
+    placeholder: 'Disabled input',
+    disabled: true,
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    variant: 'outline',
+    size: 'md',
+    placeholder: 'Search...',
+    icon: (
+      <span role="img" aria-label="magnifying glass">
+        🔍
+      </span>
+    ),
+  },
+};

--- a/libs/ts/ui/src/components/Input/Input.tsx
+++ b/libs/ts/ui/src/components/Input/Input.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import React from 'react';
 import {
   FocusEventHandler,
   MouseEventHandler,
@@ -8,7 +9,7 @@ import {
   ReactNode,
 } from 'react';
 
-import { cn } from '@/lib/utils';
+import { cn } from '../../utils';
 
 type Variant = 'outline' | 'filled' | 'transparent' | 'error';
 

--- a/libs/ts/ui/src/components/Input/index.tsx
+++ b/libs/ts/ui/src/components/Input/index.tsx
@@ -1,0 +1,1 @@
+export { Input } from './Input';

--- a/libs/ts/ui/src/index.tsx
+++ b/libs/ts/ui/src/index.tsx
@@ -1,4 +1,5 @@
 export * from './components/Button';
+export * from './components/Input';
 export * from './components/ImageWrapper';
 export * from './components/Tabs';
 export * from './components/Badge';


### PR DESCRIPTION
### Changes Included

### Relocated Input Component
- Moved `Input.tsx` from its previous location to `libs/ts/ui/src/components/Input/`.
- Added an `index.tsx` file in the Input folder to simplify exports.
- Updated `libs/ts/ui/src/index.tsx` to reflect these changes.

### Added Storybook Support
- Created `Input.stories.tsx` to document and test the Input component in Storybook.

### Updated Exports
- Modified `package.json` in `libs/ts/ui` to update the exports accordingly.

### Additional Changes in DataTableToolbar
- Updated `apps/docs.blocksense.network/components/ui/DataTable/DataTableToolbar.tsx`:
  - Fixed the `onChange` handler by explicitly typing the event as `React.ChangeEvent<HTMLInputElement>`.
  - Updated the import statement to properly reference the `Input` component from `@blocksense/ui/Input`.
