### PR TITLE
feat(oracles): Implement price fetch from GeckoTerminal for dex pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,6 +4674,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gecko-terminal"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "blocksense-sdk",
+ "serde 1.0.217",
+ "serde-this-or-that",
+ "serde_json",
+ "url",
+ "wit-bindgen",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "apps/sequencer_tests",
   "apps/trigger-oracle",
   "apps/oracles/crypto-price-feeds",
+  "apps/oracles/gecko-terminal",
   "libs/anomaly_detection",
   "libs/data_feeds",
   "libs/derive",

--- a/apps/oracles/gecko-terminal/Cargo.toml
+++ b/apps/oracles/gecko-terminal/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "gecko-terminal"
+authors = ["Yordan Madzhunkov"]
+description = ""
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = "0.16.0"
+blocksense-sdk = { path = "../../../libs/sdk" }
+anyhow = "1.0.82"
+serde_json = "1.0"
+url = "2.5"
+serde = { version = "1.0", features = ["derive"] }
+serde-this-or-that = "0.5.0"

--- a/apps/oracles/gecko-terminal/spin.toml
+++ b/apps/oracles/gecko-terminal/spin.toml
@@ -1,0 +1,28 @@
+spin_manifest_version = 2
+
+[application]
+authors = ["Yordan Madzhunkov"]
+name = "GeckoTerminal dex prices"
+version = "0.1.0"
+
+[application.trigger.settings]
+interval_time_in_seconds = 10
+sequencer = "http://127.0.0.1:9856/post_reports_batch"
+secret_key = "536d1f9d97166eba5ff0efb8cc8dbeb856fb13d2d126ed1efc761e9955014003"
+reporter_id = 0
+
+[[trigger.oracle]]
+component = "gecko-terminal"
+
+[[trigger.oracle.data_feeds]]
+id = "607"
+data = '{"network":"monad-testnet", "pool":"0x8552706d9a27013f20ea0f9df8e20b61e283d2d3"}'
+
+
+[component.gecko-terminal]
+source = "target/wasm32-wasip1/release/gecko_terminal_oracle.wasm"
+
+allowed_outbound_hosts = ["https://app.geckoterminal.com/"]
+
+[component.gecko-terminal.build]
+command = "cargo build --target wasm32-wasip1 --release"

--- a/apps/oracles/gecko-terminal/src/lib.rs
+++ b/apps/oracles/gecko-terminal/src/lib.rs
@@ -1,0 +1,227 @@
+use anyhow::{Context, Ok, Result};
+use blocksense_sdk::{
+    oracle::{DataFeedResult, DataFeedResultValue, Payload, Settings},
+    oracle_component,
+    spin::http::{send, Method, Request, Response},
+};
+
+use serde::{Deserialize, Serialize};
+use serde_this_or_that::as_f64;
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct PoolAttributes {
+    pub address: String,
+    pub name: String,
+    #[serde(deserialize_with = "as_f64")]
+    pub price_in_usd: f64,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct GeckoTerminalData {
+    pub id: String,
+    pub attributes: PoolAttributes,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct GeckoTerminalResponce {
+    pub data: GeckoTerminalData,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+pub struct GeckoTerminalPool {
+    pub network: String,
+    pub pool: String,
+}
+
+#[oracle_component]
+async fn oracle_request(settings: Settings) -> Result<Payload> {
+    println!("Starting oracle component - Gecko Terminal");
+
+    let mut payload: Payload = Payload::new();
+
+    for feed in settings.data_feeds {
+        let pool_with_network: GeckoTerminalPool =
+            serde_json::from_str(&feed.data).context("Can't parse GeckoTerminalPool resource")?;
+        let network = pool_with_network.network;
+        let pool = pool_with_network.pool;
+        let url = format!("https://app.geckoterminal.com/api/p1/{network}/pools/{pool}");
+        // let url = "https://app.geckoterminal.com/api/p1/monad-testnet/pools/0x8552706d9a27013f20ea0f9df8e20b61e283d2d3";
+        let mut req = Request::builder();
+        req.method(Method::Get);
+        req.uri(url.as_str());
+        let resp: Response = send(req).await?;
+        let body = resp.into_body();
+        let string = String::from_utf8(body)?;
+        let value: GeckoTerminalResponce = serde_json::from_str(&string)
+            .context("Couldn't parse Gecko terminal response properly")?;
+        payload.values.push(DataFeedResult {
+            id: feed.id,
+            value: DataFeedResultValue::Numerical(value.data.attributes.price_in_usd),
+        });
+    }
+    println!("{payload:?}");
+    Ok(payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::GeckoTerminalResponce;
+    #[test]
+    fn test_parsing_responce() {
+        let raw = r#"{
+            "data":{
+                "id":"171227265",
+                "type":"pool",
+                "attributes":{
+                    "address":"0x8552706d9a27013f20ea0f9df8e20b61e283d2d3",
+                    "name":"USDT / WMON 0.2%",
+                    "fully_diluted_valuation":"1817838994588.86",
+                    "base_token_id":"38534023",
+                    "price_in_usd":"181.783899458886",
+                    "price_in_target_token":"10.0009767679",
+                    "reserve_in_usd":"1308999961.9237",
+                    "reserve_threshold_met":true,
+                    "from_volume_in_usd":"50075.0824436682",
+                    "to_volume_in_usd":"50075.0824436682",
+                    "api_address":"0x8552706d9a27013f20ea0f9df8e20b61e283d2d3",
+                    "pool_fee":"0.2%",
+                    "token_weightages":null,
+                    "token_reserves":{
+                        "38534023":{
+                            "reserves":"7197341.24226823",
+                            "reserves_in_usd":1308369509.3935878
+                        },
+                        "38379114":{
+                            "reserves":"33411.1466004131",
+                            "reserves_in_usd":607305.5948889041
+                        }
+                    },
+                    "token_value_data":{
+                        "38534023":{
+                            "fdv_in_usd":1817851155520.9482,
+                            "market_cap_in_usd":null,
+                            "market_cap_to_holders_ratio":null
+                        },
+                        "38379114":{
+                            "fdv_in_usd":1840830347.322756,
+                            "market_cap_in_usd":null,
+                            "market_cap_to_holders_ratio":null
+                        }
+                    },
+                    "balancer_pool_id":null,
+                    "swap_count_24h":8215,
+                    "swap_url":"https://alpha.izumi.finance/trade/swap?outputCurrency=0x6a7436775c0d0b70cff4c5365404ec37c9d9af4b",
+                    "sentiment_votes":{
+                        "total":0.0,
+                        "up_percentage":0,
+                        "down_percentage":0
+                    },
+                    "price_percent_change":"-5.9%",
+                    "price_percent_changes":{
+                        "last_5m":"-0.41%",
+                        "last_15m":"-0.54%",
+                        "last_30m":"-0.73%",
+                        "last_1h":"-1.15%",
+                        "last_6h":"-2.35%",
+                        "last_24h":"-5.9%"
+                    },
+                    "historical_data":{
+                        "last_5m":{
+                            "swaps_count":11,
+                            "buyers_count":1,
+                            "price_in_usd":"182.5310041265",
+                            "sellers_count":10,
+                            "volume_in_usd":"362.2660782419",
+                            "buy_swaps_count":1,
+                            "sell_swaps_count":10
+                        },
+                        "last_15m":{
+                            "swaps_count":23,
+                            "buyers_count":13,
+                            "price_in_usd":"182.7618519101",
+                            "sellers_count":10,
+                            "volume_in_usd":"727.4782276277",
+                            "buy_swaps_count":13,
+                            "sell_swaps_count":10
+                        },
+                        "last_30m":{
+                            "swaps_count":31,
+                            "buyers_count":15,
+                            "price_in_usd":"183.1175400712",
+                            "sellers_count":12,
+                            "volume_in_usd":"727.9833855317",
+                            "buy_swaps_count":18,
+                            "sell_swaps_count":13
+                        },
+                        "last_1h":{
+                            "swaps_count":39,
+                            "buyers_count":22,
+                            "price_in_usd":"183.8985543357",
+                            "sellers_count":12,
+                            "volume_in_usd":"768.7889156705",
+                            "buy_swaps_count":26,
+                            "sell_swaps_count":13
+                        },
+                        "last_6h":{
+                            "swaps_count":257,
+                            "buyers_count":160,
+                            "price_in_usd":"186.1624889329",
+                            "sellers_count":31,
+                            "volume_in_usd":"2018.1630831767",
+                            "buy_swaps_count":220,
+                            "sell_swaps_count":37
+                        },
+                        "last_24h":{
+                            "swaps_count":8215,
+                            "buyers_count":4051,
+                            "price_in_usd":"193.1915026651",
+                            "sellers_count":763,
+                            "volume_in_usd":"50075.0824436682",
+                            "buy_swaps_count":7242,
+                            "sell_swaps_count":973
+                        }
+                    },
+                    "locked_liquidity":null,
+                    "security_indicators":[],
+                    "gt_score":34.862385321100916,
+                    "gt_score_details":{"info":0.0,"pool":31.25,"transactions":60.0,"holders":0.0,"creation":50.0},
+                    "pool_reports_count":0,
+                    "pool_created_at":"2025-02-27T07:11:12.925Z",
+                    "latest_swap_timestamp":"2025-03-12T08:59:51Z",
+                    "high_low_price_data_by_token_id":{
+                        "38379114":{
+                            "high_price_in_usd_24h":19.6155703601,
+                            "high_price_timestamp_24h":"2025-03-11T19:03:12Z",
+                            "low_price_in_usd_24h":18.1766145126,
+                            "low_price_timestamp_24h":"2025-03-12T08:59:51Z"
+                        },
+                        "38534023":{
+                            "high_price_in_usd_24h":196.9619233054,
+                            "high_price_timestamp_24h":"2025-03-11T19:03:12Z",
+                            "low_price_in_usd_24h":181.7838994589,
+                            "low_price_timestamp_24h":"2025-03-12T08:59:51Z"
+                        }
+                    },
+                    "is_nsfw":false,
+                    "is_stale_pool":null,
+                    "is_pool_address_explorable":true
+                },
+                "relationships":{
+                    "dex":{"data":{"id":"21916","type":"dex"}},
+                    "tokens":{"data":[{"id":"38534023","type":"token"},{"id":"38379114","type":"token"}]},
+                    "pool_metric":{"data":{"id":"4758509","type":"pool_metric"}},
+                    "pairs":{"data":[{"id":"8774160","type":"pair"}]}}
+                }
+            }"#;
+
+        let value: GeckoTerminalResponce =
+            serde_json::from_str(raw).expect("This should never happen");
+        assert_eq!(value.data.id, "171227265");
+        assert_eq!(value.data.attributes.name, "USDT / WMON 0.2%");
+        assert_eq!(
+            value.data.attributes.address,
+            "0x8552706d9a27013f20ea0f9df8e20b61e283d2d3"
+        );
+        assert_eq!(value.data.attributes.price_in_usd, 181.783899458886 as f64);
+    }
+}

--- a/apps/sequencer/src/http_handlers/admin.rs
+++ b/apps/sequencer/src/http_handlers/admin.rs
@@ -497,6 +497,14 @@ pub async fn get_oracle_scripts(
                 ],
                 capabilities: HashSet::from_iter(vec![]),
             },
+            OracleScript {
+                id: "gecko_terminal".to_string(),
+                name: None,
+                description: None,
+                oracle_script_wasm: "gecko_terminal_oracle.wasm".to_string(),
+                allowed_outbound_hosts: vec!["https://app.geckoterminal.com/".to_string()],
+                capabilities: HashSet::from_iter(vec![]),
+            },
         ],
     };
 

--- a/config/feeds_config.json
+++ b/config/feeds_config.json
@@ -7171,6 +7171,34 @@
       "value_type": "Numerical",
       "aggregate_type": "Median",
       "stride": 0
+    },
+    {
+      "id": 607,
+      "name": "USDT / WMON 0.2%",
+      "fullName": "WMON on monad-testnet pool with contract 0x8552706d9a27013f20ea0f9df8e20b61e283d2d3",
+      "description": "WMON / USDT",
+      "decimals": 8,
+      "report_interval_ms": 90000,
+      "quorum_percentage": 100,
+      "skip_publish_if_less_then_percentage": 0.1,
+      "always_publish_heartbeat_ms": 3600000,
+      "type": "Crypto",
+      "script": "gecko-terminal",
+      "pair": {
+        "base": "WMON",
+        "quote": "USDT"
+      },
+      "first_report_start_time": {
+        "secs_since_epoch": 0,
+        "nanos_since_epoch": 0
+      },
+      "resources": {
+        "network": "monad-testnet",
+        "pool": "0x8552706d9a27013f20ea0f9df8e20b61e283d2d3"
+      },
+      "value_type": "Numerical",
+      "aggregate_type": "Median",
+      "stride": 0
     }
 
   ]

--- a/libs/ts/config-types/src/data-feeds-config/index.ts
+++ b/libs/ts/config-types/src/data-feeds-config/index.ts
@@ -23,19 +23,6 @@ export const FeedCategorySchema = S.Union(
  */
 export type FeedCategory = S.Schema.Type<typeof FeedCategorySchema>;
 
-/**
- * Schema for the scripts that can be used to fetch data.
- */
-export const ScriptSchema = S.Union(
-  S.Literal('CoinMarketCap'),
-  S.Literal('YahooFinance'),
-  S.Literal('exsat'),
-).annotations({ identifier: 'ScriptName' });
-
-export type Script = S.Schema.Type<typeof ScriptSchema>;
-
-export const decodeScript = S.decodeUnknownSync(ScriptSchema);
-
 export const PairSchema = S.mutable(
   S.Struct({
     base: S.String,
@@ -88,7 +75,7 @@ export const FeedSchema = S.mutable(
     type: FeedCategorySchema,
     description: S.String,
     decimals: S.Number,
-    script: ScriptSchema,
+    script: S.String,
     pair: PairSchema,
     report_interval_ms: S.Number,
     first_report_start_time: FirstReportStartTimeSchema,

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -61,6 +61,7 @@
         oracle-scripts = {
           crypto-price-feeds = mkOracleScript /apps/oracles/crypto-price-feeds false;
           exsat = mkOracleScript /libs/sdk/examples/exsat_network true;
+          gecko-terminal = mkOracleScript /apps/oracles/gecko-terminal false;
 
           # Legacy oracle scripts
           cmc = mkOracleScript /libs/sdk/examples/cmc true;

--- a/nix/test-environments/example-setup-01.nix
+++ b/nix/test-environments/example-setup-01.nix
@@ -132,19 +132,8 @@ in
     };
 
     oracles = {
-      exsat = {
-        oracle_script_wasm = "exsat_holdings_oracle.wasm";
-        capabilities = [ ];
-        allowed_outbound_hosts = [
-          "https://raw.githubusercontent.com"
-          "https://rpc-us.exsat.network"
-          "https://blockchain.info"
-        ];
-      };
-
       crypto-price-feeds = {
         oracle_script_wasm = "crypto_price_feeds.wasm";
-
         capabilities = [ ];
         allowed_outbound_hosts = [
           "https://api.kraken.com"
@@ -162,6 +151,24 @@ in
           "https://api.bitget.com"
           "https://api.gateio.ws"
           "https://www.okx.com"
+        ];
+      };
+
+      exsat = {
+        oracle_script_wasm = "exsat_holdings_oracle.wasm";
+        capabilities = [ ];
+        allowed_outbound_hosts = [
+          "https://raw.githubusercontent.com"
+          "https://rpc-us.exsat.network"
+          "https://blockchain.info"
+        ];
+      };
+
+      gecko-terminal = {
+        oracle_script_wasm = "gecko_terminal.wasm";
+        capabilities = [ ];
+        allowed_outbound_hosts = [
+          "https://app.geckoterminal.com"
         ];
       };
     };


### PR DESCRIPTION
Oracle for NOSTRA that fetches prices from Gecko Terminal, which provides information for dex prices

`scripts/sdk$ ./start-oracle-example.sh gecko_terminal`

```bash
2025-03-12T11:31:50.572762Z TRACE trigger_oracle: Triggering application: GeckoTerminal dex prices; component_id: gecko-terminal
2025-03-12T11:31:50.572767Z TRACE trigger_oracle: Calling handle oracle request for `gecko-terminal`
Starting oracle component - Gecko Terminal
Payload { values: [DataFeedResult { id: "607", value: Numerical(179.859758223554) }] }
2025-03-12T11:31:50.755463Z TRACE trigger_oracle: Oracle request for `gecko-terminal` completed in 182ms
```