### PR TITLE
[ui]: Migrate Callout component to Storybook

### DIFF
--- a/apps/docs.blocksense.network/app/docs/contracts/integration-guide/using-data-feeds/chainlink-proxy/page.mdx
+++ b/apps/docs.blocksense.network/app/docs/contracts/integration-guide/using-data-feeds/chainlink-proxy/page.mdx
@@ -2,7 +2,7 @@
 title: Chainlink Proxy
 ---
 
-import { Callout } from "@/components/common/Callout";
+import { Callout } from "@blocksense/ui/Callout";
 
 # Chainlink Proxy
 

--- a/apps/docs.blocksense.network/app/docs/contracts/integration-guide/using-data-feeds/feed-registry/page.mdx
+++ b/apps/docs.blocksense.network/app/docs/contracts/integration-guide/using-data-feeds/feed-registry/page.mdx
@@ -1,7 +1,7 @@
 ---
 title: Feed Registry
 ---
-import { Callout } from "@/components/common/Callout";
+import { Callout } from "@blocksense/ui/Callout";
 
 # Feed Registry
 

--- a/apps/docs.blocksense.network/app/docs/contracts/integration-guide/using-data-feeds/historic-data-feed/page.mdx
+++ b/apps/docs.blocksense.network/app/docs/contracts/integration-guide/using-data-feeds/historic-data-feed/page.mdx
@@ -2,7 +2,7 @@
 title: Historic Data Feed Store
 ---
 
-import { Callout } from "@/components/common/Callout";
+import { Callout } from "@blocksense/ui/Callout";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@blocksense/ui/Tabs';
 
 # Historical Data Feed Store

--- a/apps/docs.blocksense.network/app/docs/programming-languages-rnd/noir-plonky2-backend/page.mdx
+++ b/apps/docs.blocksense.network/app/docs/programming-languages-rnd/noir-plonky2-backend/page.mdx
@@ -1,7 +1,7 @@
 ---
 title: Noir PLONKY2 backend
 ---
-import { Callout } from "@/components/common/Callout";
+import { Callout } from "@blocksense/ui/Callout";
 
 # Noir PLONKY2 backend
 

--- a/apps/docs.blocksense.network/components/DeployedContracts/DeployedContracts.tsx
+++ b/apps/docs.blocksense.network/components/DeployedContracts/DeployedContracts.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRef, useState } from 'react';
-import { Callout } from '@/components/common/Callout';
+import { Callout } from '@blocksense/ui/Callout';
 
 import { parseNetworkName } from '@blocksense/base-utils/evm';
 

--- a/libs/ts/ui/package.json
+++ b/libs/ts/ui/package.json
@@ -15,6 +15,7 @@
     "./Label": "./src/components/Label/index.tsx",
     "./Switch": "./src/components/Switch/index.tsx",
     "./Card": "./src/components/Card/index.tsx",
+    "./Callout": "./src/components/Callout/index.tsx",
     "./Accordion": "./src/components/Accordion/index.tsx",
     "./Icon": "./src/components/Icon/index.tsx"
   },

--- a/libs/ts/ui/src/components/Callout/Callout.stories.tsx
+++ b/libs/ts/ui/src/components/Callout/Callout.stories.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import { Meta, StoryObj } from '@storybook/react';
+import { Callout } from './Callout';
+
+const meta: Meta<typeof Callout> = {
+  title: 'Components/Callout',
+  component: Callout,
+  argTypes: {
+    type: {
+      control: 'select',
+      options: ['default', 'error', 'info', 'warning'],
+    },
+    emoji: {
+      control: 'text',
+    },
+    title: {
+      control: 'text',
+    },
+    children: {
+      control: 'text',
+    },
+    className: {
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Callout>;
+
+export const Default: Story = {
+  args: {
+    type: 'default',
+    title: 'Default Callout',
+    children: 'This is a default callout message.',
+  },
+};
+
+export const Info: Story = {
+  args: {
+    type: 'info',
+    title: 'Information',
+    children: 'This is an informational message.',
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    type: 'warning',
+    title: 'Warning',
+    children: 'Be cautious! This is a warning.',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    type: 'error',
+    title: 'Error',
+    children: 'An error has occurred.',
+  },
+};

--- a/libs/ts/ui/src/components/Callout/Callout.tsx
+++ b/libs/ts/ui/src/components/Callout/Callout.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { ReactNode, ReactElement } from 'react';
+import React, { ReactNode, ReactElement } from 'react';
 
-import { cn } from '@/lib/utils';
+import { cn } from '../../utils';
 
 const typeToEmoji = {
   default: 'ℹ️',

--- a/libs/ts/ui/src/components/Callout/index.tsx
+++ b/libs/ts/ui/src/components/Callout/index.tsx
@@ -1,0 +1,1 @@
+export { Callout } from './Callout';

--- a/libs/ts/ui/src/index.tsx
+++ b/libs/ts/ui/src/index.tsx
@@ -6,5 +6,6 @@ export * from './components/Badge';
 export * from './components/Label';
 export * from './components/Switch';
 export * from './components/Card';
+export * from './components/Callout';
 export * from './components/Accordion';
 export * from './components/Icon';


### PR DESCRIPTION
### Changes Included

#### Relocated Callout Component
- Moved `Callout.tsx` from `apps/docs.blocksense.network/components/common/` to `libs/ts/ui/src/components/Callout/`.
- Added an `index.tsx` file in the `Callout` folder to simplify exports.
- Updated `libs/ts/ui/src/index.tsx` to reflect these changes.

#### Added Storybook Support
- Created `Callout.stories.tsx` to document and test the `Callout` component in Storybook.

#### Updated Exports
- Modified `package.json` in `libs/ts/ui` to update the exports accordingly for the `Callout` component.

#### Additional Changes in Documentation
- Updated the documentation files:
  - `apps/docs.blocksense.network/app/docs/contracts/integration-guide/using-data-feeds/chainlink-proxy/page.mdx`
  - `apps/docs.blocksense.network/app/docs/contracts/integration-guide/using-data-feeds/feed-registry/page.mdx`
  - `apps/docs.blocksense.network/app/docs/contracts/integration-guide/using-data-feeds/historic-data-feed/page.mdx`
  - `apps/docs.blocksense.network/app/docs/programming-languages-rnd/noir-plonky2-backend/page.mdx`
- Updated references in `apps/docs.blocksense.network/components/DeployedContracts/DeployedContracts.tsx`.
