### PR TITLE
[ui]: Migrate `Badge` component to `Storybook`

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/Pragmas.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/Pragmas.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Badge } from '@/components/common/Badge';
+import { Badge } from '@blocksense/ui/Badge';
 
 import { PragmaDocItem } from '@blocksense/sol-reflector';
 

--- a/apps/docs.blocksense.network/components/ui/DataTable/DataTableBadge.tsx
+++ b/apps/docs.blocksense.network/components/ui/DataTable/DataTableBadge.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Badge } from '@/components/common/Badge';
+import { Badge } from '@blocksense/ui/Badge';
 
 type DataTableBadgeProps = {
   children: React.ReactNode;

--- a/libs/ts/ui/package.json
+++ b/libs/ts/ui/package.json
@@ -8,7 +8,8 @@
     "./ImageWrapper": "./src/components/ImageWrapper/index.tsx",
     "./Tooltip": "./src/components/Tooltip/index.tsx",
     "./CopyButton": "./src/components/CopyButton/index.tsx",
-    "./Tabs": "./src/components/Tabs/index.tsx"
+    "./Tabs": "./src/components/Tabs/index.tsx",
+    "./Badge": "./src/components/Badge/index.tsx"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.0.7",

--- a/libs/ts/ui/src/components/Badge/Badge.stories.tsx
+++ b/libs/ts/ui/src/components/Badge/Badge.stories.tsx
@@ -1,0 +1,53 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Badge } from './Badge';
+
+const meta: Meta<typeof Badge> = {
+  title: 'Components/Badge',
+  component: Badge,
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'highlight', 'accentary', 'danger', 'outline'],
+    },
+    children: { control: 'text' },
+    className: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Badge>;
+
+export const Primary: Story = {
+  args: {
+    variant: 'primary',
+    children: 'Primary Badge',
+  },
+};
+
+export const Highlight: Story = {
+  args: {
+    variant: 'highlight',
+    children: 'Highlight Badge',
+  },
+};
+
+export const Accentary: Story = {
+  args: {
+    variant: 'accentary',
+    children: 'Accentary Badge',
+  },
+};
+
+export const Danger: Story = {
+  args: {
+    variant: 'danger',
+    children: 'Danger Badge',
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    variant: 'outline',
+    children: 'Outline Badge',
+  },
+};

--- a/libs/ts/ui/src/components/Badge/Badge.tsx
+++ b/libs/ts/ui/src/components/Badge/Badge.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 
-import { cn } from '@/lib/utils';
+import { cn } from '../../utils';
 
 type Variant = 'primary' | 'highlight' | 'accentary' | 'danger' | 'outline';
 

--- a/libs/ts/ui/src/components/Badge/index.tsx
+++ b/libs/ts/ui/src/components/Badge/index.tsx
@@ -1,0 +1,1 @@
+export { Badge } from './Badge';

--- a/libs/ts/ui/src/index.tsx
+++ b/libs/ts/ui/src/index.tsx
@@ -1,3 +1,4 @@
 export * from './components/Button';
 export * from './components/ImageWrapper';
 export * from './components/Tabs';
+export * from './components/Badge';


### PR DESCRIPTION
🆕 What’s New?

This PR migrates the `Badge` component to `Storybook`, improving documentation and reusability across the project.

✨ Changes:

- Moved the `Badge` component from @blocksense/docs.blocksense.network to @blocksense/ui.
- Updated `package.json` and `index.tsx` to ensure proper exports.
- Adjusted imports in `@blocksense/docs.blocksense.network` to reference `Badge` from `@blocksense/ui`.
- Added `Badge.stories.tsx` to `Storybook` for better component visualization.

✅ Why?

This migration enhances maintainability and aligns with our `UI component structure`, ensuring consistent usage across projects.

🔍 How to Test:

Run Storybook and verify that the `Badge` component renders correctly.
Ensure existing imports and functionality remain intact after the update.