### PR TITLE
[ui]: Migrate Accordion component to Storybook

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/ContractAccordion.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/ContractAccordion.tsx
@@ -9,7 +9,7 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
-} from '@/components/common/Accordion';
+} from '@blocksense/ui/Accordion';
 import { AnchorLinkTitle } from '@/sol-contracts-components/AnchorLinkTitle';
 import { useExpandCollapse } from '@/hooks/useExpandCollapse';
 

--- a/libs/ts/ui/assets/icons/chevron-down.svg
+++ b/libs/ts/ui/assets/icons/chevron-down.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class="lucide lucide-chevron-down h-4 w-4 mx-4 shrink-0 transition-transform duration-200"
+>
+  <path d="m6 9 6 6 6-6"></path>
+</svg>

--- a/libs/ts/ui/package.json
+++ b/libs/ts/ui/package.json
@@ -14,7 +14,8 @@
     "./Badge": "./src/components/Badge/index.tsx",
     "./Label": "./src/components/Label/index.tsx",
     "./Switch": "./src/components/Switch/index.tsx",
-    "./Card": "./src/components/Card/index.tsx"
+    "./Card": "./src/components/Card/index.tsx",
+    "./Accordion": "./src/components/Accordion/index.tsx"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.0.7",

--- a/libs/ts/ui/src/components/Accordion/Accordion.stories.tsx
+++ b/libs/ts/ui/src/components/Accordion/Accordion.stories.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from '../Accordion';
+
+export default {
+  title: 'Components/Accordion',
+  component: Accordion,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+const Template = args => (
+  <Accordion {...args}>
+    <AccordionItem value="item1">
+      <AccordionTrigger>Item 1</AccordionTrigger>
+      <AccordionContent>
+        <p>This is the content for item 1.</p>
+      </AccordionContent>
+    </AccordionItem>
+    <AccordionItem value="item2">
+      <AccordionTrigger>Item 2</AccordionTrigger>
+      <AccordionContent>
+        <p>This is the content for item 2.</p>
+      </AccordionContent>
+    </AccordionItem>
+    <AccordionItem value="item3">
+      <AccordionTrigger>Item 3</AccordionTrigger>
+      <AccordionContent>
+        <p>This is the content for item 3.</p>
+      </AccordionContent>
+    </AccordionItem>
+  </Accordion>
+);
+
+export const Multiple = Template.bind({});
+Multiple.args = {
+  type: 'multiple',
+  value: [],
+  className: 'w-full max-w-md mx-auto my-8',
+};
+
+export const Single = Template.bind({});
+Single.args = {
+  type: 'single',
+  value: [],
+  className: 'w-full max-w-md mx-auto my-8',
+};

--- a/libs/ts/ui/src/components/Accordion/Accordion.tsx
+++ b/libs/ts/ui/src/components/Accordion/Accordion.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {
+import React, {
   createContext,
   useContext,
   HTMLAttributes,
@@ -12,7 +12,7 @@ import {
 } from 'react';
 
 import { ImageWrapper } from '@blocksense/ui/ImageWrapper';
-import { cn } from '@/lib/utils';
+import { cn } from '../../utils';
 
 type AccordionContextType = {
   openItems: string[];

--- a/libs/ts/ui/src/components/Accordion/index.tsx
+++ b/libs/ts/ui/src/components/Accordion/index.tsx
@@ -1,0 +1,6 @@
+export {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from './Accordion';

--- a/libs/ts/ui/src/index.tsx
+++ b/libs/ts/ui/src/index.tsx
@@ -6,3 +6,4 @@ export * from './components/Badge';
 export * from './components/Label';
 export * from './components/Switch';
 export * from './components/Card';
+export * from './components/Accordion';


### PR DESCRIPTION
### Changes Included

### Relocated Input Component
- Moved `Accordion.tsx` from its previous location to `libs/ts/ui/src/components/Accordion/`.
- Added an `Accordion.tsx` file in the Accordion folder to simplify exports.
- Updated `libs/ts/ui/src/Accordion.tsx` to reflect these changes.

### Added Storybook Support
- Created `Accordion.stories.tsx` to document and test the Accordion component in Storybook.

### Updated Exports
- Modified `package.json` in `libs/ts/ui` to update the exports accordingly.