### PR TITLE
fix(docs.ws): Fix utility classes and breakpoints that break the header of contract-base-info

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/ContractBaseInfo.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/ContractBaseInfo.tsx
@@ -15,16 +15,16 @@ export const ContractBaseInfo = ({ ...contract }: ContractDocItem) => {
       <AnchorLinkTitle title={contract.name} titleLevel={2} />
       <div className="contract-base-info border-solid border border-slate-200 bg-white shadow-md px-2 py-2 md:px-4 md:pt-4 pb-0 rounded-md mt-6 mb-6 flex flex-col xl:flex-row items-start dark:bg-neutral-900 dark:border-neutral-600">
         <section className="contract-base-info__content w-full">
-          <header className="contract-base-info__header px-2 py-2 flex flex-col items-start mb-3 xl:flex-row xl:justify-between xl:items-center">
+          <header className="contract-base-info__header px-2 py-2 flex [@media(max-width:1024px)]:flex-col items-start mb-3  xl:flex-row xl:justify-between xl:items-center">
             <h2 className="contract-base-info__base-contracts-title text-2xl mr-2 font-semibold text-gray-800 dark:text-white">
               Overview
             </h2>
 
-            <div className="flex flex-col w-full justify-end xl:flex-row xl:items-center xl:space-x-2">
+            <div className="flex [@media(max-width:1024px)]:flex-col w-full justify-end lg:flex-row xl:items-center space-x-2">
               <aside className="contract-base-info__description border-solid border border-slate-200 bg-slate-50 rounded-md font-bold px-4 py-1.5 dark:bg-neutral-900 dark:border-neutral-600">
-                <dl className="contract-base-info__list flex flex-col xl:flex-row xl:items-center xl:space-x-2">
+                <dl className="contract-base-info__list flex flex-row xl:items-center space-x-2">
                   <div
-                    className={`contract-base-info__item flex items-center ${contract.contractKind === 'contract' ? 'mb-2 xl:mb-0' : 'mb-0'}`}
+                    className={`contract-base-info__item flex items-center mb-0`}
                   >
                     <ImageWrapper
                       src="/icons/blocksense-kind.svg"
@@ -90,7 +90,7 @@ export const ContractBaseInfo = ({ ...contract }: ContractDocItem) => {
           <aside className="contract-base-info__base-contracts-description mx-2 pb-6">
             <ContractOverview contractString={JSON.stringify(contract)} />
           </aside>
-          <footer className="contract-base-info__header mt-6 mx-2 mb-6">
+          <footer className="contract-base-info__footer mt-6 mx-2 mb-6">
             <NatSpec natspec={contract.natspec} />
           </footer>
         </section>


### PR DESCRIPTION
This PR updates ```ContractBaseInfo``` header with some exchanged classes and most important - with an arbitrary media query in the ```contract-base-info__header``` class to apply a flex-col layout at a specific 1024px breakpoint. 
Media arbitrary value workarounds the issue `'[v4] using variables with breakpoints'  `described[ here.](https://github.com/tailwindlabs/tailwindcss/discussions/15113)

Until we  get back the `tailwind.config.js `again we don't want to keep the contract-base-info__header broken. 

That's why we use arbitraty media query into the className, that works with the CSS native approach using variables we currently utilize.

**Before:**
![image](https://github.com/user-attachments/assets/65a1c8f0-0d12-46c4-ba38-e609f09f48cc)

**After:**
![image](https://github.com/user-attachments/assets/37076bab-1d68-497a-b769-330a7e669b6e)
![image](https://github.com/user-attachments/assets/94c136b3-882b-42f3-b2ef-b6f32c8b7e19)
![image](https://github.com/user-attachments/assets/37e7f929-12cf-40fd-8ac6-167ab1c24f30)

