### PR TITLE
[ui]: Migrate `Select` component to `Storybook`

### DIFF
--- a/apps/docs.blocksense.network/components/ui/DataTable/DataTablePagination.tsx
+++ b/apps/docs.blocksense.network/components/ui/DataTable/DataTablePagination.tsx
@@ -16,7 +16,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@/components/common/Select';
+} from '@blocksense/ui/Select';
 
 interface DataTablePaginationProps<TData> {
   table: Table<TData>;

--- a/libs/ts/ui/package.json
+++ b/libs/ts/ui/package.json
@@ -22,7 +22,8 @@
     "./Icon": "./src/components/Icon/index.tsx",
     "./DropdownMenu": "./src/components/DropdownMenu/index.tsx",
     "./Drawer": "./src/components/Drawer/index.tsx",
-    "./Dialog": "./src/components/Dialog/index.tsx"
+    "./Dialog": "./src/components/Dialog/index.tsx",
+    "./Select": "./src/components/Select/index.tsx"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.0.7",

--- a/libs/ts/ui/src/components/Select/Select.stories.tsx
+++ b/libs/ts/ui/src/components/Select/Select.stories.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react';
+
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+  SelectLabel,
+} from './Select';
+
+export default {
+  title: 'Components/Select',
+  component: Select,
+};
+
+export const DefaultSelect = () => {
+  const [selectedValue, setSelectedValue] = useState('');
+
+  return (
+    <Select value={selectedValue} onValueChangeAction={setSelectedValue}>
+      <SelectTrigger className="btn">
+        <SelectValue placeholder="Select an Item" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectLabel>Items</SelectLabel>
+        <SelectItem value="Item 1">Item 1</SelectItem>
+        <SelectItem value="Item 2">Item 2</SelectItem>
+        <SelectItem value="Item 3">Item 3</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+};
+
+export const SideAlignExamples = () => {
+  const [defaultValue, setDefaultValue] = useState('');
+  const [bottomCenterValue, setBottomCenterValue] = useState('');
+  const [bottomEndValue, setBottomEndValue] = useState('');
+  const [topStartValue, setTopStartValue] = useState('');
+  const [topCenterValue, setTopCenterValue] = useState('');
+  const [topEndValue, setTopEndValue] = useState('');
+
+  return (
+    <div className="flex flex-col gap-10">
+      <div className="flex items-center gap-10">
+        <Select value={defaultValue} onValueChangeAction={setDefaultValue}>
+          <SelectTrigger className="btn">
+            <SelectValue placeholder="Bottom Start (default)" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="Item 1">Item 1</SelectItem>
+            <SelectItem value="Item 2">Item 2</SelectItem>
+            <SelectItem value="Item 3">Item 3</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select
+          value={bottomCenterValue}
+          onValueChangeAction={setBottomCenterValue}
+        >
+          <SelectTrigger className="btn">
+            <SelectValue placeholder="Bottom Center" />
+          </SelectTrigger>
+          <SelectContent align="center">
+            <SelectItem value="Item 1">Item 1</SelectItem>
+            <SelectItem value="Item 2">Item 2</SelectItem>
+            <SelectItem value="Item 3">Item 3</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={bottomEndValue} onValueChangeAction={setBottomEndValue}>
+          <SelectTrigger className="btn">
+            <SelectValue placeholder="Bottom End" />
+          </SelectTrigger>
+          <SelectContent align="end">
+            <SelectItem value="Item 1">Item 1</SelectItem>
+            <SelectItem value="Item 2">Item 2</SelectItem>
+            <SelectItem value="Item 3">Item 3</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="flex items-center gap-10">
+        <Select value={topStartValue} onValueChangeAction={setTopStartValue}>
+          <SelectTrigger className="btn">
+            <SelectValue placeholder="Top Start" />
+          </SelectTrigger>
+          <SelectContent side="top">
+            <SelectItem value="Item 1">Item 1</SelectItem>
+            <SelectItem value="Item 2">Item 2</SelectItem>
+            <SelectItem value="Item 3">Item 3</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={topCenterValue} onValueChangeAction={setTopCenterValue}>
+          <SelectTrigger className="btn">
+            <SelectValue placeholder="Top Center" />
+          </SelectTrigger>
+          <SelectContent side="top" align="center">
+            <SelectItem value="Item 1">Item 1</SelectItem>
+            <SelectItem value="Item 2">Item 2</SelectItem>
+            <SelectItem value="Item 3">Item 3</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={topEndValue} onValueChangeAction={setTopEndValue}>
+          <SelectTrigger className="btn">
+            <SelectValue placeholder="Top End" />
+          </SelectTrigger>
+          <SelectContent side="top" align="end">
+            <SelectItem value="Item 1">Item 1</SelectItem>
+            <SelectItem value="Item 2">Item 2</SelectItem>
+            <SelectItem value="Item 3">Item 3</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+};
+
+const statusOptions = ['Active', 'Inactive', 'Pending', 'Completed'];
+
+export const SelectStatusFilter = () => {
+  const [selectedStatus, setSelectedStatus] = useState('');
+
+  return (
+    <div className="flex items-center gap-10">
+      <Select value={selectedStatus} onValueChangeAction={setSelectedStatus}>
+        <SelectTrigger className="btn">
+          <SelectValue placeholder="Filter by status" />
+        </SelectTrigger>
+        <SelectContent side="bottom">
+          {statusOptions.map(status => (
+            <SelectItem key={status} value={status}>
+              {status}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};

--- a/libs/ts/ui/src/components/Select/Select.tsx
+++ b/libs/ts/ui/src/components/Select/Select.tsx
@@ -10,7 +10,7 @@ import React, {
   HTMLAttributes,
 } from 'react';
 
-import { cn } from '@/lib/utils';
+import { cn } from '../../utils';
 import { Icon } from '@blocksense/ui/Icon';
 import { Button } from '@blocksense/ui/Button';
 
@@ -109,7 +109,7 @@ export const SelectTrigger = ({
   return (
     <Button
       className={cn(
-        'select__trigger flex h-10 mt-0 w-full items-center justify-between rounded-md px-2 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50',
+        'select__trigger flex gap-1 h-10 mt-0 w-full items-center justify-between rounded-md px-2 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       onClick={toggleOpen}
@@ -261,6 +261,29 @@ export const SelectItem = ({
           />
         )}
       </span>
+      {children}
+    </div>
+  );
+};
+
+type SelectLabelProps = HTMLAttributes<HTMLDivElement> & {
+  className?: string;
+  children: ReactNode;
+};
+
+export const SelectLabel = ({
+  className,
+  children,
+  ...props
+}: SelectLabelProps) => {
+  return (
+    <div
+      className={cn(
+        'select__label relative cursor-default m-1 select-none py-1.5 pl-8 pr-2 font-bold text-sm',
+        className,
+      )}
+      {...props}
+    >
       {children}
     </div>
   );

--- a/libs/ts/ui/src/components/Select/index.tsx
+++ b/libs/ts/ui/src/components/Select/index.tsx
@@ -1,0 +1,8 @@
+export {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+  SelectLabel,
+} from './Select';

--- a/libs/ts/ui/src/index.tsx
+++ b/libs/ts/ui/src/index.tsx
@@ -13,3 +13,4 @@ export * from './components/Drawer';
 export * from './components/Accordion';
 export * from './components/Icon';
 export * from './components/Dialog';
+export * from './components/Select';


### PR DESCRIPTION
This PR migrates the `Select` component to `Storybook`, improving documentation and reusability across the project.

* Changes:

  - Moved the `Select` component from `@blocksense/docs.blocksense.network` to `@blocksense/ui`.
  - Updated `package.json` and `index.tsx` to ensure proper exports.
  - Adjusted imports in `@blocksense/docs.blocksense.network` to reference `Select` from `@blocksense/ui`.
  - Added `Select.stories.tsx` to `Storybook` for better component visualization.

* Why?

  - This migration enhances maintainability and aligns with our UI component structure, ensuring consistent usage across projects.

* How to Test:

  - Run `Storybook` and verify that the `Select` component renders correctly.
  - Ensure existing imports and functionality remain intact after the update.