### PR TITLE
[ui]: Fix `ImageWrapper`

### DIFF
--- a/libs/ts/ui/src/components/ImageWrapper/ImageWrapper.tsx
+++ b/libs/ts/ui/src/components/ImageWrapper/ImageWrapper.tsx
@@ -14,9 +14,5 @@ export const ImageWrapper = ({
   className = ' ',
   onClick,
 }: ImageProps) => {
-  return (
-    <div className={`${className}`} onClick={onClick}>
-      <Image src={src} alt={alt} fill quality={50} />
-    </div>
-  );
+  return <img src={src} alt={alt} className={className} onClick={onClick} />;
 };


### PR DESCRIPTION
Fast fix for `ImageWrapper` - replacing next image component with basic img tag.

![image](https://github.com/user-attachments/assets/7da8dedc-92a3-4dca-8c2f-c8ab20b02711)
