### PR TITLE
[DFCG]: DFCG reads artifacts from `blocksense-network/dfcg-artifacts`

### DIFF
--- a/apps/data-feeds-config-generator/package.json
+++ b/apps/data-feeds-config-generator/package.json
@@ -24,7 +24,6 @@
     "get-cmc-market-cap-data": "yarn ts scripts/get-cmc-market-cap-data.ts",
     "get-providers-data": "yarn ts scripts/get-providers-data.ts",
     "generate-data-feeds-config": "yarn ts scripts/generate-feeds-config.ts",
-    "generate": "yarn get-chainlink-feeds && yarn generate-data-feeds-config",
     "fetch-symbols": "yarn ts src/data-services/fetchers/scripts/fetch-symbols.ts",
     "test": "yarn vitest --typecheck -w false"
   },

--- a/apps/data-feeds-config-generator/package.json
+++ b/apps/data-feeds-config-generator/package.json
@@ -21,6 +21,7 @@
     "build": "yarn run rollup:build-workspace",
     "ts": "yarn node --import tsx",
     "get-chainlink-feeds": "yarn ts scripts/get_chainlink_feeds.ts",
+    "get-cmc-market-cap-data": "yarn ts scripts/get-cmc-market-cap-data.ts",
     "generate-data-feeds-config": "yarn ts scripts/generate-feeds-config.ts",
     "generate": "yarn get-chainlink-feeds && yarn generate-data-feeds-config",
     "fetch-symbols": "yarn ts src/data-services/fetchers/scripts/fetch-symbols.ts",

--- a/apps/data-feeds-config-generator/package.json
+++ b/apps/data-feeds-config-generator/package.json
@@ -22,6 +22,7 @@
     "ts": "yarn node --import tsx",
     "get-chainlink-feeds": "yarn ts scripts/get_chainlink_feeds.ts",
     "get-cmc-market-cap-data": "yarn ts scripts/get-cmc-market-cap-data.ts",
+    "get-providers-data": "yarn ts scripts/get-providers-data.ts",
     "generate-data-feeds-config": "yarn ts scripts/generate-feeds-config.ts",
     "generate": "yarn get-chainlink-feeds && yarn generate-data-feeds-config",
     "fetch-symbols": "yarn ts src/data-services/fetchers/scripts/fetch-symbols.ts",

--- a/apps/data-feeds-config-generator/package.json
+++ b/apps/data-feeds-config-generator/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@blocksense/base-utils": "workspace:*",
     "@blocksense/contracts": "workspace:*",
+    "@octokit/rest": "^21.1.1",
     "@types/keccak": "^3",
     "@types/node": "^22.10.2",
     "effect": "^3.12.1",

--- a/apps/data-feeds-config-generator/scripts/generate-feeds-config.ts
+++ b/apps/data-feeds-config-generator/scripts/generate-feeds-config.ts
@@ -77,45 +77,45 @@ async function main() {
   }
 
   const rawDataFeeds = await getOrCreateArtifact(
-    'raw_chainlink_feeds',
+    'DFCG_0_raw_chainlink_feeds',
     RawDataFeedsSchema,
     () => collectRawDataFeeds(artifacts.clArtifacts),
   );
 
   const aggregatedDataFeeds = await getOrCreateArtifact(
-    'aggregated_chainlink_feeds',
+    'DFCG_1_aggregated_chainlink_feeds',
     null,
     async () => aggregateNetworkInfoPerField(rawDataFeeds),
   );
 
   // Representation of all the Chainlink data feeds in our feed config format.
   const allPossibleCLDataFeeds = await getOrCreateArtifact(
-    'step_1_chainlink_all_possible_feeds',
+    'DFCG_2_chainlink_all_possible_feeds',
     null,
     async () => getAllPossibleCLFeeds(aggregatedDataFeeds),
   );
 
   // Representation of all the Chainlink data feeds on mainnets in our feed config format.
   const onMainnetCLDataFeeds = await getOrCreateArtifact(
-    'step_2_chainlink_on_mainnet_feeds',
+    'DFCG_3_chainlink_on_mainnet_feeds',
     null,
     async () => getCLFeedsOnMainnet(rawDataFeeds),
   );
 
   const feedConfig = await getOrCreateArtifact(
-    'feeds_config_new',
+    'DFCG_4_feeds_config_new',
     NewFeedsConfigSchema,
     () => generateFeedConfig(rawDataFeeds, artifacts),
   );
 
   const feedRegistryEvents = await getOrCreateArtifact(
-    'feed_registry_events',
+    'DFCG_5_feed_registry_events',
     FeedRegistryEventsPerAggregatorSchema,
     () => getAllProposedFeedsInRegistry('ethereum-mainnet'),
   );
 
   const chainlinkCompatConfig = await getOrCreateArtifact(
-    'chainlink_compatibility_new',
+    'DFCG_6_chainlink_compatibility_new',
     ChainlinkCompatibilityConfigSchema,
     () =>
       generateChainlinkCompatibilityConfig(

--- a/apps/data-feeds-config-generator/scripts/get-cmc-market-cap-data.ts
+++ b/apps/data-feeds-config-generator/scripts/get-cmc-market-cap-data.ts
@@ -1,0 +1,12 @@
+import { selectDirectory } from '@blocksense/base-utils/fs';
+import { fetchAssetsInMarketCapOrder } from '../src/data-services/fetchers/aggregators/cmc';
+import { artifactsDir } from '../src/paths';
+
+async function main() {
+  const cmcData = await fetchAssetsInMarketCapOrder();
+  const { writeJSON } = selectDirectory(artifactsDir);
+
+  await writeJSON({ name: 'cmc_market_cap_data', content: cmcData });
+}
+
+await main();

--- a/apps/data-feeds-config-generator/scripts/get-providers-data.ts
+++ b/apps/data-feeds-config-generator/scripts/get-providers-data.ts
@@ -1,0 +1,40 @@
+import { keysOf } from '@blocksense/base-utils/array-iter';
+import { assertNotNull } from '@blocksense/base-utils/assert';
+import { selectDirectory } from '@blocksense/base-utils/fs';
+
+import * as aggregatorFetchers from '../src/data-services/fetchers/aggregators/index';
+import * as exchangeFetchers from '../src/data-services/fetchers/exchanges/index';
+import { ProviderData } from '../src/feeds-config/data-providers';
+import { artifactsDir } from '../src/paths';
+
+async function main() {
+  const fetcherCategories = {
+    exchanges: exchangeFetchers,
+    aggregators: aggregatorFetchers,
+  };
+
+  const allFetchers = { ...exchangeFetchers, ...aggregatorFetchers };
+  const exchangeAssetsMap: ProviderData[] = await Promise.all(
+    Object.entries(allFetchers).map(async ([name, fetcher]) => {
+      const fetcherData = await new fetcher().fetchAssets();
+      const fetcherName = name.split('AssetsFetcher')[0];
+      return {
+        name: fetcherName,
+        type: assertNotNull(
+          keysOf(fetcherCategories).find(
+            category => name in fetcherCategories[category],
+          ),
+        ),
+        data: fetcherData,
+      };
+    }),
+  );
+
+  const { writeJSON } = selectDirectory(artifactsDir);
+  await writeJSON({
+    name: 'providers_data',
+    content: exchangeAssetsMap,
+  });
+}
+
+await main();

--- a/apps/data-feeds-config-generator/src/chainlink-compatibility/index.ts
+++ b/apps/data-feeds-config-generator/src/chainlink-compatibility/index.ts
@@ -82,14 +82,6 @@ async function getBlocksenseFeedsCompatibility(
     {} as BlocksenseFeedsCompatibility,
   );
 
-  {
-    const { writeJSON } = selectDirectory(artifactsDir);
-    await writeJSON({
-      content: { blocksenseFeedsCompatibility: blocksenseFeedsCompatibility },
-      name: 'blocksense_feeds_compatibility',
-    });
-  }
-
   return blocksenseFeedsCompatibility;
 }
 
@@ -118,16 +110,6 @@ async function getChainlinkAddressToBlocksenseId(
     },
     {} as ChainlinkAddressToBlocksenseId,
   );
-
-  {
-    const { writeJSON } = selectDirectory(artifactsDir);
-    await writeJSON({
-      content: {
-        chainlinkAddressToBlocksenseId: chainlinkAddressToBlocksenseId,
-      },
-      name: 'chainlink_address_to_blocksense_id',
-    });
-  }
 
   return chainlinkAddressToBlocksenseId;
 }

--- a/apps/data-feeds-config-generator/src/data-services/artifacts-downloader.ts
+++ b/apps/data-feeds-config-generator/src/data-services/artifacts-downloader.ts
@@ -1,0 +1,125 @@
+import { Octokit } from '@octokit/rest';
+import { Schema, ParseResult } from 'effect';
+
+import { getEnvString } from '@blocksense/base-utils/env';
+import { ProviderData } from '../feeds-config/data-providers';
+import { ChainLinkFeedInfo, ChainLinkFeedInfoSchema } from './types';
+import {
+  CMCMarketCapDataRes,
+  CMCMarketCapDataResSchema,
+} from './fetchers/aggregators/cmc';
+
+const OWNER = 'blocksense-network';
+const REPO = 'dfcg-artifacts';
+const BRANCH = 'main';
+
+const CMC_MARKET_CAP_DATA_ARTIFACT = 'cmc_market_cap_data.json';
+const PROVIDERS_DATA_ARTIFACT = 'providers_data.json';
+const CHAINLINK_FEEDS_DATA_DIR = 'chainlink_feeds';
+
+const GITHUB_TOKEN = getEnvString('DFCG_ARTIFACTS_ACCESS_TOKEN');
+
+const octokit = new Octokit({
+  auth: GITHUB_TOKEN,
+});
+
+export type CLArtifacts = {
+  base: string;
+  content: ChainLinkFeedInfo;
+};
+
+export type Artifacts = {
+  cmcMarketCap: CMCMarketCapDataRes;
+  exchangeAssets: ProviderData[];
+  clArtifacts: CLArtifacts[];
+};
+
+async function downloadAndDecodeFile<A, I>(
+  filePath: string,
+  schema: Schema.Schema<A, I, never> | null,
+) {
+  try {
+    const { data: fileData } = await octokit.repos.getContent({
+      owner: OWNER,
+      repo: REPO,
+      path: filePath,
+      ref: BRANCH,
+    });
+
+    if (!('download_url' in fileData)) {
+      throw new Error('Unexpected response structure');
+    }
+
+    const fileResponse = await fetch(fileData.download_url!);
+    console.info(`Downloaded: ${filePath}`);
+
+    const fileContent = await fileResponse.text();
+    const fileContentAsJson = JSON.parse(fileContent);
+
+    if (schema) {
+      return ParseResult.decodeUnknownSync(schema)(fileContentAsJson);
+    }
+    return fileContentAsJson;
+  } catch (error) {
+    console.error(`Error downloading ${filePath}:`, error);
+  }
+}
+
+export async function fetchRepoFiles(
+  dirPath: string = '',
+  artifacts: Artifacts = {
+    cmcMarketCap: [],
+    exchangeAssets: [],
+    clArtifacts: [],
+  },
+) {
+  try {
+    const { data: files } = await octokit.repos.getContent({
+      owner: OWNER,
+      repo: REPO,
+      path: dirPath,
+      ref: BRANCH,
+    });
+
+    if (!Array.isArray(files)) {
+      throw new Error('No files found');
+    }
+
+    for (const file of files) {
+      if (file.type === 'file') {
+        if (file.name === CMC_MARKET_CAP_DATA_ARTIFACT) {
+          artifacts.cmcMarketCap = await downloadAndDecodeFile(
+            file.path,
+            CMCMarketCapDataResSchema,
+          );
+        } else if (file.name === PROVIDERS_DATA_ARTIFACT) {
+          artifacts.exchangeAssets = await downloadAndDecodeFile(
+            file.path,
+            null,
+          );
+        } else {
+          const content = await downloadAndDecodeFile(
+            file.path,
+            Schema.Array(ChainLinkFeedInfoSchema),
+          );
+          artifacts.clArtifacts.push({
+            base: file.name,
+            content,
+          });
+        }
+      } else if (file.type === 'dir') {
+        if (file.path === CHAINLINK_FEEDS_DATA_DIR) {
+          console.info(`Fetching files in ${file.path}`);
+          await fetchRepoFiles(file.path, artifacts); // Recursively fetch subdirectories
+        } else {
+          console.warn(`Unknown directory: ${file.path}`);
+        }
+      }
+    }
+
+    return artifacts;
+  } catch (error) {
+    console.error(`Error fetching files in ${dirPath}:`, error);
+    return null;
+  }
+}

--- a/apps/data-feeds-config-generator/src/data-services/chainlink_feeds.ts
+++ b/apps/data-feeds-config-generator/src/data-services/chainlink_feeds.ts
@@ -1,7 +1,6 @@
 import { Web3 } from 'web3';
 
 import { assertIsObject } from '@blocksense/base-utils/assert';
-import { selectDirectory } from '@blocksense/base-utils/fs';
 import { getRpcUrl, isTestnet, networkName } from '@blocksense/base-utils/evm';
 
 import {
@@ -26,13 +25,12 @@ import {
   decodeChainLinkFeedsInfo,
 } from './types';
 import { Pair, createPair } from '@blocksense/config-types/data-feeds-config';
+import { CLArtifacts } from './artifacts-downloader';
 
-export async function collectRawDataFeeds(directoryPath: string) {
-  const { readAllJSONFiles } = selectDirectory(directoryPath);
-
+export async function collectRawDataFeeds(clArtifacts: CLArtifacts[]) {
   const rawDataFeeds: RawDataFeeds = {};
 
-  for (const { base, content } of await readAllJSONFiles()) {
+  for (const { base, content } of clArtifacts) {
     const info = decodeChainLinkFeedsInfo(content);
 
     for (const feed of info) {

--- a/apps/data-feeds-config-generator/src/data-services/fetchers/aggregators/cmc.ts
+++ b/apps/data-feeds-config-generator/src/data-services/fetchers/aggregators/cmc.ts
@@ -109,7 +109,7 @@ export async function fetchCMCCryptoList(): Promise<CMCInfoResp> {
   return typedData;
 }
 
-const CMCMarketCapDataSchema = S.Struct({
+export const CMCMarketCapDataSchema = S.Struct({
   cmc_rank: S.Number,
   id: S.Number,
   symbol: S.String,
@@ -119,11 +119,20 @@ const CMCMarketCapDataSchema = S.Struct({
       market_cap: S.Number,
     }),
   }),
+  market_cap_rank: S.NullishOr(S.Number),
 });
 
 export type CMCMarketCapData = S.Schema.Type<typeof CMCMarketCapDataSchema>;
 
-const CMCMarketCapDataRespSchema = S.mutable(
+export const CMCMarketCapDataResSchema = S.mutable(
+  S.Array(CMCMarketCapDataSchema),
+);
+
+export type CMCMarketCapDataRes = S.Schema.Type<
+  typeof CMCMarketCapDataResSchema
+>;
+
+export const CMCMarketCapDataRespSchema = S.mutable(
   S.Struct({
     data: S.mutable(S.Record({ key: S.String, value: CMCMarketCapDataSchema })),
   }),
@@ -143,9 +152,7 @@ async function fetchMarketCapData(ids: string[]): Promise<CMCMarketCapResp> {
   return typedData;
 }
 
-export async function fetchAssetsInMarketCapOrder(): Promise<
-  (CMCMarketCapData & { market_cap_rank: number })[]
-> {
+export async function fetchAssetsInMarketCapOrder(): Promise<CMCMarketCapDataRes> {
   const BATCH_SIZE = 1000;
 
   const cmcData = await fetchCMCCryptoList();

--- a/apps/data-feeds-config-generator/src/data-services/types.ts
+++ b/apps/data-feeds-config-generator/src/data-services/types.ts
@@ -23,7 +23,7 @@ export type ChainLinkFeedDocsInfo = S.Schema.Type<
 /**
  * Schema for the ChainLink feed information.
  */
-const ChainLinkFeedInfoSchema = S.Struct({
+export const ChainLinkFeedInfoSchema = S.Struct({
   compareOffchain: S.String,
   contractAddress: S.String,
   contractType: S.String,

--- a/apps/data-feeds-config-generator/src/feeds-config/data-providers.ts
+++ b/apps/data-feeds-config-generator/src/feeds-config/data-providers.ts
@@ -37,12 +37,6 @@ export async function addDataProviders(
     }),
   );
 
-  // Write data to JSON file
-  await saveToFile(
-    dataFeedsWithCryptoResources,
-    'dataFeedsWithCryptoResources',
-  );
-
   return dataFeedsWithCryptoResources;
 }
 

--- a/apps/data-feeds-config-generator/src/feeds-config/data-providers.ts
+++ b/apps/data-feeds-config-generator/src/feeds-config/data-providers.ts
@@ -37,7 +37,12 @@ export async function addDataProviders(
     }),
   );
 
-  return dataFeedsWithCryptoResources;
+  // Filter out feeds without exchange providers
+  const feedsWithExchangeProviders = dataFeedsWithCryptoResources.filter(
+    feed => 'exchanges' in feed.additional_feed_info.arguments,
+  );
+
+  return feedsWithExchangeProviders;
 }
 
 // Function to get all providers for a feed

--- a/apps/data-feeds-config-generator/src/feeds-config/data-providers.ts
+++ b/apps/data-feeds-config-generator/src/feeds-config/data-providers.ts
@@ -171,3 +171,9 @@ type ExchangeData = {
   type: 'exchanges' | 'aggregators';
   data: AssetInfo[];
 };
+
+export type ProviderData = {
+  name: string;
+  type: 'exchanges' | 'aggregators';
+  data: AssetInfo[];
+};

--- a/apps/data-feeds-config-generator/src/feeds-config/types.ts
+++ b/apps/data-feeds-config-generator/src/feeds-config/types.ts
@@ -5,4 +5,6 @@ export type SimplifiedFeed = Pick<
   'description' | 'full_name' | 'additional_feed_info'
 >;
 
-export type SimplifiedFeedWithRank = SimplifiedFeed & { rank: number | null };
+export type SimplifiedFeedWithRank = SimplifiedFeed & {
+  rank: number | null | undefined;
+};

--- a/config/chainlink_compatibility_new.json
+++ b/config/chainlink_compatibility_new.json
@@ -415,17 +415,6 @@
     },
     "43": {
       "id": 43,
-      "description": "WSTETH/USD-RefPrice-mainnet-production",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
-        }
-      }
-    },
-    "44": {
-      "id": 44,
       "description": "USDS / USD",
       "chainlink_compatibility": {
         "base": "0xdC035D45d973E3EC169d2276DDab16f1e407384F",
@@ -438,8 +427,8 @@
         }
       }
     },
-    "47": {
-      "id": 47,
+    "46": {
+      "id": 46,
       "description": "XLM / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -452,8 +441,8 @@
         }
       }
     },
-    "50": {
-      "id": 50,
+    "49": {
+      "id": 49,
       "description": "AVAX / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -474,8 +463,8 @@
         }
       }
     },
-    "53": {
-      "id": 53,
+    "52": {
+      "id": 52,
       "description": "SHIB / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -491,8 +480,8 @@
         }
       }
     },
-    "56": {
-      "id": 56,
+    "55": {
+      "id": 55,
       "description": "SUI/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -502,8 +491,8 @@
         }
       }
     },
-    "59": {
-      "id": 59,
+    "58": {
+      "id": 58,
       "description": "BCH / BNB",
       "chainlink_compatibility": {
         "base": null,
@@ -513,8 +502,8 @@
         }
       }
     },
-    "60": {
-      "id": 60,
+    "59": {
+      "id": 59,
       "description": "BCH / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -528,8 +517,8 @@
         }
       }
     },
-    "63": {
-      "id": 63,
+    "62": {
+      "id": 62,
       "description": "LTC / BNB",
       "chainlink_compatibility": {
         "base": null,
@@ -539,8 +528,8 @@
         }
       }
     },
-    "64": {
-      "id": 64,
+    "63": {
+      "id": 63,
       "description": "LTC / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -556,8 +545,8 @@
         }
       }
     },
-    "67": {
-      "id": 67,
+    "66": {
+      "id": 66,
       "description": "TON/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -567,8 +556,8 @@
         }
       }
     },
-    "70": {
-      "id": 70,
+    "69": {
+      "id": 69,
       "description": "OM/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
@@ -578,8 +567,8 @@
         }
       }
     },
-    "73": {
-      "id": 73,
+    "72": {
+      "id": 72,
       "description": "DOT / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -598,8 +587,8 @@
         }
       }
     },
-    "74": {
-      "id": 74,
+    "73": {
+      "id": 73,
       "description": "DOT / BNB",
       "chainlink_compatibility": {
         "base": null,
@@ -609,8 +598,8 @@
         }
       }
     },
-    "77": {
-      "id": 77,
+    "76": {
+      "id": 76,
       "description": "USDe/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -620,8 +609,8 @@
         }
       }
     },
-    "78": {
-      "id": 78,
+    "77": {
+      "id": 77,
       "description": "USDe / USD",
       "chainlink_compatibility": {
         "base": "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3",
@@ -637,8 +626,8 @@
         }
       }
     },
-    "83": {
-      "id": 83,
+    "82": {
+      "id": 82,
       "description": "DAI / USD",
       "chainlink_compatibility": {
         "base": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
@@ -670,8 +659,8 @@
         }
       }
     },
-    "84": {
-      "id": 84,
+    "83": {
+      "id": 83,
       "description": "DAI / BNB",
       "chainlink_compatibility": {
         "base": null,
@@ -682,8 +671,8 @@
         }
       }
     },
-    "87": {
-      "id": 87,
+    "86": {
+      "id": 86,
       "description": "HYPE/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
@@ -693,8 +682,8 @@
         }
       }
     },
-    "89": {
-      "id": 89,
+    "88": {
+      "id": 88,
       "description": "XMR / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -706,8 +695,8 @@
         }
       }
     },
-    "92": {
-      "id": 92,
+    "91": {
+      "id": 91,
       "description": "UNI / USD",
       "chainlink_compatibility": {
         "base": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
@@ -727,8 +716,8 @@
         }
       }
     },
-    "93": {
-      "id": 93,
+    "92": {
+      "id": 92,
       "description": "UNI / BNB",
       "chainlink_compatibility": {
         "base": null,
@@ -738,8 +727,8 @@
         }
       }
     },
-    "94": {
-      "id": 94,
+    "93": {
+      "id": 93,
       "description": "UNI / ETH",
       "chainlink_compatibility": {
         "base": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
@@ -750,19 +739,8 @@
         }
       }
     },
-    "97": {
-      "id": 97,
-      "description": "SUSDE/USD-RefPrice-mainnet-production",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
-        }
-      }
-    },
-    "98": {
-      "id": 98,
+    "96": {
+      "id": 96,
       "description": "APT/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -772,8 +750,8 @@
         }
       }
     },
-    "101": {
-      "id": 101,
+    "99": {
+      "id": 99,
       "description": "NEAR / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -789,8 +767,8 @@
         }
       }
     },
-    "104": {
-      "id": 104,
+    "102": {
+      "id": 102,
       "description": "PEPE/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -800,8 +778,8 @@
         }
       }
     },
-    "107": {
-      "id": 107,
+    "105": {
+      "id": 105,
       "description": "ETC / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -813,8 +791,8 @@
         }
       }
     },
-    "110": {
-      "id": 110,
+    "108": {
+      "id": 108,
       "description": "ONDO/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -824,8 +802,8 @@
         }
       }
     },
-    "113": {
-      "id": 113,
+    "111": {
+      "id": 111,
       "description": "ICP / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -838,8 +816,8 @@
         }
       }
     },
-    "116": {
-      "id": 116,
+    "114": {
+      "id": 114,
       "description": "AAVE / USD",
       "chainlink_compatibility": {
         "base": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
@@ -866,8 +844,8 @@
         }
       }
     },
-    "117": {
-      "id": 117,
+    "115": {
+      "id": 115,
       "description": "AAVE / ETH",
       "chainlink_compatibility": {
         "base": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
@@ -878,8 +856,8 @@
         }
       }
     },
-    "120": {
-      "id": 120,
+    "118": {
+      "id": 118,
       "description": "MNT / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -890,19 +868,8 @@
         }
       }
     },
-    "123": {
-      "id": 123,
-      "description": "cbBTC/USD-RefPrice-mainnet-production",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
-        }
-      }
-    },
-    "124": {
-      "id": 124,
+    "121": {
+      "id": 121,
       "description": "TAO/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -912,8 +879,8 @@
         }
       }
     },
-    "127": {
-      "id": 127,
+    "124": {
+      "id": 124,
       "description": "VET / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -923,8 +890,8 @@
         }
       }
     },
-    "129": {
-      "id": 129,
+    "126": {
+      "id": 126,
       "description": "FDUSD / USD",
       "chainlink_compatibility": {
         "base": "0xc5f0f7b66764F6ec8C8Dff7BA683102295E16409",
@@ -935,8 +902,8 @@
         }
       }
     },
-    "132": {
-      "id": 132,
+    "129": {
+      "id": 129,
       "description": "TIA/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -946,8 +913,8 @@
         }
       }
     },
-    "135": {
-      "id": 135,
+    "132": {
+      "id": 132,
       "description": "POL / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -963,8 +930,8 @@
         }
       }
     },
-    "136": {
-      "id": 136,
+    "133": {
+      "id": 133,
       "description": "MATIC / ETH",
       "chainlink_compatibility": {
         "base": null,
@@ -974,8 +941,8 @@
         }
       }
     },
-    "139": {
-      "id": 139,
+    "136": {
+      "id": 136,
       "description": "FIL / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -990,8 +957,8 @@
         }
       }
     },
-    "140": {
-      "id": 140,
+    "137": {
+      "id": 137,
       "description": "FIL / ETH",
       "chainlink_compatibility": {
         "base": null,
@@ -1001,8 +968,8 @@
         }
       }
     },
-    "143": {
-      "id": 143,
+    "140": {
+      "id": 140,
       "description": "LBTC/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
@@ -1012,9 +979,20 @@
         }
       }
     },
+    "142": {
+      "id": 142,
+      "description": "ALGO/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
     "145": {
       "id": 145,
-      "description": "ALGO/USD-RefPrice-DS-Premium-Global-003",
+      "description": "RENDER/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -1025,17 +1003,6 @@
     },
     "148": {
       "id": 148,
-      "description": "RENDER/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "151": {
-      "id": 151,
       "description": "ATOM / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1049,8 +1016,8 @@
         }
       }
     },
-    "154": {
-      "id": 154,
+    "151": {
+      "id": 151,
       "description": "ARB / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1067,8 +1034,8 @@
         }
       }
     },
-    "157": {
-      "id": 157,
+    "154": {
+      "id": 154,
       "description": "JUP/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1078,8 +1045,8 @@
         }
       }
     },
-    "160": {
-      "id": 160,
+    "157": {
+      "id": 157,
       "description": "OP / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1093,8 +1060,8 @@
         }
       }
     },
-    "163": {
-      "id": 163,
+    "160": {
+      "id": 160,
       "description": "S/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
@@ -1104,8 +1071,8 @@
         }
       }
     },
-    "166": {
-      "id": 166,
+    "163": {
+      "id": 163,
       "description": "FET / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1117,8 +1084,8 @@
         }
       }
     },
-    "169": {
-      "id": 169,
+    "166": {
+      "id": 166,
       "description": "ENA/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1128,19 +1095,8 @@
         }
       }
     },
-    "172": {
-      "id": 172,
-      "description": "USD0 / USD",
-      "chainlink_compatibility": {
-        "base": "0x73A15FeD60Bf67631dC6cd7Bc5B6e8da8190aCF5",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x90Fb891e7EE51972f7D9309a6B812D04ED2643c7"
-        }
-      }
-    },
-    "173": {
-      "id": 173,
+    "169": {
+      "id": 169,
       "description": "MKR / USD",
       "chainlink_compatibility": {
         "base": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
@@ -1157,8 +1113,8 @@
         }
       }
     },
-    "174": {
-      "id": 174,
+    "170": {
+      "id": 170,
       "description": "MKR / ETH",
       "chainlink_compatibility": {
         "base": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
@@ -1169,8 +1125,8 @@
         }
       }
     },
-    "177": {
-      "id": 177,
+    "173": {
+      "id": 173,
       "description": "ZBU / USD",
       "chainlink_compatibility": {
         "base": "0xe77f6aCD24185e149e329C1C0F479201b9Ec2f4B",
@@ -1182,8 +1138,8 @@
         }
       }
     },
-    "179": {
-      "id": 179,
+    "175": {
+      "id": 175,
       "description": "STX / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1195,8 +1151,8 @@
         }
       }
     },
-    "182": {
-      "id": 182,
+    "178": {
+      "id": 178,
       "description": "INJ / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1209,8 +1165,8 @@
         }
       }
     },
-    "185": {
-      "id": 185,
+    "181": {
+      "id": 181,
       "description": "IMX/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1220,8 +1176,8 @@
         }
       }
     },
-    "188": {
-      "id": 188,
+    "184": {
+      "id": 184,
       "description": "QNT/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1231,9 +1187,31 @@
         }
       }
     },
-    "190": {
-      "id": 190,
+    "186": {
+      "id": 186,
       "description": "WLD/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "189": {
+      "id": 189,
+      "description": "THETA / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "polygon-mainnet": "0xC7c7eAc6c3Ec943Bb6D15F2FB7aa80aA0c9dAF32"
+        }
+      }
+    },
+    "192": {
+      "id": 192,
+      "description": "GRT/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -1244,39 +1222,6 @@
     },
     "193": {
       "id": 193,
-      "description": "THETA / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "polygon-mainnet": "0xC7c7eAc6c3Ec943Bb6D15F2FB7aa80aA0c9dAF32"
-        }
-      }
-    },
-    "196": {
-      "id": 196,
-      "description": "USD0++ / USD",
-      "chainlink_compatibility": {
-        "base": "0x35D8949372D46B7a3D5A56006AE77B215fc69bC0",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0xF816091bA795C1b55859599fcDa8f786B2816e01"
-        }
-      }
-    },
-    "197": {
-      "id": 197,
-      "description": "GRT/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "198": {
-      "id": 198,
       "description": "GRT / ETH",
       "chainlink_compatibility": {
         "base": "0xc944E90C64B2c07662A292be6244BDf05Cda44a7",
@@ -1286,8 +1231,8 @@
         }
       }
     },
-    "201": {
-      "id": 201,
+    "196": {
+      "id": 196,
       "description": "SEI/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1297,8 +1242,8 @@
         }
       }
     },
-    "204": {
-      "id": 204,
+    "199": {
+      "id": 199,
       "description": "BONK/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1308,8 +1253,8 @@
         }
       }
     },
-    "207": {
-      "id": 207,
+    "202": {
+      "id": 202,
       "description": "LDO/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1319,8 +1264,8 @@
         }
       }
     },
-    "210": {
-      "id": 210,
+    "205": {
+      "id": 205,
       "description": "EOS / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1333,8 +1278,8 @@
         }
       }
     },
-    "211": {
-      "id": 211,
+    "206": {
+      "id": 206,
       "description": "EOS / BNB",
       "chainlink_compatibility": {
         "base": null,
@@ -1344,8 +1289,8 @@
         }
       }
     },
-    "214": {
-      "id": 214,
+    "209": {
+      "id": 209,
       "description": "GALA/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1355,8 +1300,8 @@
         }
       }
     },
-    "217": {
-      "id": 217,
+    "212": {
+      "id": 212,
       "description": "PYUSD / USD",
       "chainlink_compatibility": {
         "base": "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8",
@@ -1366,8 +1311,8 @@
         }
       }
     },
-    "219": {
-      "id": 219,
+    "214": {
+      "id": 214,
       "description": "XTZ / BNB",
       "chainlink_compatibility": {
         "base": null,
@@ -1377,8 +1322,8 @@
         }
       }
     },
-    "220": {
-      "id": 220,
+    "215": {
+      "id": 215,
       "description": "XTZ / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1391,8 +1336,8 @@
         }
       }
     },
-    "223": {
-      "id": 223,
+    "218": {
+      "id": 218,
       "description": "SAND / USD",
       "chainlink_compatibility": {
         "base": "0x3845badAde8e6dFF049820680d1F14bD3903a5d0",
@@ -1407,8 +1352,8 @@
         }
       }
     },
-    "226": {
-      "id": 226,
+    "221": {
+      "id": 221,
       "description": "BERA/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1418,8 +1363,8 @@
         }
       }
     },
-    "229": {
-      "id": 229,
+    "224": {
+      "id": 224,
       "description": "JTO/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1429,8 +1374,8 @@
         }
       }
     },
-    "232": {
-      "id": 232,
+    "227": {
+      "id": 227,
       "description": "FLOW/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1440,8 +1385,8 @@
         }
       }
     },
-    "235": {
-      "id": 235,
+    "230": {
+      "id": 230,
       "description": "FLOKI/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1451,19 +1396,8 @@
         }
       }
     },
-    "238": {
-      "id": 238,
-      "description": "ezETH/USD-RefPrice-mainnet-production",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
-        }
-      }
-    },
-    "239": {
-      "id": 239,
+    "233": {
+      "id": 233,
       "description": "ENS / USD",
       "chainlink_compatibility": {
         "base": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
@@ -1473,8 +1407,8 @@
         }
       }
     },
-    "242": {
-      "id": 242,
+    "236": {
+      "id": 236,
       "description": "MANA / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1486,8 +1420,8 @@
         }
       }
     },
-    "243": {
-      "id": 243,
+    "237": {
+      "id": 237,
       "description": "MANA / ETH",
       "chainlink_compatibility": {
         "base": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
@@ -1497,8 +1431,8 @@
         }
       }
     },
-    "246": {
-      "id": 246,
+    "240": {
+      "id": 240,
       "description": "CRV / USD",
       "chainlink_compatibility": {
         "base": "0xD533a949740bb3306d119CC777fa900bA034cd52",
@@ -1517,8 +1451,8 @@
         }
       }
     },
-    "247": {
-      "id": 247,
+    "241": {
+      "id": 241,
       "description": "CRV / ETH",
       "chainlink_compatibility": {
         "base": "0xD533a949740bb3306d119CC777fa900bA034cd52",
@@ -1529,8 +1463,8 @@
         }
       }
     },
-    "250": {
-      "id": 250,
+    "244": {
+      "id": 244,
       "description": "PYTH/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1540,8 +1474,8 @@
         }
       }
     },
-    "253": {
-      "id": 253,
+    "247": {
+      "id": 247,
       "description": "EGLD/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1551,8 +1485,8 @@
         }
       }
     },
-    "256": {
-      "id": 256,
+    "250": {
+      "id": 250,
       "description": "RON / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1563,8 +1497,8 @@
         }
       }
     },
-    "259": {
-      "id": 259,
+    "253": {
+      "id": 253,
       "description": "AXS / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1580,8 +1514,8 @@
         }
       }
     },
-    "262": {
-      "id": 262,
+    "256": {
+      "id": 256,
       "description": "TUSD / USD",
       "chainlink_compatibility": {
         "base": "0x0000000000085d4780B73119b644AE5ecd22b376",
@@ -1595,8 +1529,8 @@
         }
       }
     },
-    "263": {
-      "id": 263,
+    "257": {
+      "id": 257,
       "description": "TUSD / ETH",
       "chainlink_compatibility": {
         "base": "0x0000000000085d4780B73119b644AE5ecd22b376",
@@ -1606,8 +1540,8 @@
         }
       }
     },
-    "265": {
-      "id": 265,
+    "259": {
+      "id": 259,
       "description": "ZEC/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1617,8 +1551,8 @@
         }
       }
     },
-    "268": {
-      "id": 268,
+    "262": {
+      "id": 262,
       "description": "KAVA / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1629,8 +1563,8 @@
         }
       }
     },
-    "270": {
-      "id": 270,
+    "264": {
+      "id": 264,
       "description": "DYDX/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1640,8 +1574,8 @@
         }
       }
     },
-    "273": {
-      "id": 273,
+    "267": {
+      "id": 267,
       "description": "XCN / USD",
       "chainlink_compatibility": {
         "base": "0xA2cd3D43c775978A96BdBf12d733D5A1ED94fb18",
@@ -1651,8 +1585,8 @@
         }
       }
     },
-    "275": {
-      "id": 275,
+    "269": {
+      "id": 269,
       "description": "WIF/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1662,8 +1596,8 @@
         }
       }
     },
-    "278": {
-      "id": 278,
+    "272": {
+      "id": 272,
       "description": "STRK/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1673,8 +1607,8 @@
         }
       }
     },
-    "281": {
-      "id": 281,
+    "275": {
+      "id": 275,
       "description": "CAKE / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1686,8 +1620,8 @@
         }
       }
     },
-    "282": {
-      "id": 282,
+    "276": {
+      "id": 276,
       "description": "CAKE / BNB",
       "chainlink_compatibility": {
         "base": null,
@@ -1697,8 +1631,8 @@
         }
       }
     },
-    "285": {
-      "id": 285,
+    "279": {
+      "id": 279,
       "description": "MATIC / USD",
       "chainlink_compatibility": {
         "base": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
@@ -1722,8 +1656,8 @@
         }
       }
     },
-    "288": {
-      "id": 288,
+    "282": {
+      "id": 282,
       "description": "AERO / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1733,8 +1667,8 @@
         }
       }
     },
-    "290": {
-      "id": 290,
+    "284": {
+      "id": 284,
       "description": "CHZ / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1746,8 +1680,8 @@
         }
       }
     },
-    "293": {
-      "id": 293,
+    "287": {
+      "id": 287,
       "description": "FRAX / USD",
       "chainlink_compatibility": {
         "base": "0x853d955aCEf822Db058eb8505911ED77F175b99e",
@@ -1764,8 +1698,8 @@
         }
       }
     },
-    "295": {
-      "id": 295,
+    "289": {
+      "id": 289,
       "description": "CORE / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1775,8 +1709,8 @@
         }
       }
     },
-    "298": {
-      "id": 298,
+    "292": {
+      "id": 292,
       "description": "RUNE / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1787,8 +1721,8 @@
         }
       }
     },
-    "301": {
-      "id": 301,
+    "295": {
+      "id": 295,
       "description": "AR/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1798,8 +1732,8 @@
         }
       }
     },
-    "304": {
-      "id": 304,
+    "298": {
+      "id": 298,
       "description": "CFX / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1809,8 +1743,8 @@
         }
       }
     },
-    "307": {
-      "id": 307,
+    "301": {
+      "id": 301,
       "description": "FTT / ETH",
       "chainlink_compatibility": {
         "base": "0x50D1c9771902476076eCFc8B2A83Ad6b9355a4c9",
@@ -1820,8 +1754,8 @@
         }
       }
     },
-    "308": {
-      "id": 308,
+    "302": {
+      "id": 302,
       "description": "FTT / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1832,8 +1766,8 @@
         }
       }
     },
-    "311": {
-      "id": 311,
+    "305": {
+      "id": 305,
       "description": "APE / USD",
       "chainlink_compatibility": {
         "base": "0x4d224452801ACEd8B2F0aebE155379bb5D594381",
@@ -1848,8 +1782,8 @@
         }
       }
     },
-    "312": {
-      "id": 312,
+    "306": {
+      "id": 306,
       "description": "APE / ETH",
       "chainlink_compatibility": {
         "base": "0x4d224452801ACEd8B2F0aebE155379bb5D594381",
@@ -1859,8 +1793,8 @@
         }
       }
     },
-    "315": {
-      "id": 315,
+    "309": {
+      "id": 309,
       "description": "VIRTUAL/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1870,8 +1804,8 @@
         }
       }
     },
-    "318": {
-      "id": 318,
+    "312": {
+      "id": 312,
       "description": "PENGU/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1881,8 +1815,8 @@
         }
       }
     },
-    "321": {
-      "id": 321,
+    "315": {
+      "id": 315,
       "description": "COMP / USD",
       "chainlink_compatibility": {
         "base": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
@@ -1902,8 +1836,8 @@
         }
       }
     },
-    "324": {
-      "id": 324,
+    "318": {
+      "id": 318,
       "description": "AXL / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1914,8 +1848,8 @@
         }
       }
     },
-    "326": {
-      "id": 326,
+    "320": {
+      "id": 320,
       "description": "PENDLE / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1927,8 +1861,8 @@
         }
       }
     },
-    "329": {
-      "id": 329,
+    "323": {
+      "id": 323,
       "description": "SPX/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
@@ -1938,8 +1872,8 @@
         }
       }
     },
-    "331": {
-      "id": 331,
+    "325": {
+      "id": 325,
       "description": "GNO / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1949,8 +1883,8 @@
         }
       }
     },
-    "333": {
-      "id": 333,
+    "327": {
+      "id": 327,
       "description": "MORPHO/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
@@ -1960,8 +1894,8 @@
         }
       }
     },
-    "336": {
-      "id": 336,
+    "330": {
+      "id": 330,
       "description": "RSR / USD",
       "chainlink_compatibility": {
         "base": "0x320623b8E4fF03373931769A31Fc52A4E78B5d70",
@@ -1973,8 +1907,8 @@
         }
       }
     },
-    "339": {
-      "id": 339,
+    "333": {
+      "id": 333,
       "description": "BRETT/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1984,8 +1918,8 @@
         }
       }
     },
-    "342": {
-      "id": 342,
+    "336": {
+      "id": 336,
       "description": "BEAM / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1995,8 +1929,8 @@
         }
       }
     },
-    "344": {
-      "id": 344,
+    "338": {
+      "id": 338,
       "description": "deUSD / USD",
       "chainlink_compatibility": {
         "base": "0x15700B564Ca08D9439C58cA5053166E8317aa138",
@@ -2009,8 +1943,8 @@
         }
       }
     },
-    "346": {
-      "id": 346,
+    "340": {
+      "id": 340,
       "description": "SNX / USD",
       "chainlink_compatibility": {
         "base": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
@@ -2030,8 +1964,8 @@
         }
       }
     },
-    "347": {
-      "id": 347,
+    "341": {
+      "id": 341,
       "description": "SNX / ETH",
       "chainlink_compatibility": {
         "base": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
@@ -2041,8 +1975,8 @@
         }
       }
     },
-    "350": {
-      "id": 350,
+    "344": {
+      "id": 344,
       "description": "FARTCOIN/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2052,8 +1986,8 @@
         }
       }
     },
-    "353": {
-      "id": 353,
+    "347": {
+      "id": 347,
       "description": "1INCH / USD",
       "chainlink_compatibility": {
         "base": "0x111111111117dC0aa78b770fA6A738034120C302",
@@ -2069,8 +2003,8 @@
         }
       }
     },
-    "356": {
-      "id": 356,
+    "350": {
+      "id": 350,
       "description": "DASH / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2080,8 +2014,8 @@
         }
       }
     },
-    "358": {
-      "id": 358,
+    "352": {
+      "id": 352,
       "description": "EIGEN/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2091,9 +2025,31 @@
         }
       }
     },
+    "355": {
+      "id": 355,
+      "description": "ZK/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "358": {
+      "id": 358,
+      "description": "KSM / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "kusama-moonriver": "0xbaA5A3379F28D3e63e623E5F96FafEE6A34d02fd"
+        }
+      }
+    },
     "361": {
       "id": 361,
-      "description": "ZK/USD-RefPrice-DS-Premium-Global-003",
+      "description": "SATS/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2104,28 +2060,6 @@
     },
     "364": {
       "id": 364,
-      "description": "KSM / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "kusama-moonriver": "0xbaA5A3379F28D3e63e623E5F96FafEE6A34d02fd"
-        }
-      }
-    },
-    "367": {
-      "id": 367,
-      "description": "SATS/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "370": {
-      "id": 370,
       "description": "ASTR/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2135,8 +2069,8 @@
         }
       }
     },
-    "373": {
-      "id": 373,
+    "367": {
+      "id": 367,
       "description": "ZIL / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2148,9 +2082,31 @@
         }
       }
     },
+    "370": {
+      "id": 370,
+      "description": "ATH/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "373": {
+      "id": 373,
+      "description": "BLUR/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
     "376": {
       "id": 376,
-      "description": "ATH/USD-RefPrice-DS-Premium-Global-003",
+      "description": "NOT/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2161,28 +2117,6 @@
     },
     "379": {
       "id": 379,
-      "description": "BLUR/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "382": {
-      "id": 382,
-      "description": "NOT/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "385": {
-      "id": 385,
       "description": "USDD / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2192,8 +2126,8 @@
         }
       }
     },
-    "388": {
-      "id": 388,
+    "382": {
+      "id": 382,
       "description": "BAT / USD",
       "chainlink_compatibility": {
         "base": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
@@ -2206,8 +2140,8 @@
         }
       }
     },
-    "389": {
-      "id": 389,
+    "383": {
+      "id": 383,
       "description": "BAT / ETH",
       "chainlink_compatibility": {
         "base": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
@@ -2217,8 +2151,8 @@
         }
       }
     },
-    "392": {
-      "id": 392,
+    "386": {
+      "id": 386,
       "description": "MASK / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2228,8 +2162,8 @@
         }
       }
     },
-    "395": {
-      "id": 395,
+    "389": {
+      "id": 389,
       "description": "ID/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2239,8 +2173,8 @@
         }
       }
     },
-    "398": {
-      "id": 398,
+    "392": {
+      "id": 392,
       "description": "ZRX / USD",
       "chainlink_compatibility": {
         "base": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
@@ -2253,8 +2187,8 @@
         }
       }
     },
-    "399": {
-      "id": 399,
+    "393": {
+      "id": 393,
       "description": "ZRX / ETH",
       "chainlink_compatibility": {
         "base": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
@@ -2264,8 +2198,8 @@
         }
       }
     },
-    "402": {
-      "id": 402,
+    "396": {
+      "id": 396,
       "description": "ZRO/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2275,8 +2209,8 @@
         }
       }
     },
-    "405": {
-      "id": 405,
+    "399": {
+      "id": 399,
       "description": "HOT/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2286,8 +2220,8 @@
         }
       }
     },
-    "407": {
-      "id": 407,
+    "401": {
+      "id": 401,
       "description": "WEMIX / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2298,8 +2232,8 @@
         }
       }
     },
-    "409": {
-      "id": 409,
+    "403": {
+      "id": 403,
       "description": "ORDI/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2309,8 +2243,8 @@
         }
       }
     },
-    "412": {
-      "id": 412,
+    "406": {
+      "id": 406,
       "description": "CELO / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2323,8 +2257,8 @@
         }
       }
     },
-    "415": {
-      "id": 415,
+    "409": {
+      "id": 409,
       "description": "AI16Z/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2334,8 +2268,8 @@
         }
       }
     },
-    "418": {
-      "id": 418,
+    "412": {
+      "id": 412,
       "description": "CVX / USD",
       "chainlink_compatibility": {
         "base": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
@@ -2350,8 +2284,8 @@
         }
       }
     },
-    "421": {
-      "id": 421,
+    "415": {
+      "id": 415,
       "description": "MOG/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2361,8 +2295,8 @@
         }
       }
     },
-    "423": {
-      "id": 423,
+    "417": {
+      "id": 417,
       "description": "ANKR / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2373,8 +2307,8 @@
         }
       }
     },
-    "426": {
-      "id": 426,
+    "420": {
+      "id": 420,
       "description": "YFI / USD",
       "chainlink_compatibility": {
         "base": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
@@ -2393,8 +2327,8 @@
         }
       }
     },
-    "427": {
-      "id": 427,
+    "421": {
+      "id": 421,
       "description": "YFI / BNB",
       "chainlink_compatibility": {
         "base": null,
@@ -2404,8 +2338,8 @@
         }
       }
     },
-    "428": {
-      "id": 428,
+    "422": {
+      "id": 422,
       "description": "YFI / ETH",
       "chainlink_compatibility": {
         "base": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
@@ -2416,8 +2350,8 @@
         }
       }
     },
-    "431": {
-      "id": 431,
+    "425": {
+      "id": 425,
       "description": "ENJ / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2428,8 +2362,8 @@
         }
       }
     },
-    "432": {
-      "id": 432,
+    "426": {
+      "id": 426,
       "description": "ENJ / ETH",
       "chainlink_compatibility": {
         "base": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c",
@@ -2439,8 +2373,8 @@
         }
       }
     },
-    "435": {
-      "id": 435,
+    "429": {
+      "id": 429,
       "description": "PNUT/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
@@ -2450,8 +2384,8 @@
         }
       }
     },
-    "438": {
-      "id": 438,
+    "432": {
+      "id": 432,
       "description": "ONE / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2462,8 +2396,8 @@
         }
       }
     },
-    "441": {
-      "id": 441,
+    "435": {
+      "id": 435,
       "description": "MEW/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2473,8 +2407,8 @@
         }
       }
     },
-    "444": {
-      "id": 444,
+    "438": {
+      "id": 438,
       "description": "SUSHI / USD",
       "chainlink_compatibility": {
         "base": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
@@ -2492,8 +2426,8 @@
         }
       }
     },
-    "445": {
-      "id": 445,
+    "439": {
+      "id": 439,
       "description": "SUSHI / ETH",
       "chainlink_compatibility": {
         "base": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
@@ -2504,8 +2438,8 @@
         }
       }
     },
-    "448": {
-      "id": 448,
+    "442": {
+      "id": 442,
       "description": "IOTX / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2515,8 +2449,8 @@
         }
       }
     },
-    "450": {
-      "id": 450,
+    "444": {
+      "id": 444,
       "description": "ETHFI/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2526,8 +2460,8 @@
         }
       }
     },
-    "453": {
-      "id": 453,
+    "447": {
+      "id": 447,
       "description": "WOO / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2539,8 +2473,8 @@
         }
       }
     },
-    "455": {
-      "id": 455,
+    "449": {
+      "id": 449,
       "description": "POPCAT/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
@@ -2550,8 +2484,8 @@
         }
       }
     },
-    "457": {
-      "id": 457,
+    "451": {
+      "id": 451,
       "description": "TURBO/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2561,8 +2495,8 @@
         }
       }
     },
-    "460": {
-      "id": 460,
+    "454": {
+      "id": 454,
       "description": "DGB / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2572,8 +2506,8 @@
         }
       }
     },
-    "463": {
-      "id": 463,
+    "457": {
+      "id": 457,
       "description": "LRC / ETH",
       "chainlink_compatibility": {
         "base": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
@@ -2583,8 +2517,8 @@
         }
       }
     },
-    "464": {
-      "id": 464,
+    "458": {
+      "id": 458,
       "description": "HMSTR/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2594,8 +2528,8 @@
         }
       }
     },
-    "467": {
-      "id": 467,
+    "461": {
+      "id": 461,
       "description": "GMX / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2609,8 +2543,8 @@
         }
       }
     },
-    "469": {
-      "id": 469,
+    "463": {
+      "id": 463,
       "description": "EURC / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2622,19 +2556,8 @@
         }
       }
     },
-    "471": {
-      "id": 471,
-      "description": "RLUSD / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x7d95b7bf7bB7750d818F42Df114739B6C88CF9bC"
-        }
-      }
-    },
-    "472": {
-      "id": 472,
+    "465": {
+      "id": 465,
       "description": "GMT / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2645,8 +2568,8 @@
         }
       }
     },
-    "475": {
-      "id": 475,
+    "468": {
+      "id": 468,
       "description": "FXS / USD",
       "chainlink_compatibility": {
         "base": "0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0",
@@ -2662,8 +2585,8 @@
         }
       }
     },
-    "477": {
-      "id": 477,
+    "470": {
+      "id": 470,
       "description": "ONT / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2673,8 +2596,8 @@
         }
       }
     },
-    "480": {
-      "id": 480,
+    "473": {
+      "id": 473,
       "description": "SXP / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2685,9 +2608,42 @@
         }
       }
     },
-    "482": {
-      "id": 482,
+    "475": {
+      "id": 475,
       "description": "POLYX/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "477": {
+      "id": 477,
+      "description": "BAND / BNB",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": null,
+        "chainlink_aggregators": {
+          "bsc-mainnet": "0x2f52D9f15D1C3b381F44483957851f4D0486EDfF"
+        }
+      }
+    },
+    "478": {
+      "id": 478,
+      "description": "BAND / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "bsc-mainnet": "0x7DBC514F75adf57F7a7Cb637fcBAd6F1c1b90eE5"
+        }
+      }
+    },
+    "481": {
+      "id": 481,
+      "description": "ARKM/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2698,39 +2654,6 @@
     },
     "484": {
       "id": 484,
-      "description": "BAND / BNB",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": null,
-        "chainlink_aggregators": {
-          "bsc-mainnet": "0x2f52D9f15D1C3b381F44483957851f4D0486EDfF"
-        }
-      }
-    },
-    "485": {
-      "id": 485,
-      "description": "BAND / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "bsc-mainnet": "0x7DBC514F75adf57F7a7Cb637fcBAd6F1c1b90eE5"
-        }
-      }
-    },
-    "488": {
-      "id": 488,
-      "description": "ARKM/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "491": {
-      "id": 491,
       "description": "IO/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2740,8 +2663,8 @@
         }
       }
     },
-    "494": {
-      "id": 494,
+    "487": {
+      "id": 487,
       "description": "STORJ / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2751,8 +2674,8 @@
         }
       }
     },
-    "497": {
-      "id": 497,
+    "490": {
+      "id": 490,
       "description": "RPL / USD",
       "chainlink_compatibility": {
         "base": "0xD33526068D116cE69F19A9ee46F0bd304F21A51f",
@@ -2765,8 +2688,8 @@
         }
       }
     },
-    "500": {
-      "id": 500,
+    "493": {
+      "id": 493,
       "description": "USUAL/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
@@ -2776,8 +2699,8 @@
         }
       }
     },
-    "503": {
-      "id": 503,
+    "496": {
+      "id": 496,
       "description": "AEVO/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2787,8 +2710,8 @@
         }
       }
     },
-    "506": {
-      "id": 506,
+    "499": {
+      "id": 499,
       "description": "METIS / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2799,8 +2722,8 @@
         }
       }
     },
-    "509": {
-      "id": 509,
+    "502": {
+      "id": 502,
       "description": "NEIRO / USD",
       "chainlink_compatibility": {
         "base": "0xEE2a03Aa6Dacf51C18679C516ad5283d8E7C2637",
@@ -2810,8 +2733,8 @@
         }
       }
     },
-    "512": {
-      "id": 512,
+    "505": {
+      "id": 505,
       "description": "MEME/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2821,8 +2744,8 @@
         }
       }
     },
-    "515": {
-      "id": 515,
+    "508": {
+      "id": 508,
       "description": "UMA / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2835,8 +2758,8 @@
         }
       }
     },
-    "518": {
-      "id": 518,
+    "511": {
+      "id": 511,
       "description": "AVAIL / USD",
       "chainlink_compatibility": {
         "base": "0xEeB4d8400AEefafC1B2953e0094134A887C76Bd8",
@@ -2847,8 +2770,8 @@
         }
       }
     },
-    "520": {
-      "id": 520,
+    "513": {
+      "id": 513,
       "description": "MANTA/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2858,8 +2781,8 @@
         }
       }
     },
-    "523": {
-      "id": 523,
+    "516": {
+      "id": 516,
       "description": "ALT/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2869,8 +2792,8 @@
         }
       }
     },
-    "526": {
-      "id": 526,
+    "519": {
+      "id": 519,
       "description": "SPELL / USD",
       "chainlink_compatibility": {
         "base": "0x090185f2135308BaD17527004364eBcC2D37e5F6",
@@ -2884,8 +2807,8 @@
         }
       }
     },
-    "528": {
-      "id": 528,
+    "521": {
+      "id": 521,
       "description": "BOME/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2895,8 +2818,8 @@
         }
       }
     },
-    "531": {
-      "id": 531,
+    "524": {
+      "id": 524,
       "description": "IQ/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2906,8 +2829,8 @@
         }
       }
     },
-    "534": {
-      "id": 534,
+    "527": {
+      "id": 527,
       "description": "AIXBT/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
@@ -2917,8 +2840,8 @@
         }
       }
     },
-    "537": {
-      "id": 537,
+    "530": {
+      "id": 530,
       "description": "VELO / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2928,8 +2851,8 @@
         }
       }
     },
-    "540": {
-      "id": 540,
+    "533": {
+      "id": 533,
       "description": "BAL / USD",
       "chainlink_compatibility": {
         "base": "0xba100000625a3754423978a60c9317c58a424e3D",
@@ -2944,8 +2867,8 @@
         }
       }
     },
-    "543": {
-      "id": 543,
+    "536": {
+      "id": 536,
       "description": "XVS / BNB",
       "chainlink_compatibility": {
         "base": null,
@@ -2955,8 +2878,8 @@
         }
       }
     },
-    "544": {
-      "id": 544,
+    "537": {
+      "id": 537,
       "description": "XVS / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2968,8 +2891,8 @@
         }
       }
     },
-    "546": {
-      "id": 546,
+    "539": {
+      "id": 539,
       "description": "CHR / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2979,8 +2902,8 @@
         }
       }
     },
-    "548": {
-      "id": 548,
+    "541": {
+      "id": 541,
       "description": "ONG / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2990,8 +2913,8 @@
         }
       }
     },
-    "550": {
-      "id": 550,
+    "543": {
+      "id": 543,
       "description": "BLAST/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3001,9 +2924,42 @@
         }
       }
     },
+    "545": {
+      "id": 545,
+      "description": "BIGTIME/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "548": {
+      "id": 548,
+      "description": "ILV/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "550": {
+      "id": 550,
+      "description": "USDP / USD",
+      "chainlink_compatibility": {
+        "base": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "ethereum-mainnet": "0xb611401574061947aBAc7d2406711F115BE22A6e"
+        }
+      }
+    },
     "552": {
       "id": 552,
-      "description": "BIGTIME/USD-RefPrice-DS-Premium-Global-003",
+      "description": "PEOPLE/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -3014,52 +2970,6 @@
     },
     "555": {
       "id": 555,
-      "description": "ILV/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "557": {
-      "id": 557,
-      "description": "USDP / USD",
-      "chainlink_compatibility": {
-        "base": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0xb611401574061947aBAc7d2406711F115BE22A6e"
-        }
-      }
-    },
-    "559": {
-      "id": 559,
-      "description": "PEOPLE/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "562": {
-      "id": 562,
-      "description": "USDX / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x9b9b43029aA05729b5c391CfBB4150087eF42950",
-          "base-mainnet": "0x9120eFBD64713BB6Ebb5c8e560e8e56aFE712eD2",
-          "bsc-mainnet": "0x27E96cBD8db24eb35509d8c4E820972861f74EA0"
-        }
-      }
-    },
-    "563": {
-      "id": 563,
       "description": "TRB / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3070,8 +2980,8 @@
         }
       }
     },
-    "566": {
-      "id": 566,
+    "558": {
+      "id": 558,
       "description": "PIXEL/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3081,8 +2991,8 @@
         }
       }
     },
-    "569": {
-      "id": 569,
+    "561": {
+      "id": 561,
       "description": "XAI/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3092,8 +3002,8 @@
         }
       }
     },
-    "571": {
-      "id": 571,
+    "563": {
+      "id": 563,
       "description": "SLP / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3103,8 +3013,8 @@
         }
       }
     },
-    "574": {
-      "id": 574,
+    "566": {
+      "id": 566,
       "description": "USDtb / USD",
       "chainlink_compatibility": {
         "base": "0xC139190F447e929f090Edeb554D95AbB8b18aC1C",
@@ -3114,8 +3024,8 @@
         }
       }
     },
-    "576": {
-      "id": 576,
+    "568": {
+      "id": 568,
       "description": "HSK / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3125,8 +3035,8 @@
         }
       }
     },
-    "578": {
-      "id": 578,
+    "570": {
+      "id": 570,
       "description": "JOE / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3137,8 +3047,8 @@
         }
       }
     },
-    "581": {
-      "id": 581,
+    "573": {
+      "id": 573,
       "description": "SCR/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3148,8 +3058,8 @@
         }
       }
     },
-    "584": {
-      "id": 584,
+    "576": {
+      "id": 576,
       "description": "DOGS/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3159,8 +3069,8 @@
         }
       }
     },
-    "587": {
-      "id": 587,
+    "579": {
+      "id": 579,
       "description": "EDU/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3170,8 +3080,8 @@
         }
       }
     },
-    "589": {
-      "id": 589,
+    "581": {
+      "id": 581,
       "description": "ANON / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3182,8 +3092,8 @@
         }
       }
     },
-    "591": {
-      "id": 591,
+    "583": {
+      "id": 583,
       "description": "C98 / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3193,8 +3103,8 @@
         }
       }
     },
-    "593": {
-      "id": 593,
+    "585": {
+      "id": 585,
       "description": "KNC / USD",
       "chainlink_compatibility": {
         "base": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
@@ -3210,8 +3120,8 @@
         }
       }
     },
-    "594": {
-      "id": 594,
+    "586": {
+      "id": 586,
       "description": "KNC / ETH",
       "chainlink_compatibility": {
         "base": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
@@ -3221,8 +3131,8 @@
         }
       }
     },
-    "597": {
-      "id": 597,
+    "589": {
+      "id": 589,
       "description": "BB/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3232,8 +3142,8 @@
         }
       }
     },
-    "600": {
-      "id": 600,
+    "592": {
+      "id": 592,
       "description": "BUSD / USD",
       "chainlink_compatibility": {
         "base": "0x4Fabb145d64652a948d72533023f6E7A623C7C53",
@@ -3245,20 +3155,8 @@
         }
       }
     },
-    "602": {
-      "id": 602,
-      "description": "USDL / USD",
-      "chainlink_compatibility": {
-        "base": "0xbdC7c08592Ee4aa51D06C27Ee23D5087D65aDbcD",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x92615843016d046678ED9176d02287db083faC62",
-          "arbitrum-mainnet": "0xc67FE680410646e40feeF06600bb8A21e554CF09"
-        }
-      }
-    },
-    "603": {
-      "id": 603,
+    "594": {
+      "id": 594,
       "description": "WIN / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3268,8 +3166,8 @@
         }
       }
     },
-    "606": {
-      "id": 606,
+    "597": {
+      "id": 597,
       "description": "MOVR / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3279,8 +3177,8 @@
         }
       }
     },
-    "609": {
-      "id": 609,
+    "600": {
+      "id": 600,
       "description": "GOAT/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3290,8 +3188,8 @@
         }
       }
     },
-    "611": {
-      "id": 611,
+    "602": {
+      "id": 602,
       "description": "AI/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3301,8 +3199,8 @@
         }
       }
     },
-    "613": {
-      "id": 613,
+    "604": {
+      "id": 604,
       "description": "OMNI/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3312,8 +3210,8 @@
         }
       }
     },
-    "616": {
-      "id": 616,
+    "607": {
+      "id": 607,
       "description": "BONE / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3324,8 +3222,8 @@
         }
       }
     },
-    "619": {
-      "id": 619,
+    "610": {
+      "id": 610,
       "description": "REZ/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3335,8 +3233,8 @@
         }
       }
     },
-    "622": {
-      "id": 622,
+    "613": {
+      "id": 613,
       "description": "DODO / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3349,21 +3247,8 @@
         }
       }
     },
-    "624": {
-      "id": 624,
-      "description": "LUSD / USD",
-      "chainlink_compatibility": {
-        "base": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x36A0448c46AaE145dD5BC320D5153426a2a586F5",
-          "arbitrum-mainnet": "0x20CD97619A51d1a6f1910ce62d98Aceb9a13d5e6",
-          "optimism-mainnet": "0x19dC743a5E9a73eefAbA7047C7CEeBc650F37336"
-        }
-      }
-    },
-    "625": {
-      "id": 625,
+    "615": {
+      "id": 615,
       "description": "QI / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3373,8 +3258,8 @@
         }
       }
     },
-    "627": {
-      "id": 627,
+    "617": {
+      "id": 617,
       "description": "CYBER/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3384,8 +3269,8 @@
         }
       }
     },
-    "629": {
-      "id": 629,
+    "619": {
+      "id": 619,
       "description": "MERL/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3395,8 +3280,8 @@
         }
       }
     },
-    "632": {
-      "id": 632,
+    "622": {
+      "id": 622,
       "description": "DEGEN / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3406,8 +3291,8 @@
         }
       }
     },
-    "634": {
-      "id": 634,
+    "624": {
+      "id": 624,
       "description": "HIGH / USD",
       "chainlink_compatibility": {
         "base": "0x71Ab77b7dbB4fa7e017BC15090b2163221420282",
@@ -3418,8 +3303,8 @@
         }
       }
     },
-    "636": {
-      "id": 636,
+    "626": {
+      "id": 626,
       "description": "COQ / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3429,8 +3314,8 @@
         }
       }
     },
-    "638": {
-      "id": 638,
+    "628": {
+      "id": 628,
       "description": "GNS / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3441,8 +3326,8 @@
         }
       }
     },
-    "640": {
-      "id": 640,
+    "630": {
+      "id": 630,
       "description": "GRIFFAIN/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
@@ -3452,8 +3337,8 @@
         }
       }
     },
-    "642": {
-      "id": 642,
+    "632": {
+      "id": 632,
       "description": "OGN / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3464,8 +3349,8 @@
         }
       }
     },
-    "644": {
-      "id": 644,
+    "634": {
+      "id": 634,
       "description": "MAGIC / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3476,8 +3361,8 @@
         }
       }
     },
-    "647": {
-      "id": 647,
+    "637": {
+      "id": 637,
       "description": "STG / USD",
       "chainlink_compatibility": {
         "base": "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6",
@@ -3490,21 +3375,8 @@
         }
       }
     },
-    "649": {
-      "id": 649,
-      "description": "DPI / USD",
-      "chainlink_compatibility": {
-        "base": "0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x2878E76c12dAD8DFfDcCeb52588e091aa3858d26",
-          "arbitrum-mainnet": "0xe7F278c6cf5A9349f98F01A9c8ddD6Eaa2a1DD24",
-          "polygon-mainnet": "0x40698914C15b07C6daa5a76829Ee6639989b8Edf"
-        }
-      }
-    },
-    "650": {
-      "id": 650,
+    "639": {
+      "id": 639,
       "description": "MOODENG/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3514,8 +3386,8 @@
         }
       }
     },
-    "653": {
-      "id": 653,
+    "642": {
+      "id": 642,
       "description": "BADGER / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3525,8 +3397,8 @@
         }
       }
     },
-    "656": {
-      "id": 656,
+    "645": {
+      "id": 645,
       "description": "ACE/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3536,8 +3408,8 @@
         }
       }
     },
-    "659": {
-      "id": 659,
+    "648": {
+      "id": 648,
       "description": "CUSD / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3547,9 +3419,64 @@
         }
       }
     },
+    "650": {
+      "id": 650,
+      "description": "MAV/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "652": {
+      "id": 652,
+      "description": "ALPHA / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "avalanche-mainnet": "0x15505bcC6D3c6f8F3cfC3d6D96f5A6301A08D2cc"
+        }
+      }
+    },
+    "655": {
+      "id": 655,
+      "description": "LISTA / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "bsc-mainnet": "0x3007a29FF5F4D2A4361A306cbF80337394875a0D"
+        }
+      }
+    },
+    "657": {
+      "id": 657,
+      "description": "AMPL / USD",
+      "chainlink_compatibility": {
+        "base": "0xD46bA6D942050d489DBd938a2C909A5d5039A161",
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "ethereum-mainnet": "0xd5090674b4653240cd94eE886484ca808c6E6694"
+        }
+      }
+    },
+    "659": {
+      "id": 659,
+      "description": "HOOK/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
     "661": {
       "id": 661,
-      "description": "MAV/USD-RefPrice-DS-Premium-Global-003",
+      "description": "ZEREBRO/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -3560,61 +3487,6 @@
     },
     "663": {
       "id": 663,
-      "description": "ALPHA / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "avalanche-mainnet": "0x15505bcC6D3c6f8F3cfC3d6D96f5A6301A08D2cc"
-        }
-      }
-    },
-    "666": {
-      "id": 666,
-      "description": "LISTA / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "bsc-mainnet": "0x3007a29FF5F4D2A4361A306cbF80337394875a0D"
-        }
-      }
-    },
-    "668": {
-      "id": 668,
-      "description": "AMPL / USD",
-      "chainlink_compatibility": {
-        "base": "0xD46bA6D942050d489DBd938a2C909A5d5039A161",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0xd5090674b4653240cd94eE886484ca808c6E6694"
-        }
-      }
-    },
-    "670": {
-      "id": 670,
-      "description": "HOOK/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "672": {
-      "id": 672,
-      "description": "ZEREBRO/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "674": {
-      "id": 674,
       "description": "ORDER / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3624,8 +3496,8 @@
         }
       }
     },
-    "676": {
-      "id": 676,
+    "665": {
+      "id": 665,
       "description": "RDNT / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3638,8 +3510,8 @@
         }
       }
     },
-    "679": {
-      "id": 679,
+    "668": {
+      "id": 668,
       "description": "MLN / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3650,8 +3522,8 @@
         }
       }
     },
-    "680": {
-      "id": 680,
+    "669": {
+      "id": 669,
       "description": "MLN / ETH",
       "chainlink_compatibility": {
         "base": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892",
@@ -3662,8 +3534,8 @@
         }
       }
     },
-    "683": {
-      "id": 683,
+    "672": {
+      "id": 672,
       "description": "QUICK / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3673,8 +3545,8 @@
         }
       }
     },
-    "685": {
-      "id": 685,
+    "674": {
+      "id": 674,
       "description": "ALCX / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3684,8 +3556,8 @@
         }
       }
     },
-    "688": {
-      "id": 688,
+    "677": {
+      "id": 677,
       "description": "PERP / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3697,8 +3569,8 @@
         }
       }
     },
-    "691": {
-      "id": 691,
+    "680": {
+      "id": 680,
       "description": "GHST / ETH",
       "chainlink_compatibility": {
         "base": null,
@@ -3708,8 +3580,8 @@
         }
       }
     },
-    "692": {
-      "id": 692,
+    "681": {
+      "id": 681,
       "description": "GHST / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3719,8 +3591,8 @@
         }
       }
     },
-    "695": {
-      "id": 695,
+    "684": {
+      "id": 684,
       "description": "BSW / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3730,8 +3602,8 @@
         }
       }
     },
-    "697": {
-      "id": 697,
+    "686": {
+      "id": 686,
       "description": "NULS / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3741,8 +3613,8 @@
         }
       }
     },
-    "700": {
-      "id": 700,
+    "689": {
+      "id": 689,
       "description": "WING / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3752,8 +3624,8 @@
         }
       }
     },
-    "702": {
-      "id": 702,
+    "691": {
+      "id": 691,
       "description": "TOKEN/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3763,8 +3635,8 @@
         }
       }
     },
-    "704": {
-      "id": 704,
+    "693": {
+      "id": 693,
       "description": "LINA / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3774,8 +3646,8 @@
         }
       }
     },
-    "706": {
-      "id": 706,
+    "695": {
+      "id": 695,
       "description": "TRUMP/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3785,8 +3657,8 @@
         }
       }
     },
-    "709": {
-      "id": 709,
+    "698": {
+      "id": 698,
       "description": "ULTI / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3796,8 +3668,8 @@
         }
       }
     },
-    "711": {
-      "id": 711,
+    "700": {
+      "id": 700,
       "description": "ALPACA / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3808,8 +3680,8 @@
         }
       }
     },
-    "713": {
-      "id": 713,
+    "702": {
+      "id": 702,
       "description": "REN / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3819,8 +3691,8 @@
         }
       }
     },
-    "715": {
-      "id": 715,
+    "704": {
+      "id": 704,
       "description": "MAVIA / USD",
       "chainlink_compatibility": {
         "base": "0x24fcFC492C1393274B6bcd568ac9e225BEc93584",
@@ -3831,8 +3703,8 @@
         }
       }
     },
-    "717": {
-      "id": 717,
+    "706": {
+      "id": 706,
       "description": "KLIMA / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3842,8 +3714,8 @@
         }
       }
     },
-    "719": {
-      "id": 719,
+    "708": {
+      "id": 708,
       "description": "SKY / USD",
       "chainlink_compatibility": {
         "base": "0x56072C95FAA701256059aa122697B133aDEd9279",
@@ -3853,8 +3725,8 @@
         }
       }
     },
-    "721": {
-      "id": 721,
+    "710": {
+      "id": 710,
       "description": "WELL / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3865,8 +3737,8 @@
         }
       }
     },
-    "723": {
-      "id": 723,
+    "712": {
+      "id": 712,
       "description": "FOXY / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3876,8 +3748,8 @@
         }
       }
     },
-    "725": {
-      "id": 725,
+    "714": {
+      "id": 714,
       "description": "MELANIA/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3887,8 +3759,8 @@
         }
       }
     },
-    "728": {
-      "id": 728,
+    "717": {
+      "id": 717,
       "description": "MICHI/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3898,33 +3770,8 @@
         }
       }
     },
-    "730": {
-      "id": 730,
-      "description": "AUSD / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "avalanche-mainnet": "0x4A5cE69A1aDA639042B30e1574Eb9D6e939388A3"
-        }
-      }
-    },
-    "731": {
-      "id": 731,
-      "description": "USR / USD",
-      "chainlink_compatibility": {
-        "base": "0x66a1E37c9b0eAddca17d3662D6c05F4DECf3e110",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x75c4B587EC408A4B5877f69F532221A0991d8e09",
-          "arbitrum-mainnet": "0x5b1dfB31846D04Cd3A79baF842957F17634d0D5E",
-          "base-mainnet": "0x0FC7044a83a1Bd1c0661faf26A48D96902e2b5A5",
-          "optimism-mainnet": "0x6131C96D9a73126c3B68bB1f4998eeE0708ffc10"
-        }
-      }
-    },
-    "732": {
-      "id": 732,
+    "719": {
+      "id": 719,
       "description": "NEIROETH/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
@@ -3934,8 +3781,8 @@
         }
       }
     },
-    "734": {
-      "id": 734,
+    "721": {
+      "id": 721,
       "description": "VVV/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
@@ -3945,8 +3792,8 @@
         }
       }
     },
-    "736": {
-      "id": 736,
+    "723": {
+      "id": 723,
       "description": "IP/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
@@ -3956,8 +3803,8 @@
         }
       }
     },
-    "738": {
-      "id": 738,
+    "725": {
+      "id": 725,
       "description": "FTM / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3976,8 +3823,8 @@
         }
       }
     },
-    "741": {
-      "id": 741,
+    "728": {
+      "id": 728,
       "description": "RNDR / USD",
       "chainlink_compatibility": {
         "base": null,

--- a/config/chainlink_compatibility_new.json
+++ b/config/chainlink_compatibility_new.json
@@ -7,7 +7,7 @@
         "base": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "ethereum-mainnet": "0x4a3411ac2948B33c69666B35cc6d055B27Ea84f1",
+          "ethereum-mainnet": "0xdc715c751f1cc129A6b47fEDC87D9918a4580502",
           "ethereum-sepolia": "0x6B4181139e9500D0C21788e7c6B21c1d0d9b1112",
           "andromeda-mainnet": "0x0F13cfAE20B3df71EEEFd67a260ECf0CF15629fA",
           "arbitrum-mainnet": "0x942d00008D658dbB40745BBEc89A93c253f9B882",
@@ -404,23 +404,23 @@
     },
     "40": {
       "id": 40,
-      "description": "wstETH/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "41": {
-      "id": 41,
       "description": "HBAR / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
           "polygon-mainnet": "0xc7fB8424b8309bc040508e957E38a9a6Bb64F677"
+        }
+      }
+    },
+    "43": {
+      "id": 43,
+      "description": "WSTETH/USD-RefPrice-mainnet-production",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
         }
       }
     },
@@ -476,6 +476,23 @@
     },
     "53": {
       "id": 53,
+      "description": "SHIB / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x626Fd7E1bbD2bbfA91260a1F7E485CE2286231A7",
+          "avalanche-mainnet": "0x184CCa2bA7015052424Fa2f509fB252926789D7C",
+          "base-mainnet": "0x97100bac08Ef1532401041b5F864B4De999ab6D4",
+          "bsc-mainnet": "0x63d009877EFBE61A74eBE40e682eF5593213B6C1",
+          "optimism-mainnet": "0xB6B77f1696bc4F95860228286d27f7f4df5D26e4",
+          "optimism-sepolia": "0x8585a1718121c7Aff9804918e9477fB48a2c587B",
+          "polygon-mainnet": "0xF4427712809751316A429F6dd6479Eb954B81277"
+        }
+      }
+    },
+    "56": {
+      "id": 56,
       "description": "SUI/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -485,8 +502,8 @@
         }
       }
     },
-    "56": {
-      "id": 56,
+    "59": {
+      "id": 59,
       "description": "BCH / BNB",
       "chainlink_compatibility": {
         "base": null,
@@ -496,8 +513,8 @@
         }
       }
     },
-    "57": {
-      "id": 57,
+    "60": {
+      "id": 60,
       "description": "BCH / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -511,8 +528,8 @@
         }
       }
     },
-    "60": {
-      "id": 60,
+    "63": {
+      "id": 63,
       "description": "LTC / BNB",
       "chainlink_compatibility": {
         "base": null,
@@ -522,8 +539,8 @@
         }
       }
     },
-    "61": {
-      "id": 61,
+    "64": {
+      "id": 64,
       "description": "LTC / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -536,23 +553,6 @@
           "optimism-mainnet": "0xfC7608cf76F489191Cb319DD6167aEEE387Bb251",
           "optimism-sepolia": "0x3D4136A6057f2CA7c26a107697589CA7E2c7D81C",
           "polygon-mainnet": "0x53Ba81B50b47EE4dfe98F72Db287226580F2C912"
-        }
-      }
-    },
-    "64": {
-      "id": 64,
-      "description": "SHIB / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x626Fd7E1bbD2bbfA91260a1F7E485CE2286231A7",
-          "avalanche-mainnet": "0x184CCa2bA7015052424Fa2f509fB252926789D7C",
-          "base-mainnet": "0x97100bac08Ef1532401041b5F864B4De999ab6D4",
-          "bsc-mainnet": "0x63d009877EFBE61A74eBE40e682eF5593213B6C1",
-          "optimism-mainnet": "0xB6B77f1696bc4F95860228286d27f7f4df5D26e4",
-          "optimism-sepolia": "0x8585a1718121c7Aff9804918e9477fB48a2c587B",
-          "polygon-mainnet": "0xF4427712809751316A429F6dd6479Eb954B81277"
         }
       }
     },
@@ -569,6 +569,17 @@
     },
     "70": {
       "id": 70,
+      "description": "OM/USD-RefPrice-mainnet-production",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
+        }
+      }
+    },
+    "73": {
+      "id": 73,
       "description": "DOT / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -587,25 +598,14 @@
         }
       }
     },
-    "71": {
-      "id": 71,
+    "74": {
+      "id": 74,
       "description": "DOT / BNB",
       "chainlink_compatibility": {
         "base": null,
         "quote": null,
         "chainlink_aggregators": {
           "bsc-mainnet": "0x2DADEb97E61A489edEe5aD52aF26d3F7d2CB55B9"
-        }
-      }
-    },
-    "74": {
-      "id": 74,
-      "description": "OM/USD-RefPrice-mainnet-production",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
         }
       }
     },
@@ -791,6 +791,17 @@
     },
     "104": {
       "id": 104,
+      "description": "PEPE/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "107": {
+      "id": 107,
       "description": "ETC / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -802,8 +813,33 @@
         }
       }
     },
-    "107": {
-      "id": 107,
+    "110": {
+      "id": 110,
+      "description": "ONDO/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "113": {
+      "id": 113,
+      "description": "ICP / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "bsc-mainnet": "0xDD746F1C05207D1478dC217F4e832786ABEd5C80",
+          "optimism-mainnet": "0xcCb014Fe9d7d7FB0E50E3aE8f0BF25b26e6596c6",
+          "optimism-sepolia": "0x5f3B52BB02401147179123d3C365bB1077D2454c",
+          "polygon-mainnet": "0xfA98EF4Cab9D65B656299377937Ca8Db2b62C322"
+        }
+      }
+    },
+    "116": {
+      "id": 116,
       "description": "AAVE / USD",
       "chainlink_compatibility": {
         "base": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
@@ -830,8 +866,8 @@
         }
       }
     },
-    "108": {
-      "id": 108,
+    "117": {
+      "id": 117,
       "description": "AAVE / ETH",
       "chainlink_compatibility": {
         "base": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
@@ -839,42 +875,6 @@
         "chainlink_aggregators": {
           "ethereum-mainnet": "0x347b3886BdC7242Ae7f5f00398e801c8bfA8F52C",
           "polygon-mainnet": "0x3eC5642df92bb307C1117C55a4B390fB4EFf3783"
-        }
-      }
-    },
-    "111": {
-      "id": 111,
-      "description": "ONDO/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "114": {
-      "id": 114,
-      "description": "ICP / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "bsc-mainnet": "0xDD746F1C05207D1478dC217F4e832786ABEd5C80",
-          "optimism-mainnet": "0xcCb014Fe9d7d7FB0E50E3aE8f0BF25b26e6596c6",
-          "optimism-sepolia": "0x5f3B52BB02401147179123d3C365bB1077D2454c",
-          "polygon-mainnet": "0xfA98EF4Cab9D65B656299377937Ca8Db2b62C322"
-        }
-      }
-    },
-    "117": {
-      "id": 117,
-      "description": "PEPE/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
         }
       }
     },
@@ -892,17 +892,6 @@
     },
     "123": {
       "id": 123,
-      "description": "VET / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "bsc-mainnet": "0xA90204b8Cffa45EDbca42CB577CDF6fafAbF0d33"
-        }
-      }
-    },
-    "125": {
-      "id": 125,
       "description": "cbBTC/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
@@ -912,8 +901,30 @@
         }
       }
     },
-    "126": {
-      "id": 126,
+    "124": {
+      "id": 124,
+      "description": "TAO/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "127": {
+      "id": 127,
+      "description": "VET / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "bsc-mainnet": "0xA90204b8Cffa45EDbca42CB577CDF6fafAbF0d33"
+        }
+      }
+    },
+    "129": {
+      "id": 129,
       "description": "FDUSD / USD",
       "chainlink_compatibility": {
         "base": "0xc5f0f7b66764F6ec8C8Dff7BA683102295E16409",
@@ -924,9 +935,9 @@
         }
       }
     },
-    "129": {
-      "id": 129,
-      "description": "TAO/USD-RefPrice-DS-Premium-Global-003",
+    "132": {
+      "id": 132,
+      "description": "TIA/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -935,8 +946,8 @@
         }
       }
     },
-    "132": {
-      "id": 132,
+    "135": {
+      "id": 135,
       "description": "POL / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -952,8 +963,8 @@
         }
       }
     },
-    "133": {
-      "id": 133,
+    "136": {
+      "id": 136,
       "description": "MATIC / ETH",
       "chainlink_compatibility": {
         "base": null,
@@ -963,8 +974,8 @@
         }
       }
     },
-    "136": {
-      "id": 136,
+    "139": {
+      "id": 139,
       "description": "FIL / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -979,8 +990,8 @@
         }
       }
     },
-    "137": {
-      "id": 137,
+    "140": {
+      "id": 140,
       "description": "FIL / ETH",
       "chainlink_compatibility": {
         "base": null,
@@ -990,36 +1001,25 @@
         }
       }
     },
-    "140": {
-      "id": 140,
-      "description": "ALGO/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
     "143": {
       "id": 143,
-      "description": "TIA/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "146": {
-      "id": 146,
       "description": "LBTC/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
           "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
+        }
+      }
+    },
+    "145": {
+      "id": 145,
+      "description": "ALGO/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
         }
       }
     },
@@ -1036,6 +1036,21 @@
     },
     "151": {
       "id": 151,
+      "description": "ATOM / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x77b911DBe147ED5b4554997860D6362A5652fC91",
+          "arbitrum-sepolia": "0x924A5C0627D30A178cB481b8EdDC163D0Ee477b4",
+          "bsc-mainnet": "0x5988452C7b6890C27D6D3b04ee6cDbB57CB6EB26",
+          "optimism-mainnet": "0x81d9a9056e9Af6585010B784Df5853a0fDEf8b11",
+          "optimism-sepolia": "0x0153002d20B96532C639313c2d54c3dA09109309"
+        }
+      }
+    },
+    "154": {
+      "id": 154,
       "description": "ARB / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1052,23 +1067,19 @@
         }
       }
     },
-    "154": {
-      "id": 154,
-      "description": "ATOM / USD",
+    "157": {
+      "id": 157,
+      "description": "JUP/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x77b911DBe147ED5b4554997860D6362A5652fC91",
-          "arbitrum-sepolia": "0x924A5C0627D30A178cB481b8EdDC163D0Ee477b4",
-          "bsc-mainnet": "0x5988452C7b6890C27D6D3b04ee6cDbB57CB6EB26",
-          "optimism-mainnet": "0x81d9a9056e9Af6585010B784Df5853a0fDEf8b11",
-          "optimism-sepolia": "0x0153002d20B96532C639313c2d54c3dA09109309"
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
         }
       }
     },
-    "157": {
-      "id": 157,
+    "160": {
+      "id": 160,
       "description": "OP / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1082,30 +1093,8 @@
         }
       }
     },
-    "160": {
-      "id": 160,
-      "description": "ENA/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
     "163": {
       "id": 163,
-      "description": "JUP/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "166": {
-      "id": 166,
       "description": "S/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
@@ -1115,8 +1104,8 @@
         }
       }
     },
-    "169": {
-      "id": 169,
+    "166": {
+      "id": 166,
       "description": "FET / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1128,8 +1117,30 @@
         }
       }
     },
+    "169": {
+      "id": 169,
+      "description": "ENA/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
     "172": {
       "id": 172,
+      "description": "USD0 / USD",
+      "chainlink_compatibility": {
+        "base": "0x73A15FeD60Bf67631dC6cd7Bc5B6e8da8190aCF5",
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "ethereum-mainnet": "0x90Fb891e7EE51972f7D9309a6B812D04ED2643c7"
+        }
+      }
+    },
+    "173": {
+      "id": 173,
       "description": "MKR / USD",
       "chainlink_compatibility": {
         "base": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
@@ -1146,8 +1157,8 @@
         }
       }
     },
-    "173": {
-      "id": 173,
+    "174": {
+      "id": 174,
       "description": "MKR / ETH",
       "chainlink_compatibility": {
         "base": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
@@ -1158,19 +1169,21 @@
         }
       }
     },
-    "176": {
-      "id": 176,
-      "description": "USD0 / USD",
+    "177": {
+      "id": 177,
+      "description": "ZBU / USD",
       "chainlink_compatibility": {
-        "base": "0x73A15FeD60Bf67631dC6cd7Bc5B6e8da8190aCF5",
+        "base": "0xe77f6aCD24185e149e329C1C0F479201b9Ec2f4B",
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "ethereum-mainnet": "0x90Fb891e7EE51972f7D9309a6B812D04ED2643c7"
+          "ethereum-mainnet": "0x3eC38C31bD2b83C6749b09D61a1C4e53748AEeF4",
+          "base-mainnet": "0xA54DF8Ba7212667152aBa0D21d7c3221d14126F9",
+          "bsc-mainnet": "0x9E0B61b01765f86a28386AB9B56B21419Ddd9EDE"
         }
       }
     },
-    "177": {
-      "id": 177,
+    "179": {
+      "id": 179,
       "description": "STX / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1182,8 +1195,8 @@
         }
       }
     },
-    "180": {
-      "id": 180,
+    "182": {
+      "id": 182,
       "description": "INJ / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1196,27 +1209,14 @@
         }
       }
     },
-    "183": {
-      "id": 183,
-      "description": "SEI/USD-RefPrice-DS-Premium-Global-003",
+    "185": {
+      "id": 185,
+      "description": "IMX/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
           "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "186": {
-      "id": 186,
-      "description": "ZBU / USD",
-      "chainlink_compatibility": {
-        "base": "0xe77f6aCD24185e149e329C1C0F479201b9Ec2f4B",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x3eC38C31bD2b83C6749b09D61a1C4e53748AEeF4",
-          "base-mainnet": "0xA54DF8Ba7212667152aBa0D21d7c3221d14126F9",
-          "bsc-mainnet": "0x9E0B61b01765f86a28386AB9B56B21419Ddd9EDE"
         }
       }
     },
@@ -1233,7 +1233,7 @@
     },
     "190": {
       "id": 190,
-      "description": "IMX/USD-RefPrice-DS-Premium-Global-003",
+      "description": "WLD/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -1266,17 +1266,6 @@
     },
     "197": {
       "id": 197,
-      "description": "LDO/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "200": {
-      "id": 200,
       "description": "GRT/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1286,8 +1275,8 @@
         }
       }
     },
-    "201": {
-      "id": 201,
+    "198": {
+      "id": 198,
       "description": "GRT / ETH",
       "chainlink_compatibility": {
         "base": "0xc944E90C64B2c07662A292be6244BDf05Cda44a7",
@@ -1297,9 +1286,20 @@
         }
       }
     },
+    "201": {
+      "id": 201,
+      "description": "SEI/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
     "204": {
       "id": 204,
-      "description": "WLD/USD-RefPrice-DS-Premium-Global-003",
+      "description": "BONK/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -1310,7 +1310,7 @@
     },
     "207": {
       "id": 207,
-      "description": "BONK/USD-RefPrice-DS-Premium-Global-003",
+      "description": "LDO/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -1346,6 +1346,17 @@
     },
     "214": {
       "id": 214,
+      "description": "GALA/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "217": {
+      "id": 217,
       "description": "PYUSD / USD",
       "chainlink_compatibility": {
         "base": "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8",
@@ -1355,8 +1366,8 @@
         }
       }
     },
-    "216": {
-      "id": 216,
+    "219": {
+      "id": 219,
       "description": "XTZ / BNB",
       "chainlink_compatibility": {
         "base": null,
@@ -1366,8 +1377,8 @@
         }
       }
     },
-    "217": {
-      "id": 217,
+    "220": {
+      "id": 220,
       "description": "XTZ / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1380,8 +1391,8 @@
         }
       }
     },
-    "220": {
-      "id": 220,
+    "223": {
+      "id": 223,
       "description": "SAND / USD",
       "chainlink_compatibility": {
         "base": "0x3845badAde8e6dFF049820680d1F14bD3903a5d0",
@@ -1396,41 +1407,8 @@
         }
       }
     },
-    "223": {
-      "id": 223,
-      "description": "JTO/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
     "226": {
       "id": 226,
-      "description": "ezETH/USD-RefPrice-mainnet-production",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
-        }
-      }
-    },
-    "227": {
-      "id": 227,
-      "description": "ENS / USD",
-      "chainlink_compatibility": {
-        "base": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x6Cc5173Ffd8d674C64f2DC7237730Ff021829865"
-        }
-      }
-    },
-    "230": {
-      "id": 230,
       "description": "BERA/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1440,8 +1418,19 @@
         }
       }
     },
-    "233": {
-      "id": 233,
+    "229": {
+      "id": 229,
+      "description": "JTO/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "232": {
+      "id": 232,
       "description": "FLOW/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1451,19 +1440,8 @@
         }
       }
     },
-    "236": {
-      "id": 236,
-      "description": "GALA/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "239": {
-      "id": 239,
+    "235": {
+      "id": 235,
       "description": "FLOKI/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1473,30 +1451,30 @@
         }
       }
     },
+    "238": {
+      "id": 238,
+      "description": "ezETH/USD-RefPrice-mainnet-production",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
+        }
+      }
+    },
+    "239": {
+      "id": 239,
+      "description": "ENS / USD",
+      "chainlink_compatibility": {
+        "base": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "ethereum-mainnet": "0x6Cc5173Ffd8d674C64f2DC7237730Ff021829865"
+        }
+      }
+    },
     "242": {
       "id": 242,
-      "description": "PYTH/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "245": {
-      "id": 245,
-      "description": "EGLD/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "248": {
-      "id": 248,
       "description": "MANA / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1508,8 +1486,8 @@
         }
       }
     },
-    "249": {
-      "id": 249,
+    "243": {
+      "id": 243,
       "description": "MANA / ETH",
       "chainlink_compatibility": {
         "base": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
@@ -1519,81 +1497,8 @@
         }
       }
     },
-    "252": {
-      "id": 252,
-      "description": "FRAX / USD",
-      "chainlink_compatibility": {
-        "base": "0x853d955aCEf822Db058eb8505911ED77F175b99e",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x8F73090a7c58B8BDcC9A93cBB6816e5cC4f01E8c",
-          "arbitrum-mainnet": "0x5D041081725468Aa43e72ff0445Fde2Ad1aDE775",
-          "avalanche-mainnet": "0x5995b0D7A318E44ee654F5f188372E4a3a249c5d",
-          "bsc-mainnet": "0xb208D9Ee1703674b7Ced85b615Db69d65430aF67",
-          "fantom-mainnet": "0xc2bD6467d9567Cfaf2783d7DE5F337bf98Fe62C1",
-          "kusama-moonriver": "0xA3A70d23c94229d4985057eFE9C9cE1039A5657C",
-          "optimism-mainnet": "0xaB544FDAD5F68f0F8e53284f942D76177635A3D6",
-          "polygon-mainnet": "0xED78A887422fbEf80CB3775Ea32057051025499a"
-        }
-      }
-    },
-    "254": {
-      "id": 254,
-      "description": "TUSD / USD",
-      "chainlink_compatibility": {
-        "base": "0x0000000000085d4780B73119b644AE5ecd22b376",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0xffB5820Df5F3366949754b31AB1E48331b943C1f",
-          "arbitrum-mainnet": "0xEC2E9000B487F28Fd03455f9277bE3c96a3180b2",
-          "avalanche-mainnet": "0xFE7019D5BCD395C56FB1cF43be548B1F056288FB",
-          "bsc-mainnet": "0xB8a62D647b176B9AB10Fa0c2078b718f62aE2eBE",
-          "polygon-mainnet": "0x24c1772f2725af97F0811Dc3Aee99B17dfd6115E"
-        }
-      }
-    },
-    "255": {
-      "id": 255,
-      "description": "TUSD / ETH",
-      "chainlink_compatibility": {
-        "base": "0x0000000000085d4780B73119b644AE5ecd22b376",
-        "quote": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x55A5f1E833e9412925502459e7AB3656a596591e"
-        }
-      }
-    },
-    "257": {
-      "id": 257,
-      "description": "RON / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0xc0552C1a54409D11a7f644b7B3A0F8c9AD628F2A",
-          "arbitrum-sepolia": "0x7155D1a0E0Ea9C00d9f3e107bc5BC80C1C5CbD16"
-        }
-      }
-    },
-    "260": {
-      "id": 260,
-      "description": "AXS / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0xA303a72d334e589122454e8e849E147BAd309E73",
-          "avalanche-mainnet": "0x566FB95c9F636a0d27b5874d49C1dfffA2551014",
-          "avalanche-fuji": "0x9DE4086641E636A76C279ce6357EfC2570665727",
-          "bsc-mainnet": "0x0B01DbBB5f306BeA950dc0EAAd55b48eAfaDcA23",
-          "optimism-mainnet": "0x7A18889f137B593f4E03C0A698A4360f43d1731c",
-          "optimism-sepolia": "0x3a7B80170761C8bbaa63e216a1D705D3125F5194",
-          "polygon-mainnet": "0xB12bCEAD553B559F68E4E1102c77f659D238734B"
-        }
-      }
-    },
-    "263": {
-      "id": 263,
+    "246": {
+      "id": 246,
       "description": "CRV / USD",
       "chainlink_compatibility": {
         "base": "0xD533a949740bb3306d119CC777fa900bA034cd52",
@@ -1612,8 +1517,8 @@
         }
       }
     },
-    "264": {
-      "id": 264,
+    "247": {
+      "id": 247,
       "description": "CRV / ETH",
       "chainlink_compatibility": {
         "base": "0xD533a949740bb3306d119CC777fa900bA034cd52",
@@ -1624,8 +1529,85 @@
         }
       }
     },
-    "267": {
-      "id": 267,
+    "250": {
+      "id": 250,
+      "description": "PYTH/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "253": {
+      "id": 253,
+      "description": "EGLD/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "256": {
+      "id": 256,
+      "description": "RON / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0xc0552C1a54409D11a7f644b7B3A0F8c9AD628F2A",
+          "arbitrum-sepolia": "0x7155D1a0E0Ea9C00d9f3e107bc5BC80C1C5CbD16"
+        }
+      }
+    },
+    "259": {
+      "id": 259,
+      "description": "AXS / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0xA303a72d334e589122454e8e849E147BAd309E73",
+          "avalanche-mainnet": "0x566FB95c9F636a0d27b5874d49C1dfffA2551014",
+          "avalanche-fuji": "0x9DE4086641E636A76C279ce6357EfC2570665727",
+          "bsc-mainnet": "0x0B01DbBB5f306BeA950dc0EAAd55b48eAfaDcA23",
+          "optimism-mainnet": "0x7A18889f137B593f4E03C0A698A4360f43d1731c",
+          "optimism-sepolia": "0x3a7B80170761C8bbaa63e216a1D705D3125F5194",
+          "polygon-mainnet": "0xB12bCEAD553B559F68E4E1102c77f659D238734B"
+        }
+      }
+    },
+    "262": {
+      "id": 262,
+      "description": "TUSD / USD",
+      "chainlink_compatibility": {
+        "base": "0x0000000000085d4780B73119b644AE5ecd22b376",
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "ethereum-mainnet": "0xffB5820Df5F3366949754b31AB1E48331b943C1f",
+          "arbitrum-mainnet": "0xEC2E9000B487F28Fd03455f9277bE3c96a3180b2",
+          "avalanche-mainnet": "0xFE7019D5BCD395C56FB1cF43be548B1F056288FB",
+          "bsc-mainnet": "0xB8a62D647b176B9AB10Fa0c2078b718f62aE2eBE",
+          "polygon-mainnet": "0x24c1772f2725af97F0811Dc3Aee99B17dfd6115E"
+        }
+      }
+    },
+    "263": {
+      "id": 263,
+      "description": "TUSD / ETH",
+      "chainlink_compatibility": {
+        "base": "0x0000000000085d4780B73119b644AE5ecd22b376",
+        "quote": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+        "chainlink_aggregators": {
+          "ethereum-mainnet": "0x55A5f1E833e9412925502459e7AB3656a596591e"
+        }
+      }
+    },
+    "265": {
+      "id": 265,
       "description": "ZEC/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1635,8 +1617,8 @@
         }
       }
     },
-    "270": {
-      "id": 270,
+    "268": {
+      "id": 268,
       "description": "KAVA / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1647,8 +1629,30 @@
         }
       }
     },
-    "272": {
-      "id": 272,
+    "270": {
+      "id": 270,
+      "description": "DYDX/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "273": {
+      "id": 273,
+      "description": "XCN / USD",
+      "chainlink_compatibility": {
+        "base": "0xA2cd3D43c775978A96BdBf12d733D5A1ED94fb18",
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "ethereum-mainnet": "0x3E9348C8a83549B594C51D5539f0Db4E3B0B5D90"
+        }
+      }
+    },
+    "275": {
+      "id": 275,
       "description": "WIF/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1658,19 +1662,19 @@
         }
       }
     },
-    "275": {
-      "id": 275,
-      "description": "AERO / USD",
+    "278": {
+      "id": 278,
+      "description": "STRK/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "base-mainnet": "0xC18cC9B106A50D945024F0a25EfF16B6dC56D4B9"
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
         }
       }
     },
-    "277": {
-      "id": 277,
+    "281": {
+      "id": 281,
       "description": "CAKE / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1682,8 +1686,8 @@
         }
       }
     },
-    "278": {
-      "id": 278,
+    "282": {
+      "id": 282,
       "description": "CAKE / BNB",
       "chainlink_compatibility": {
         "base": null,
@@ -1693,42 +1697,8 @@
         }
       }
     },
-    "281": {
-      "id": 281,
-      "description": "DYDX/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "284": {
-      "id": 284,
-      "description": "RUNE / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "optimism-mainnet": "0x1aafcf49E103a71b31506Cb05FB072ED1B5b0414",
-          "optimism-sepolia": "0xeB70BB005fa43A47892Fb2723c363a962a259e66"
-        }
-      }
-    },
-    "287": {
-      "id": 287,
-      "description": "STRK/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "290": {
-      "id": 290,
+    "285": {
+      "id": 285,
       "description": "MATIC / USD",
       "chainlink_compatibility": {
         "base": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
@@ -1752,19 +1722,19 @@
         }
       }
     },
-    "293": {
-      "id": 293,
-      "description": "AR/USD-RefPrice-DS-Premium-Global-003",
+    "288": {
+      "id": 288,
+      "description": "AERO / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+          "base-mainnet": "0xC18cC9B106A50D945024F0a25EfF16B6dC56D4B9"
         }
       }
     },
-    "296": {
-      "id": 296,
+    "290": {
+      "id": 290,
       "description": "CHZ / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -1776,20 +1746,50 @@
         }
       }
     },
-    "299": {
-      "id": 299,
-      "description": "CFX / USD",
+    "293": {
+      "id": 293,
+      "description": "FRAX / USD",
+      "chainlink_compatibility": {
+        "base": "0x853d955aCEf822Db058eb8505911ED77F175b99e",
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "ethereum-mainnet": "0x8F73090a7c58B8BDcC9A93cBB6816e5cC4f01E8c",
+          "arbitrum-mainnet": "0x5D041081725468Aa43e72ff0445Fde2Ad1aDE775",
+          "avalanche-mainnet": "0x5995b0D7A318E44ee654F5f188372E4a3a249c5d",
+          "bsc-mainnet": "0xb208D9Ee1703674b7Ced85b615Db69d65430aF67",
+          "fantom-mainnet": "0xc2bD6467d9567Cfaf2783d7DE5F337bf98Fe62C1",
+          "kusama-moonriver": "0xA3A70d23c94229d4985057eFE9C9cE1039A5657C",
+          "optimism-mainnet": "0xaB544FDAD5F68f0F8e53284f942D76177635A3D6",
+          "polygon-mainnet": "0xED78A887422fbEf80CB3775Ea32057051025499a"
+        }
+      }
+    },
+    "295": {
+      "id": 295,
+      "description": "CORE / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "bsc-mainnet": "0x6f58a80867489738f5155596488b0100531A0b6B"
+          "arbitrum-mainnet": "0xe60F9489Ea2478A149EfD26bF9F5D31264AacAb2"
         }
       }
     },
-    "302": {
-      "id": 302,
-      "description": "VIRTUAL/USD-RefPrice-DS-Premium-Global-003",
+    "298": {
+      "id": 298,
+      "description": "RUNE / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "optimism-mainnet": "0x1aafcf49E103a71b31506Cb05FB072ED1B5b0414",
+          "optimism-sepolia": "0xeB70BB005fa43A47892Fb2723c363a962a259e66"
+        }
+      }
+    },
+    "301": {
+      "id": 301,
+      "description": "AR/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -1798,14 +1798,14 @@
         }
       }
     },
-    "305": {
-      "id": 305,
-      "description": "XCN / USD",
+    "304": {
+      "id": 304,
+      "description": "CFX / USD",
       "chainlink_compatibility": {
-        "base": "0xA2cd3D43c775978A96BdBf12d733D5A1ED94fb18",
+        "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "ethereum-mainnet": "0x3E9348C8a83549B594C51D5539f0Db4E3B0B5D90"
+          "bsc-mainnet": "0x6f58a80867489738f5155596488b0100531A0b6B"
         }
       }
     },
@@ -1834,17 +1834,55 @@
     },
     "311": {
       "id": 311,
-      "description": "CORE / USD",
+      "description": "APE / USD",
+      "chainlink_compatibility": {
+        "base": "0x4d224452801ACEd8B2F0aebE155379bb5D594381",
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "ethereum-mainnet": "0x88db96ca551e0A0a2D8646999410b60197979311",
+          "arbitrum-mainnet": "0x2C50f2Fe9427d120DEA2eb804c148d2780519d59",
+          "avalanche-fuji": "0x8c4E5F5dcA2C2813EB97AAA06cFa0780692D8a9e",
+          "optimism-mainnet": "0x384547665C7BF2bb7927E67A8a321E9a0c91Fe59",
+          "optimism-sepolia": "0x3ec8593F930EA45ea58c968260e6e9FF53FC934f",
+          "polygon-mainnet": "0x9c19be1fF177eF3B58910f26FF5c67dD167bfB91"
+        }
+      }
+    },
+    "312": {
+      "id": 312,
+      "description": "APE / ETH",
+      "chainlink_compatibility": {
+        "base": "0x4d224452801ACEd8B2F0aebE155379bb5D594381",
+        "quote": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+        "chainlink_aggregators": {
+          "ethereum-mainnet": "0xcC00DfdEaA0c96606b37EC6C83BaE9FD1f6cFb3E"
+        }
+      }
+    },
+    "315": {
+      "id": 315,
+      "description": "VIRTUAL/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "arbitrum-mainnet": "0xe60F9489Ea2478A149EfD26bF9F5D31264AacAb2"
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
         }
       }
     },
-    "314": {
-      "id": 314,
+    "318": {
+      "id": 318,
+      "description": "PENGU/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "321": {
+      "id": 321,
       "description": "COMP / USD",
       "chainlink_compatibility": {
         "base": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
@@ -1864,52 +1902,15 @@
         }
       }
     },
-    "317": {
-      "id": 317,
-      "description": "SPX/USD-RefPrice-mainnet-production",
+    "324": {
+      "id": 324,
+      "description": "AXL / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
-        }
-      }
-    },
-    "319": {
-      "id": 319,
-      "description": "APE / USD",
-      "chainlink_compatibility": {
-        "base": "0x4d224452801ACEd8B2F0aebE155379bb5D594381",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x88db96ca551e0A0a2D8646999410b60197979311",
-          "arbitrum-mainnet": "0x2C50f2Fe9427d120DEA2eb804c148d2780519d59",
-          "avalanche-fuji": "0x8c4E5F5dcA2C2813EB97AAA06cFa0780692D8a9e",
-          "optimism-mainnet": "0x384547665C7BF2bb7927E67A8a321E9a0c91Fe59",
-          "optimism-sepolia": "0x3ec8593F930EA45ea58c968260e6e9FF53FC934f",
-          "polygon-mainnet": "0x9c19be1fF177eF3B58910f26FF5c67dD167bfB91"
-        }
-      }
-    },
-    "320": {
-      "id": 320,
-      "description": "APE / ETH",
-      "chainlink_compatibility": {
-        "base": "0x4d224452801ACEd8B2F0aebE155379bb5D594381",
-        "quote": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0xcC00DfdEaA0c96606b37EC6C83BaE9FD1f6cFb3E"
-        }
-      }
-    },
-    "323": {
-      "id": 323,
-      "description": "PENGU/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+          "arbitrum-mainnet": "0x69C17BE52399EA82CC0d890EA712da8316C08535",
+          "base-mainnet": "0x038fa58bd4DA1c938D2783941e657164D497C4B6"
         }
       }
     },
@@ -1928,13 +1929,12 @@
     },
     "329": {
       "id": 329,
-      "description": "AXL / USD",
+      "description": "SPX/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x69C17BE52399EA82CC0d890EA712da8316C08535",
-          "base-mainnet": "0x038fa58bd4DA1c938D2783941e657164D497C4B6"
+          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
         }
       }
     },
@@ -1951,6 +1951,30 @@
     },
     "333": {
       "id": 333,
+      "description": "MORPHO/USD-RefPrice-mainnet-production",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
+        }
+      }
+    },
+    "336": {
+      "id": 336,
+      "description": "RSR / USD",
+      "chainlink_compatibility": {
+        "base": "0x320623b8E4fF03373931769A31Fc52A4E78B5d70",
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "ethereum-mainnet": "0x4394595b7381A001fAA6a76CF47f4b9a04bF31A0",
+          "arbitrum-mainnet": "0x58DBe57Afe332Db719D1147E6145316cBCc51Ab9",
+          "base-mainnet": "0xf3764B1fc0Ab831f75D3edd7435ABFE4Af675c9A"
+        }
+      }
+    },
+    "339": {
+      "id": 339,
       "description": "BRETT/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -1960,8 +1984,19 @@
         }
       }
     },
-    "336": {
-      "id": 336,
+    "342": {
+      "id": 342,
+      "description": "BEAM / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "avalanche-mainnet": "0x6cBEE88E5af162c453311D12c6688D202613E749"
+        }
+      }
+    },
+    "344": {
+      "id": 344,
       "description": "deUSD / USD",
       "chainlink_compatibility": {
         "base": "0x15700B564Ca08D9439C58cA5053166E8317aa138",
@@ -1974,60 +2009,8 @@
         }
       }
     },
-    "338": {
-      "id": 338,
-      "description": "MORPHO/USD-RefPrice-mainnet-production",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
-        }
-      }
-    },
-    "341": {
-      "id": 341,
-      "description": "RSR / USD",
-      "chainlink_compatibility": {
-        "base": "0x320623b8E4fF03373931769A31Fc52A4E78B5d70",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x4394595b7381A001fAA6a76CF47f4b9a04bF31A0",
-          "arbitrum-mainnet": "0x58DBe57Afe332Db719D1147E6145316cBCc51Ab9",
-          "base-mainnet": "0xf3764B1fc0Ab831f75D3edd7435ABFE4Af675c9A"
-        }
-      }
-    },
-    "344": {
-      "id": 344,
-      "description": "1INCH / USD",
-      "chainlink_compatibility": {
-        "base": "0x111111111117dC0aa78b770fA6A738034120C302",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x6AD3961c0348906504ff4125722e4Aa5146ff529",
-          "arbitrum-mainnet": "0xa64344ec6b4971d1FBDaf5550001ac5751EEd599",
-          "bsc-mainnet": "0x27847d350F93B95744d6114e04F04cCb58d4bE9A",
-          "gnosis-mainnet": "0xf50a71387D9D01ED3873E32f1044497327AF1044",
-          "optimism-mainnet": "0xbF620CB752ba2d16bAe2a3c5488cbf00b7D0Cc67",
-          "optimism-sepolia": "0x4aDC67696bA383F43DD60A9e78F2C97Fbbfc7cb1",
-          "polygon-mainnet": "0xaA931f96d9673e1688f6AB63eC3E83B22D9b1849"
-        }
-      }
-    },
-    "347": {
-      "id": 347,
-      "description": "BEAM / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "avalanche-mainnet": "0x6cBEE88E5af162c453311D12c6688D202613E749"
-        }
-      }
-    },
-    "349": {
-      "id": 349,
+    "346": {
+      "id": 346,
       "description": "SNX / USD",
       "chainlink_compatibility": {
         "base": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
@@ -2047,8 +2030,8 @@
         }
       }
     },
-    "350": {
-      "id": 350,
+    "347": {
+      "id": 347,
       "description": "SNX / ETH",
       "chainlink_compatibility": {
         "base": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
@@ -2058,14 +2041,31 @@
         }
       }
     },
-    "353": {
-      "id": 353,
-      "description": "EIGEN/USD-RefPrice-DS-Premium-Global-003",
+    "350": {
+      "id": 350,
+      "description": "FARTCOIN/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
           "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "353": {
+      "id": 353,
+      "description": "1INCH / USD",
+      "chainlink_compatibility": {
+        "base": "0x111111111117dC0aa78b770fA6A738034120C302",
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "ethereum-mainnet": "0x6AD3961c0348906504ff4125722e4Aa5146ff529",
+          "arbitrum-mainnet": "0xa64344ec6b4971d1FBDaf5550001ac5751EEd599",
+          "bsc-mainnet": "0x27847d350F93B95744d6114e04F04cCb58d4bE9A",
+          "gnosis-mainnet": "0xf50a71387D9D01ED3873E32f1044497327AF1044",
+          "optimism-mainnet": "0xbF620CB752ba2d16bAe2a3c5488cbf00b7D0Cc67",
+          "optimism-sepolia": "0x4aDC67696bA383F43DD60A9e78F2C97Fbbfc7cb1",
+          "polygon-mainnet": "0xaA931f96d9673e1688f6AB63eC3E83B22D9b1849"
         }
       }
     },
@@ -2082,12 +2082,12 @@
     },
     "358": {
       "id": 358,
-      "description": "KSM / USD",
+      "description": "EIGEN/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "kusama-moonriver": "0xbaA5A3379F28D3e63e623E5F96FafEE6A34d02fd"
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
         }
       }
     },
@@ -2104,18 +2104,18 @@
     },
     "364": {
       "id": 364,
-      "description": "SATS/USD-RefPrice-DS-Premium-Global-003",
+      "description": "KSM / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+          "kusama-moonriver": "0xbaA5A3379F28D3e63e623E5F96FafEE6A34d02fd"
         }
       }
     },
     "367": {
       "id": 367,
-      "description": "FARTCOIN/USD-RefPrice-DS-Premium-Global-003",
+      "description": "SATS/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2126,7 +2126,7 @@
     },
     "370": {
       "id": 370,
-      "description": "BLUR/USD-RefPrice-DS-Premium-Global-003",
+      "description": "ASTR/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2137,17 +2137,6 @@
     },
     "373": {
       "id": 373,
-      "description": "ASTR/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "376": {
-      "id": 376,
       "description": "ZIL / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2159,8 +2148,41 @@
         }
       }
     },
+    "376": {
+      "id": 376,
+      "description": "ATH/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
     "379": {
       "id": 379,
+      "description": "BLUR/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "382": {
+      "id": 382,
+      "description": "NOT/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "385": {
+      "id": 385,
       "description": "USDD / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2170,8 +2192,8 @@
         }
       }
     },
-    "382": {
-      "id": 382,
+    "388": {
+      "id": 388,
       "description": "BAT / USD",
       "chainlink_compatibility": {
         "base": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
@@ -2184,8 +2206,8 @@
         }
       }
     },
-    "383": {
-      "id": 383,
+    "389": {
+      "id": 389,
       "description": "BAT / ETH",
       "chainlink_compatibility": {
         "base": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
@@ -2195,8 +2217,8 @@
         }
       }
     },
-    "386": {
-      "id": 386,
+    "392": {
+      "id": 392,
       "description": "MASK / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2206,42 +2228,19 @@
         }
       }
     },
-    "389": {
-      "id": 389,
-      "description": "ATH/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "392": {
-      "id": 392,
-      "description": "AI16Z/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
     "395": {
       "id": 395,
-      "description": "WEMIX / USD",
+      "description": "ID/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "arbitrum-mainnet": "0xf8abb3c41A3b21687Ad862C9Fd00D007E413EEAA",
-          "arbitrum-sepolia": "0xffC47908525508141550A92890883a04e169a10C"
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
         }
       }
     },
-    "397": {
-      "id": 397,
+    "398": {
+      "id": 398,
       "description": "ZRX / USD",
       "chainlink_compatibility": {
         "base": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
@@ -2254,8 +2253,8 @@
         }
       }
     },
-    "398": {
-      "id": 398,
+    "399": {
+      "id": 399,
       "description": "ZRX / ETH",
       "chainlink_compatibility": {
         "base": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
@@ -2265,35 +2264,8 @@
         }
       }
     },
-    "401": {
-      "id": 401,
-      "description": "NOT/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "404": {
-      "id": 404,
-      "description": "CVX / USD",
-      "chainlink_compatibility": {
-        "base": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0xC27E191714b429C51e18FAfba6A4C31135B2e157",
-          "arbitrum-mainnet": "0x3d62E33E97de1F0ce913dB62d5972722C2A7E4f6",
-          "avalanche-mainnet": "0x1C3BEDe28d09d5dc36D861E9345628bAaCfd88b8",
-          "optimism-mainnet": "0xc51C6af1B2c0184F101D9d23d059bDaD2fd330aF",
-          "optimism-sepolia": "0x234a5fb5Bd614a7AA2FfAB244D603abFA0Ac5C5C",
-          "polygon-mainnet": "0x0d27C2703b3e6F1eAA719cd4bBb534C4a68f1e25"
-        }
-      }
-    },
-    "407": {
-      "id": 407,
+    "402": {
+      "id": 402,
       "description": "ZRO/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2303,9 +2275,32 @@
         }
       }
     },
-    "410": {
-      "id": 410,
+    "405": {
+      "id": 405,
       "description": "HOT/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "407": {
+      "id": 407,
+      "description": "WEMIX / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0xf8abb3c41A3b21687Ad862C9Fd00D007E413EEAA",
+          "arbitrum-sepolia": "0xffC47908525508141550A92890883a04e169a10C"
+        }
+      }
+    },
+    "409": {
+      "id": 409,
+      "description": "ORDI/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2330,7 +2325,7 @@
     },
     "415": {
       "id": 415,
-      "description": "ID/USD-RefPrice-DS-Premium-Global-003",
+      "description": "AI16Z/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2341,17 +2336,33 @@
     },
     "418": {
       "id": 418,
-      "description": "DGB / USD",
+      "description": "CVX / USD",
       "chainlink_compatibility": {
-        "base": null,
+        "base": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "polygon-mainnet": "0xd49A730354913127D687FB794c4446E7AeFE94AD"
+          "ethereum-mainnet": "0xC27E191714b429C51e18FAfba6A4C31135B2e157",
+          "arbitrum-mainnet": "0x3d62E33E97de1F0ce913dB62d5972722C2A7E4f6",
+          "avalanche-mainnet": "0x1C3BEDe28d09d5dc36D861E9345628bAaCfd88b8",
+          "optimism-mainnet": "0xc51C6af1B2c0184F101D9d23d059bDaD2fd330aF",
+          "optimism-sepolia": "0x234a5fb5Bd614a7AA2FfAB244D603abFA0Ac5C5C",
+          "polygon-mainnet": "0x0d27C2703b3e6F1eAA719cd4bBb534C4a68f1e25"
         }
       }
     },
     "421": {
       "id": 421,
+      "description": "MOG/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "423": {
+      "id": 423,
       "description": "ANKR / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2362,31 +2373,8 @@
         }
       }
     },
-    "424": {
-      "id": 424,
-      "description": "ORDI/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "427": {
-      "id": 427,
-      "description": "ONE / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "optimism-mainnet": "0x663ed3D2aB9F8d5282a94BA4636E346e59bDdEB9",
-          "optimism-sepolia": "0x9c2cE44DB32C8D750d8CE6aCB523e8291816C168"
-        }
-      }
-    },
-    "430": {
-      "id": 430,
+    "426": {
+      "id": 426,
       "description": "YFI / USD",
       "chainlink_compatibility": {
         "base": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
@@ -2405,8 +2393,8 @@
         }
       }
     },
-    "431": {
-      "id": 431,
+    "427": {
+      "id": 427,
       "description": "YFI / BNB",
       "chainlink_compatibility": {
         "base": null,
@@ -2416,8 +2404,8 @@
         }
       }
     },
-    "432": {
-      "id": 432,
+    "428": {
+      "id": 428,
       "description": "YFI / ETH",
       "chainlink_compatibility": {
         "base": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
@@ -2428,41 +2416,8 @@
         }
       }
     },
-    "435": {
-      "id": 435,
-      "description": "POPCAT/USD-RefPrice-mainnet-production",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
-        }
-      }
-    },
-    "437": {
-      "id": 437,
-      "description": "MOG/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "439": {
-      "id": 439,
-      "description": "MEW/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "442": {
-      "id": 442,
+    "431": {
+      "id": 431,
       "description": "ENJ / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2473,8 +2428,8 @@
         }
       }
     },
-    "443": {
-      "id": 443,
+    "432": {
+      "id": 432,
       "description": "ENJ / ETH",
       "chainlink_compatibility": {
         "base": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c",
@@ -2484,21 +2439,42 @@
         }
       }
     },
-    "446": {
-      "id": 446,
-      "description": "WOO / USD",
+    "435": {
+      "id": 435,
+      "description": "PNUT/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x807EB1664b774F37E23d7Ea4a384028cC888c511",
-          "bsc-mainnet": "0x8C328f0Deca45Eb4D1d3c36d06f77815E11b6791",
-          "polygon-mainnet": "0x1A9a36A20d02E247ABceC3C32e155E498BE398f9"
+          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
         }
       }
     },
-    "448": {
-      "id": 448,
+    "438": {
+      "id": 438,
+      "description": "ONE / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "optimism-mainnet": "0x663ed3D2aB9F8d5282a94BA4636E346e59bDdEB9",
+          "optimism-sepolia": "0x9c2cE44DB32C8D750d8CE6aCB523e8291816C168"
+        }
+      }
+    },
+    "441": {
+      "id": 441,
+      "description": "MEW/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "444": {
+      "id": 444,
       "description": "SUSHI / USD",
       "chainlink_compatibility": {
         "base": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
@@ -2516,8 +2492,8 @@
         }
       }
     },
-    "449": {
-      "id": 449,
+    "445": {
+      "id": 445,
       "description": "SUSHI / ETH",
       "chainlink_compatibility": {
         "base": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
@@ -2528,41 +2504,8 @@
         }
       }
     },
-    "452": {
-      "id": 452,
-      "description": "PNUT/USD-RefPrice-mainnet-production",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
-        }
-      }
-    },
-    "455": {
-      "id": 455,
-      "description": "ETHFI/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "458": {
-      "id": 458,
-      "description": "TURBO/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "461": {
-      "id": 461,
+    "448": {
+      "id": 448,
       "description": "IOTX / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2572,8 +2515,87 @@
         }
       }
     },
+    "450": {
+      "id": 450,
+      "description": "ETHFI/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "453": {
+      "id": 453,
+      "description": "WOO / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x807EB1664b774F37E23d7Ea4a384028cC888c511",
+          "bsc-mainnet": "0x8C328f0Deca45Eb4D1d3c36d06f77815E11b6791",
+          "polygon-mainnet": "0x1A9a36A20d02E247ABceC3C32e155E498BE398f9"
+        }
+      }
+    },
+    "455": {
+      "id": 455,
+      "description": "POPCAT/USD-RefPrice-mainnet-production",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
+        }
+      }
+    },
+    "457": {
+      "id": 457,
+      "description": "TURBO/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "460": {
+      "id": 460,
+      "description": "DGB / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "polygon-mainnet": "0xd49A730354913127D687FB794c4446E7AeFE94AD"
+        }
+      }
+    },
     "463": {
       "id": 463,
+      "description": "LRC / ETH",
+      "chainlink_compatibility": {
+        "base": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
+        "quote": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+        "chainlink_aggregators": {
+          "ethereum-mainnet": "0x506F678C8E426BA87427674f814AD2166c17981D"
+        }
+      }
+    },
+    "464": {
+      "id": 464,
+      "description": "HMSTR/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "467": {
+      "id": 467,
       "description": "GMX / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2587,30 +2609,21 @@
         }
       }
     },
-    "465": {
-      "id": 465,
-      "description": "LRC / ETH",
-      "chainlink_compatibility": {
-        "base": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
-        "quote": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x506F678C8E426BA87427674f814AD2166c17981D"
-        }
-      }
-    },
-    "466": {
-      "id": 466,
-      "description": "HMSTR/USD-RefPrice-DS-Premium-Global-003",
+    "469": {
+      "id": 469,
+      "description": "EURC / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+          "avalanche-mainnet": "0xd2eB0f960e2Af673C4162c82ffBf7e967534C1D9",
+          "base-mainnet": "0xc95cd3490be4af06F0A25435e21C2c91B988C482",
+          "celo-mainnet": "0xe0c266443401929B11A41156520b060E0bFec572"
         }
       }
     },
-    "469": {
-      "id": 469,
+    "471": {
+      "id": 471,
       "description": "RLUSD / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2620,27 +2633,15 @@
         }
       }
     },
-    "470": {
-      "id": 470,
-      "description": "ONT / USD",
+    "472": {
+      "id": 472,
+      "description": "GMT / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "bsc-mainnet": "0x4f1D73341fdDEEd7Aa8E8a8f86085C72bb734678"
-        }
-      }
-    },
-    "473": {
-      "id": 473,
-      "description": "EURC / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "avalanche-mainnet": "0xd2eB0f960e2Af673C4162c82ffBf7e967534C1D9",
-          "base-mainnet": "0xc95cd3490be4af06F0A25435e21C2c91B988C482",
-          "celo-mainnet": "0xe0c266443401929B11A41156520b060E0bFec572"
+          "bsc-mainnet": "0xc5DFc3feaC05a9C3b4c1c2e5bE5546b74a1B5cc3",
+          "bsc-testnet": "0x8f0cfD1eA98427ae9FadC100E9981dEb342CE836"
         }
       }
     },
@@ -2663,62 +2664,17 @@
     },
     "477": {
       "id": 477,
-      "description": "GMT / USD",
+      "description": "ONT / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "bsc-mainnet": "0xc5DFc3feaC05a9C3b4c1c2e5bE5546b74a1B5cc3",
-          "bsc-testnet": "0x8f0cfD1eA98427ae9FadC100E9981dEb342CE836"
+          "bsc-mainnet": "0x4f1D73341fdDEEd7Aa8E8a8f86085C72bb734678"
         }
       }
     },
     "480": {
       "id": 480,
-      "description": "POLYX/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "482": {
-      "id": 482,
-      "description": "BAND / BNB",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": null,
-        "chainlink_aggregators": {
-          "bsc-mainnet": "0x2f52D9f15D1C3b381F44483957851f4D0486EDfF"
-        }
-      }
-    },
-    "483": {
-      "id": 483,
-      "description": "BAND / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "bsc-mainnet": "0x7DBC514F75adf57F7a7Cb637fcBAd6F1c1b90eE5"
-        }
-      }
-    },
-    "486": {
-      "id": 486,
-      "description": "IO/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "489": {
-      "id": 489,
       "description": "SXP / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2729,25 +2685,69 @@
         }
       }
     },
-    "491": {
-      "id": 491,
-      "description": "USUAL/USD-RefPrice-mainnet-production",
+    "482": {
+      "id": 482,
+      "description": "POLYX/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
         }
       }
     },
-    "494": {
-      "id": 494,
+    "484": {
+      "id": 484,
+      "description": "BAND / BNB",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": null,
+        "chainlink_aggregators": {
+          "bsc-mainnet": "0x2f52D9f15D1C3b381F44483957851f4D0486EDfF"
+        }
+      }
+    },
+    "485": {
+      "id": 485,
+      "description": "BAND / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "bsc-mainnet": "0x7DBC514F75adf57F7a7Cb637fcBAd6F1c1b90eE5"
+        }
+      }
+    },
+    "488": {
+      "id": 488,
       "description": "ARKM/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
           "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "491": {
+      "id": 491,
+      "description": "IO/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "494": {
+      "id": 494,
+      "description": "STORJ / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "polygon-mainnet": "0xc76805E708d11180913265143dE3272B69AD0b80"
         }
       }
     },
@@ -2767,17 +2767,28 @@
     },
     "500": {
       "id": 500,
-      "description": "STORJ / USD",
+      "description": "USUAL/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "polygon-mainnet": "0xc76805E708d11180913265143dE3272B69AD0b80"
+          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
         }
       }
     },
     "503": {
       "id": 503,
+      "description": "AEVO/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "506": {
+      "id": 506,
       "description": "METIS / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2788,8 +2799,8 @@
         }
       }
     },
-    "506": {
-      "id": 506,
+    "509": {
+      "id": 509,
       "description": "NEIRO / USD",
       "chainlink_compatibility": {
         "base": "0xEE2a03Aa6Dacf51C18679C516ad5283d8E7C2637",
@@ -2799,31 +2810,8 @@
         }
       }
     },
-    "509": {
-      "id": 509,
-      "description": "AEVO/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
     "512": {
       "id": 512,
-      "description": "AVAIL / USD",
-      "chainlink_compatibility": {
-        "base": "0xEeB4d8400AEefafC1B2953e0094134A887C76Bd8",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x48ac3CD812680C39879A1Fd1666639dBC9B978C0",
-          "base-mainnet": "0x6135E62caFDCcFA9bAcA39b4C9Cbf8bb69908B5a"
-        }
-      }
-    },
-    "514": {
-      "id": 514,
       "description": "MEME/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -2833,8 +2821,8 @@
         }
       }
     },
-    "517": {
-      "id": 517,
+    "515": {
+      "id": 515,
       "description": "UMA / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2847,20 +2835,32 @@
         }
       }
     },
+    "518": {
+      "id": 518,
+      "description": "AVAIL / USD",
+      "chainlink_compatibility": {
+        "base": "0xEeB4d8400AEefafC1B2953e0094134A887C76Bd8",
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "ethereum-mainnet": "0x48ac3CD812680C39879A1Fd1666639dBC9B978C0",
+          "base-mainnet": "0x6135E62caFDCcFA9bAcA39b4C9Cbf8bb69908B5a"
+        }
+      }
+    },
     "520": {
       "id": 520,
-      "description": "AIXBT/USD-RefPrice-mainnet-production",
+      "description": "MANTA/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
         }
       }
     },
     "523": {
       "id": 523,
-      "description": "MANTA/USD-RefPrice-DS-Premium-Global-003",
+      "description": "ALT/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -2871,6 +2871,65 @@
     },
     "526": {
       "id": 526,
+      "description": "SPELL / USD",
+      "chainlink_compatibility": {
+        "base": "0x090185f2135308BaD17527004364eBcC2D37e5F6",
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "ethereum-mainnet": "0x9959F0691dEE3Af699728977C37ee1E348E99202",
+          "arbitrum-mainnet": "0xf6bACC7750c23A34b996A355A6E78b17Fc4BaEdC",
+          "avalanche-mainnet": "0x72470E4Cb2CA62C71783dE44259ef68DA6cBF78C",
+          "bsc-mainnet": "0x5A3b0851519Bfd72b681609137efF5b2E47C381b",
+          "fantom-mainnet": "0x421CfF3FF719b5101f9c8Da487445C39838A566c"
+        }
+      }
+    },
+    "528": {
+      "id": 528,
+      "description": "BOME/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "531": {
+      "id": 531,
+      "description": "IQ/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "534": {
+      "id": 534,
+      "description": "AIXBT/USD-RefPrice-mainnet-production",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x0000000000000000000000000000000000000000"
+        }
+      }
+    },
+    "537": {
+      "id": 537,
+      "description": "VELO / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "optimism-mainnet": "0x381FA26795F866c7FE760C0cca682f0f2563ad56"
+        }
+      }
+    },
+    "540": {
+      "id": 540,
       "description": "BAL / USD",
       "chainlink_compatibility": {
         "base": "0xba100000625a3754423978a60c9317c58a424e3D",
@@ -2885,34 +2944,8 @@
         }
       }
     },
-    "529": {
-      "id": 529,
-      "description": "SPELL / USD",
-      "chainlink_compatibility": {
-        "base": "0x090185f2135308BaD17527004364eBcC2D37e5F6",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x9959F0691dEE3Af699728977C37ee1E348E99202",
-          "arbitrum-mainnet": "0xf6bACC7750c23A34b996A355A6E78b17Fc4BaEdC",
-          "avalanche-mainnet": "0x72470E4Cb2CA62C71783dE44259ef68DA6cBF78C",
-          "bsc-mainnet": "0x5A3b0851519Bfd72b681609137efF5b2E47C381b",
-          "fantom-mainnet": "0x421CfF3FF719b5101f9c8Da487445C39838A566c"
-        }
-      }
-    },
-    "531": {
-      "id": 531,
-      "description": "ALT/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "534": {
-      "id": 534,
+    "543": {
+      "id": 543,
       "description": "XVS / BNB",
       "chainlink_compatibility": {
         "base": null,
@@ -2922,8 +2955,8 @@
         }
       }
     },
-    "535": {
-      "id": 535,
+    "544": {
+      "id": 544,
       "description": "XVS / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -2935,47 +2968,14 @@
         }
       }
     },
-    "537": {
-      "id": 537,
-      "description": "IQ/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "540": {
-      "id": 540,
-      "description": "BOME/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "543": {
-      "id": 543,
-      "description": "VELO / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "optimism-mainnet": "0x381FA26795F866c7FE760C0cca682f0f2563ad56"
-        }
-      }
-    },
     "546": {
       "id": 546,
-      "description": "HSK / USD",
+      "description": "CHR / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x0ce05dcbD07ac17528fA47f9752b233f00E6c29b"
+          "bsc-mainnet": "0x297542a584BDfa1F1C450ae3542137790C60B1EB"
         }
       }
     },
@@ -2992,6 +2992,17 @@
     },
     "550": {
       "id": 550,
+      "description": "BLAST/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "552": {
+      "id": 552,
       "description": "BIGTIME/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3001,20 +3012,9 @@
         }
       }
     },
-    "553": {
-      "id": 553,
-      "description": "CHR / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "bsc-mainnet": "0x297542a584BDfa1F1C450ae3542137790C60B1EB"
-        }
-      }
-    },
     "555": {
       "id": 555,
-      "description": "BLAST/USD-RefPrice-DS-Premium-Global-003",
+      "description": "ILV/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -3025,17 +3025,6 @@
     },
     "557": {
       "id": 557,
-      "description": "ILV/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "559": {
-      "id": 559,
       "description": "USDP / USD",
       "chainlink_compatibility": {
         "base": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
@@ -3045,8 +3034,19 @@
         }
       }
     },
-    "561": {
-      "id": 561,
+    "559": {
+      "id": 559,
+      "description": "PEOPLE/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "562": {
+      "id": 562,
       "description": "USDX / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3058,52 +3058,8 @@
         }
       }
     },
-    "562": {
-      "id": 562,
-      "description": "PEOPLE/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "565": {
-      "id": 565,
-      "description": "SCR/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "568": {
-      "id": 568,
-      "description": "SLP / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "polygon-mainnet": "0xEe2B6737b55e14b31fCa9247EA86593944F1c903"
-        }
-      }
-    },
-    "571": {
-      "id": 571,
-      "description": "USDtb / USD",
-      "chainlink_compatibility": {
-        "base": "0xC139190F447e929f090Edeb554D95AbB8b18aC1C",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x55fbFB9F8D4d03BEc3c466eaFBf35F973704661E"
-        }
-      }
-    },
-    "573": {
-      "id": 573,
+    "563": {
+      "id": 563,
       "description": "TRB / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3114,14 +3070,58 @@
         }
       }
     },
-    "576": {
-      "id": 576,
+    "566": {
+      "id": 566,
+      "description": "PIXEL/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "569": {
+      "id": 569,
       "description": "XAI/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
           "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "571": {
+      "id": 571,
+      "description": "SLP / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "polygon-mainnet": "0xEe2B6737b55e14b31fCa9247EA86593944F1c903"
+        }
+      }
+    },
+    "574": {
+      "id": 574,
+      "description": "USDtb / USD",
+      "chainlink_compatibility": {
+        "base": "0xC139190F447e929f090Edeb554D95AbB8b18aC1C",
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "ethereum-mainnet": "0x55fbFB9F8D4d03BEc3c466eaFBf35F973704661E"
+        }
+      }
+    },
+    "576": {
+      "id": 576,
+      "description": "HSK / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x0ce05dcbD07ac17528fA47f9752b233f00E6c29b"
         }
       }
     },
@@ -3139,7 +3139,7 @@
     },
     "581": {
       "id": 581,
-      "description": "DOGS/USD-RefPrice-DS-Premium-Global-003",
+      "description": "SCR/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -3150,6 +3150,17 @@
     },
     "584": {
       "id": 584,
+      "description": "DOGS/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "587": {
+      "id": 587,
       "description": "EDU/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3159,8 +3170,31 @@
         }
       }
     },
-    "586": {
-      "id": 586,
+    "589": {
+      "id": 589,
+      "description": "ANON / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x30De7e208Cc038673a42EA9F90b7de0F744F6C79",
+          "optimism-mainnet": "0x326698A9b7152b45CDB70aE33331c69305C039ea"
+        }
+      }
+    },
+    "591": {
+      "id": 591,
+      "description": "C98 / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "bsc-mainnet": "0x60bddF874814e5994C6C4A6418157DE366e5D4DF"
+        }
+      }
+    },
+    "593": {
+      "id": 593,
       "description": "KNC / USD",
       "chainlink_compatibility": {
         "base": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
@@ -3176,8 +3210,8 @@
         }
       }
     },
-    "587": {
-      "id": 587,
+    "594": {
+      "id": 594,
       "description": "KNC / ETH",
       "chainlink_compatibility": {
         "base": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
@@ -3187,8 +3221,19 @@
         }
       }
     },
-    "590": {
-      "id": 590,
+    "597": {
+      "id": 597,
+      "description": "BB/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "600": {
+      "id": 600,
       "description": "BUSD / USD",
       "chainlink_compatibility": {
         "base": "0x4Fabb145d64652a948d72533023f6E7A623C7C53",
@@ -3200,8 +3245,8 @@
         }
       }
     },
-    "592": {
-      "id": 592,
+    "602": {
+      "id": 602,
       "description": "USDL / USD",
       "chainlink_compatibility": {
         "base": "0xbdC7c08592Ee4aa51D06C27Ee23D5087D65aDbcD",
@@ -3212,58 +3257,14 @@
         }
       }
     },
-    "593": {
-      "id": 593,
-      "description": "C98 / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "bsc-mainnet": "0x60bddF874814e5994C6C4A6418157DE366e5D4DF"
-        }
-      }
-    },
-    "595": {
-      "id": 595,
+    "603": {
+      "id": 603,
       "description": "WIN / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
           "bsc-mainnet": "0x43CB601A5869Fc67f5D3389fE91C6c6fBC6F880b"
-        }
-      }
-    },
-    "598": {
-      "id": 598,
-      "description": "BADGER / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "polygon-mainnet": "0xbC71031a5588b6bDfEA3C2974bD6fa0F5b81d49b"
-        }
-      }
-    },
-    "601": {
-      "id": 601,
-      "description": "BB/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "604": {
-      "id": 604,
-      "description": "GOAT/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
         }
       }
     },
@@ -3280,7 +3281,7 @@
     },
     "609": {
       "id": 609,
-      "description": "OMNI/USD-RefPrice-DS-Premium-Global-003",
+      "description": "GOAT/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -3289,8 +3290,8 @@
         }
       }
     },
-    "612": {
-      "id": 612,
+    "611": {
+      "id": 611,
       "description": "AI/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3300,8 +3301,19 @@
         }
       }
     },
-    "614": {
-      "id": 614,
+    "613": {
+      "id": 613,
+      "description": "OMNI/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "616": {
+      "id": 616,
       "description": "BONE / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3312,32 +3324,8 @@
         }
       }
     },
-    "617": {
-      "id": 617,
-      "description": "LUSD / USD",
-      "chainlink_compatibility": {
-        "base": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x36A0448c46AaE145dD5BC320D5153426a2a586F5",
-          "arbitrum-mainnet": "0x20CD97619A51d1a6f1910ce62d98Aceb9a13d5e6",
-          "optimism-mainnet": "0x19dC743a5E9a73eefAbA7047C7CEeBc650F37336"
-        }
-      }
-    },
-    "618": {
-      "id": 618,
-      "description": "PIXEL/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "621": {
-      "id": 621,
+    "619": {
+      "id": 619,
       "description": "REZ/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3347,8 +3335,8 @@
         }
       }
     },
-    "624": {
-      "id": 624,
+    "622": {
+      "id": 622,
       "description": "DODO / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3361,8 +3349,21 @@
         }
       }
     },
-    "626": {
-      "id": 626,
+    "624": {
+      "id": 624,
+      "description": "LUSD / USD",
+      "chainlink_compatibility": {
+        "base": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "ethereum-mainnet": "0x36A0448c46AaE145dD5BC320D5153426a2a586F5",
+          "arbitrum-mainnet": "0x20CD97619A51d1a6f1910ce62d98Aceb9a13d5e6",
+          "optimism-mainnet": "0x19dC743a5E9a73eefAbA7047C7CEeBc650F37336"
+        }
+      }
+    },
+    "625": {
+      "id": 625,
       "description": "QI / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3372,20 +3373,20 @@
         }
       }
     },
-    "628": {
-      "id": 628,
-      "description": "COQ / USD",
+    "627": {
+      "id": 627,
+      "description": "CYBER/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "avalanche-mainnet": "0xbAB7eC733E04E4Ca028A303003c215D93574Ca2F"
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
         }
       }
     },
-    "630": {
-      "id": 630,
-      "description": "CYBER/USD-RefPrice-DS-Premium-Global-003",
+    "629": {
+      "id": 629,
+      "description": "MERL/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
@@ -3396,6 +3397,17 @@
     },
     "632": {
       "id": 632,
+      "description": "DEGEN / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "base-mainnet": "0xaE4602716079C0Be7948c0b84553dEE0e6564a3d"
+        }
+      }
+    },
+    "634": {
+      "id": 634,
       "description": "HIGH / USD",
       "chainlink_compatibility": {
         "base": "0x71Ab77b7dbB4fa7e017BC15090b2163221420282",
@@ -3406,42 +3418,19 @@
         }
       }
     },
-    "634": {
-      "id": 634,
-      "description": "MAGIC / USD",
+    "636": {
+      "id": 636,
+      "description": "COQ / USD",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x5ab0B1e2604d4B708721bc3cD1ce962958b4297E",
-          "arbitrum-sepolia": "0xED14143c48E32D7f99D2E0c117a95260a9120caD"
+          "avalanche-mainnet": "0xbAB7eC733E04E4Ca028A303003c215D93574Ca2F"
         }
       }
     },
-    "637": {
-      "id": 637,
-      "description": "DEGEN / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "base-mainnet": "0xaE4602716079C0Be7948c0b84553dEE0e6564a3d"
-        }
-      }
-    },
-    "639": {
-      "id": 639,
-      "description": "MERL/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "642": {
-      "id": 642,
+    "638": {
+      "id": 638,
       "description": "GNS / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3452,8 +3441,8 @@
         }
       }
     },
-    "644": {
-      "id": 644,
+    "640": {
+      "id": 640,
       "description": "GRIFFAIN/USD-RefPrice-mainnet-production",
       "chainlink_compatibility": {
         "base": null,
@@ -3463,21 +3452,8 @@
         }
       }
     },
-    "646": {
-      "id": 646,
-      "description": "DPI / USD",
-      "chainlink_compatibility": {
-        "base": "0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b",
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "ethereum-mainnet": "0x2878E76c12dAD8DFfDcCeb52588e091aa3858d26",
-          "arbitrum-mainnet": "0xe7F278c6cf5A9349f98F01A9c8ddD6Eaa2a1DD24",
-          "polygon-mainnet": "0x40698914C15b07C6daa5a76829Ee6639989b8Edf"
-        }
-      }
-    },
-    "647": {
-      "id": 647,
+    "642": {
+      "id": 642,
       "description": "OGN / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3488,8 +3464,20 @@
         }
       }
     },
-    "649": {
-      "id": 649,
+    "644": {
+      "id": 644,
+      "description": "MAGIC / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x5ab0B1e2604d4B708721bc3cD1ce962958b4297E",
+          "arbitrum-sepolia": "0xED14143c48E32D7f99D2E0c117a95260a9120caD"
+        }
+      }
+    },
+    "647": {
+      "id": 647,
       "description": "STG / USD",
       "chainlink_compatibility": {
         "base": "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6",
@@ -3502,25 +3490,38 @@
         }
       }
     },
-    "651": {
-      "id": 651,
-      "description": "CUSD / USD",
+    "649": {
+      "id": 649,
+      "description": "DPI / USD",
       "chainlink_compatibility": {
-        "base": null,
+        "base": "0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b",
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "celo-mainnet": "0x2E5eddE44187c3099529eF63Ced87994F078FbdB"
+          "ethereum-mainnet": "0x2878E76c12dAD8DFfDcCeb52588e091aa3858d26",
+          "arbitrum-mainnet": "0xe7F278c6cf5A9349f98F01A9c8ddD6Eaa2a1DD24",
+          "polygon-mainnet": "0x40698914C15b07C6daa5a76829Ee6639989b8Edf"
         }
       }
     },
-    "653": {
-      "id": 653,
+    "650": {
+      "id": 650,
       "description": "MOODENG/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
           "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "653": {
+      "id": 653,
+      "description": "BADGER / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "polygon-mainnet": "0xbC71031a5588b6bDfEA3C2974bD6fa0F5b81d49b"
         }
       }
     },
@@ -3537,6 +3538,17 @@
     },
     "659": {
       "id": 659,
+      "description": "CUSD / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "celo-mainnet": "0x2E5eddE44187c3099529eF63Ced87994F078FbdB"
+        }
+      }
+    },
+    "661": {
+      "id": 661,
       "description": "MAV/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
@@ -3546,8 +3558,8 @@
         }
       }
     },
-    "661": {
-      "id": 661,
+    "663": {
+      "id": 663,
       "description": "ALPHA / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3557,36 +3569,25 @@
         }
       }
     },
-    "664": {
-      "id": 664,
+    "666": {
+      "id": 666,
+      "description": "LISTA / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "bsc-mainnet": "0x3007a29FF5F4D2A4361A306cbF80337394875a0D"
+        }
+      }
+    },
+    "668": {
+      "id": 668,
       "description": "AMPL / USD",
       "chainlink_compatibility": {
         "base": "0xD46bA6D942050d489DBd938a2C909A5d5039A161",
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
           "ethereum-mainnet": "0xd5090674b4653240cd94eE886484ca808c6E6694"
-        }
-      }
-    },
-    "666": {
-      "id": 666,
-      "description": "ORDER / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x476de91e5Ea44747f5be60a8C8EDa5407D2af349"
-        }
-      }
-    },
-    "668": {
-      "id": 668,
-      "description": "ZEREBRO/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
         }
       }
     },
@@ -3603,17 +3604,28 @@
     },
     "672": {
       "id": 672,
-      "description": "LISTA / USD",
+      "description": "ZEREBRO/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "bsc-mainnet": "0x3007a29FF5F4D2A4361A306cbF80337394875a0D"
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
         }
       }
     },
     "674": {
       "id": 674,
+      "description": "ORDER / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x476de91e5Ea44747f5be60a8C8EDa5407D2af349"
+        }
+      }
+    },
+    "676": {
+      "id": 676,
       "description": "RDNT / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3626,8 +3638,8 @@
         }
       }
     },
-    "677": {
-      "id": 677,
+    "679": {
+      "id": 679,
       "description": "MLN / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3638,8 +3650,8 @@
         }
       }
     },
-    "678": {
-      "id": 678,
+    "680": {
+      "id": 680,
       "description": "MLN / ETH",
       "chainlink_compatibility": {
         "base": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892",
@@ -3650,8 +3662,19 @@
         }
       }
     },
-    "681": {
-      "id": 681,
+    "683": {
+      "id": 683,
+      "description": "QUICK / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "polygon-mainnet": "0x09871EF6eCf97667A11FF467A6DD4D5C5629F1bb"
+        }
+      }
+    },
+    "685": {
+      "id": 685,
       "description": "ALCX / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3661,8 +3684,8 @@
         }
       }
     },
-    "684": {
-      "id": 684,
+    "688": {
+      "id": 688,
       "description": "PERP / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3674,8 +3697,8 @@
         }
       }
     },
-    "687": {
-      "id": 687,
+    "691": {
+      "id": 691,
       "description": "GHST / ETH",
       "chainlink_compatibility": {
         "base": null,
@@ -3685,8 +3708,8 @@
         }
       }
     },
-    "688": {
-      "id": 688,
+    "692": {
+      "id": 692,
       "description": "GHST / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3696,19 +3719,8 @@
         }
       }
     },
-    "691": {
-      "id": 691,
-      "description": "QUICK / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "polygon-mainnet": "0x09871EF6eCf97667A11FF467A6DD4D5C5629F1bb"
-        }
-      }
-    },
-    "693": {
-      "id": 693,
+    "695": {
+      "id": 695,
       "description": "BSW / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3718,30 +3730,8 @@
         }
       }
     },
-    "695": {
-      "id": 695,
-      "description": "ULTI / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x884720E3da9094190dC25911B4e0E61D79562788"
-        }
-      }
-    },
     "697": {
       "id": 697,
-      "description": "TRUMP/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "700": {
-      "id": 700,
       "description": "NULS / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3751,30 +3741,8 @@
         }
       }
     },
-    "703": {
-      "id": 703,
-      "description": "TOKEN/USD-RefPrice-DS-Premium-Global-003",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "705": {
-      "id": 705,
-      "description": "LINA / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "bsc-mainnet": "0xaAE06edcF9c064f2F73cA264b6aB6a8d86F023C2"
-        }
-      }
-    },
-    "707": {
-      "id": 707,
+    "700": {
+      "id": 700,
       "description": "WING / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3784,14 +3752,47 @@
         }
       }
     },
-    "709": {
-      "id": 709,
-      "description": "REN / USD",
+    "702": {
+      "id": 702,
+      "description": "TOKEN/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
-          "gnosis-mainnet": "0x9C1Dc429a8d8F10C8ebA522b608bC27F58d6ABE2"
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "704": {
+      "id": 704,
+      "description": "LINA / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "bsc-mainnet": "0xaAE06edcF9c064f2F73cA264b6aB6a8d86F023C2"
+        }
+      }
+    },
+    "706": {
+      "id": 706,
+      "description": "TRUMP/USD-RefPrice-DS-Premium-Global-003",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
+        }
+      }
+    },
+    "709": {
+      "id": 709,
+      "description": "ULTI / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "arbitrum-mainnet": "0x884720E3da9094190dC25911B4e0E61D79562788"
         }
       }
     },
@@ -3809,6 +3810,17 @@
     },
     "713": {
       "id": 713,
+      "description": "REN / USD",
+      "chainlink_compatibility": {
+        "base": null,
+        "quote": "0x0000000000000000000000000000000000000348",
+        "chainlink_aggregators": {
+          "gnosis-mainnet": "0x9C1Dc429a8d8F10C8ebA522b608bC27F58d6ABE2"
+        }
+      }
+    },
+    "715": {
+      "id": 715,
       "description": "MAVIA / USD",
       "chainlink_compatibility": {
         "base": "0x24fcFC492C1393274B6bcd568ac9e225BEc93584",
@@ -3819,8 +3831,8 @@
         }
       }
     },
-    "715": {
-      "id": 715,
+    "717": {
+      "id": 717,
       "description": "KLIMA / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3830,8 +3842,8 @@
         }
       }
     },
-    "717": {
-      "id": 717,
+    "719": {
+      "id": 719,
       "description": "SKY / USD",
       "chainlink_compatibility": {
         "base": "0x56072C95FAA701256059aa122697B133aDEd9279",
@@ -3841,8 +3853,8 @@
         }
       }
     },
-    "719": {
-      "id": 719,
+    "721": {
+      "id": 721,
       "description": "WELL / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3853,8 +3865,8 @@
         }
       }
     },
-    "721": {
-      "id": 721,
+    "723": {
+      "id": 723,
       "description": "FOXY / USD",
       "chainlink_compatibility": {
         "base": null,
@@ -3864,26 +3876,14 @@
         }
       }
     },
-    "723": {
-      "id": 723,
+    "725": {
+      "id": 725,
       "description": "MELANIA/USD-RefPrice-DS-Premium-Global-003",
       "chainlink_compatibility": {
         "base": null,
         "quote": "0x0000000000000000000000000000000000000348",
         "chainlink_aggregators": {
           "arbitrum-mainnet": "0x534a7FF707Bc862cAB0Dda546F1B817Be5235b66"
-        }
-      }
-    },
-    "726": {
-      "id": 726,
-      "description": "ANON / USD",
-      "chainlink_compatibility": {
-        "base": null,
-        "quote": "0x0000000000000000000000000000000000000348",
-        "chainlink_aggregators": {
-          "arbitrum-mainnet": "0x30De7e208Cc038673a42EA9F90b7de0F744F6C79",
-          "optimism-mainnet": "0x326698A9b7152b45CDB70aE33331c69305C039ea"
         }
       }
     },
@@ -4195,7 +4195,7 @@
     "fantom-mainnet/0x472105bB154bD92580a9669AB2483864c3dE9974": null,
     "fantom-testnet/0xA827d4d54655b0Cd61249079fc3b70521aa3670e": null,
     "kusama-mainnet-moonriver/0xff9E6849F257D8b62c733B4E8370613406d52f3c": null,
-    "mainnet/0x4a3411ac2948B33c69666B35cc6d055B27Ea84f1": null,
+    "mainnet/0xdc715c751f1cc129A6b47fEDC87D9918a4580502": null,
     "matic-mainnet/0x014497a2AEF847C7021b17BFF70A68221D22AA63": null,
     "polkadot-mainnet-moonbeam/0xe08F9B94B2a83105fde038d1A3dC3317f35273c3": null,
     "polygon-testnet-amoy/0xd4cfC9C436c61bEF92E8002603c825401A2cCaa8": null,
@@ -4581,6 +4581,7 @@
     "avalanche-mainnet/0xE91B9f158A6e89a43223e064331532e981Cf2DcA": null,
     "bsc-mainnet/0x0885CFc31E09c42793c3c1dB48db7588E6F800CF": null,
     "celo-mainnet/0x6Dad5A3Ff709b3688188e206458375451290A414": null,
+    "celo-testnet-alfajores/0x407f985F6984CB9E4e30088FD2aD76f2dB8FF969": null,
     "ethereum-mainnet-arbitrum-1/0xadBf1c8a244d537C343d771e2Fa897F3654a1Ae4": null,
     "ethereum-mainnet-optimism-1/0xaE4c8567C942B974Af4A860380c99A8D03C6148E": null,
     "ethereum-testnet-sepolia/0x0a69d6B0671ef71Bf69f8F33e426F3Da46d4D8C5": null,
@@ -4655,6 +4656,7 @@
     "mainnet/0xE95FEbF9b8623b1b3B79BF995491197A8b67D2A7": null,
     "bsc-mainnet/0x0E8F55B887e12F251cabBE7125d076FA20c5CC28": null,
     "celo-mainnet/0xD0735E9432eA8CDE8A855D3c0e6C18aC24a92ffC": null,
+    "celo-testnet-alfajores/0xf4ABC5ffCA5C4d592bADDd7b994b39B887299919": null,
     "ethereum-mainnet-optimism-1/0x28a6B219403c1Dac04172cBb8cC1aB8bF5925830": null,
     "matic-mainnet/0x75cBCfE2776C0436ac8A87C0BE7e563A06543FfF": null,
     "bsc-mainnet/0x0E9238c21CfaFadAF5E859CD63386b098218732B": null,
@@ -4750,6 +4752,7 @@
     "mainnet/0x0BC77EA00a329138be72CCe1D70B8d1e7CDE9bc4": null,
     "bsc-mainnet/0x696D72992Bc7a8D776E52c27ae68c5Bb6b695158": null,
     "celo-mainnet/0xF80EEC3e2c9059180C5e6a002Bd93c4A6C3aAf8f": null,
+    "celo-testnet-alfajores/0xe75332302AD3Be28b3DD596A1CD8A1f778346728": null,
     "ethereum-mainnet-arbitrum-1/0x5E4C65194F6F33a8BF7E9B95F1D0Ca9d611F6D62": null,
     "mainnet/0x9c7CF045f964B45FFC6AA0Ffbffd7bb6d1b470A3": null,
     "matic-mainnet/0x08c0342e2d59A973101499992647f0595bcEc034": null,
@@ -4936,11 +4939,13 @@
     "bsc-testnet/0xfed98742ECdBb2C6f12Cd1CB40dBD9e08aE9302C": null,
     "celo-mainnet/0x2E5eddE44187c3099529eF63Ced87994F078FbdB": null,
     "celo-mainnet/0xaf984A0A7e7072A5E03024896DcA9cB129A8470F": null,
+    "celo-testnet-alfajores/0x5C829175CF45d5007C0eC536616B654d09e9a76b": null,
     "celo-mainnet/0x5FB8bFAEBe2dd6dB2AF308D293ea25e607D3A922": null,
     "celo-testnet-alfajores/0x1e73B636AB0Ff7689eD234b5DCd847f55b020471": null,
     "ethereum-mainnet-optimism-1/0xc1c4a83d4707878d6D86C8D9C3f45c4D48473AA9": null,
     "ethereum-testnet-sepolia-optimism-1/0x01c4ff19f14797673E5256604dC915707c5430E4": null,
     "celo-mainnet/0x86336eAb11886a855aF17E355164Ea8e84FaBb46": null,
+    "celo-testnet-alfajores/0x3f78a9a59a94A26390fc5744260A1D8d5AB181dC": null,
     "celo-mainnet/0x9eb524dA226328d8ff69440F0F4bAE7DC0BFf34C": null,
     "celo-testnet-alfajores/0x0425b5f0490B1Ee410f8F8687Ae588dA8e9F7832": null,
     "matic-mainnet/0x382A5Cd7Ae6FDeFce5F4FEa4727f0Bc98936dF4E": null,
@@ -4949,6 +4954,7 @@
     "celo-mainnet/0xadfc6044c20B61eC54617F326e19ddA0422DCeE1": null,
     "celo-testnet-alfajores/0x5A65c678E45D2D935c346a736387737DF60cB5B2": null,
     "celo-mainnet/0xe8a22277Eda23C30067191a70D39A67262E6bEA6": null,
+    "celo-testnet-alfajores/0x84BAE4Ea8b080fc4bf0Be5B2C7BC0f19D3B22c6D": null,
     "ethereum-mainnet-andromeda-1/0x526B00801b2a09Cb730b3d2132a85fD75D0D9A44": null,
     "ethereum-testnet-sepolia-arbitrum-1/0x2aE4072A1e1b3CAFD7eF1b74Eb6C331e03fF332E": null,
     "ethereum-mainnet-andromeda-1/0x70E63607D7cc193Ac1f12E8728E90c698c22c926": null,
@@ -5186,6 +5192,7 @@
     "ethereum-mainnet-arbitrum-1/0xDf8a3fc9bC6fA89F1b630e58f6eB4b874f24C165": null,
     "ethereum-mainnet-base-1/0xc73B7635630A94a3E9a595741cbb8A3845C27826": null,
     "ethereum-mainnet-scroll-1/0x99C3d25507c9772E524cb7081e5Ab0BB1431E294": null,
+    "ethereum-mainnet-zksync-1/0xb2AfE53eEC3f84fd9Bba5dC8E4bafA742e9C4C68": null,
     "mainnet/0x079a0E672b5FCCB93ba1f837184F19eB5497128E": null,
     "ethereum-mainnet-arbitrum-1/0xE5B5Be82015444c04B281CF4aFa6A99130ED83a2": null,
     "ethereum-mainnet-optimism-1/0x12922291D1FcD0d121B5C88f061047fE18732743": null,
@@ -5495,6 +5502,7 @@
     "mainnet/0x5B4728BA4F1A210b3545959A4E0fB6c3a16FE8f7": null,
     "mainnet/0x5C00518D3d423EC59D553Af123Be8a63B11078CF": null,
     "mainnet/0x5a0efD6D1a058A46D3Ac4511861adB8F3540BD49": null,
+    "mainnet/0x5b7544c54E78777AFdD09620912AdBa36503BF91": null,
     "mainnet/0x63f71CB5c29c33656dCd5dcA144e12532A361bEF": null,
     "mainnet/0x6418Bb052FbB827A6022F4EC3F2d6A20444304EC": null,
     "mainnet/0x64DEE1Bc46e817ed93dEA4815F071B20eD218E39": null,
@@ -5503,6 +5511,7 @@
     "mainnet/0x6D68A0636246d1dE3EbE972AD8bEE886B10610Ee": null,
     "matic-mainnet/0xCC61Ce951576e995B97664BA8B5EDe55767CE1e2": null,
     "mainnet/0x714FF6b6Fc99c2Ee37BAC73aB41c8E4ae30508a5": null,
+    "mainnet/0x786ba26Ee47097E6A5086E742aEf5Efbc6A93447": null,
     "mainnet/0x7d95b7bf7bB7750d818F42Df114739B6C88CF9bC": null,
     "mainnet/0x80e1Cd5489a144ac6e0A9D1d69EBec9076b4d21c": null,
     "mainnet/0x816F26DB1086548881217694cfC8A1F915B62D11": null,
@@ -5520,6 +5529,7 @@
     "mainnet/0x90902B68e5049d56954bDfE4C3b235a805C8f153": null,
     "mainnet/0x90Fb891e7EE51972f7D9309a6B812D04ED2643c7": null,
     "mainnet/0x918C6cDE1CDd940934820B8FA3a2C8B26a60736C": null,
+    "mainnet/0x931f90Ee9515B4b842A34A0c1f7047CBF10d1138": null,
     "mainnet/0x961e0E0f63e4E1eF2F8e93579195371af39A4f2D": null,
     "mainnet/0x980c372084158c9132135728c4Dbf40F5E683E31": null,
     "matic-mainnet/0x60B68f82dc7fEda77a6484e2A8743991dC853e85": null,

--- a/config/feeds_config_new.json
+++ b/config/feeds_config_new.json
@@ -3907,49 +3907,6 @@
     },
     {
       "id": 43,
-      "full_name": "WSTETH / USD",
-      "description": "Wrapped stETH",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "WSTETH",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "WSTETH"
-              ],
-              "id": [
-                12409
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "WSTETH/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 44,
       "full_name": "USDS / USD",
       "description": "USDS",
       "type": "price-feed",
@@ -4017,7 +3974,7 @@
       }
     },
     {
-      "id": 45,
+      "id": 44,
       "full_name": "USDS / USDT",
       "description": "USDS",
       "type": "price-feed",
@@ -4062,7 +4019,7 @@
       }
     },
     {
-      "id": 46,
+      "id": 45,
       "full_name": "USDS / USDC",
       "description": "USDS",
       "type": "price-feed",
@@ -4102,7 +4059,7 @@
       }
     },
     {
-      "id": 47,
+      "id": 46,
       "full_name": "XLM / USD",
       "description": "Stellar",
       "type": "price-feed",
@@ -4228,7 +4185,7 @@
       }
     },
     {
-      "id": 48,
+      "id": 47,
       "full_name": "XLM / USDT",
       "description": "Stellar",
       "type": "price-feed",
@@ -4323,7 +4280,7 @@
       }
     },
     {
-      "id": 49,
+      "id": 48,
       "full_name": "XLM / USDC",
       "description": "Stellar",
       "type": "price-feed",
@@ -4383,7 +4340,7 @@
       }
     },
     {
-      "id": 50,
+      "id": 49,
       "full_name": "AVAX / USD",
       "description": "Avalanche",
       "type": "price-feed",
@@ -4516,7 +4473,7 @@
       }
     },
     {
-      "id": 51,
+      "id": 50,
       "full_name": "AVAX / USDT",
       "description": "Avalanche",
       "type": "price-feed",
@@ -4614,7 +4571,7 @@
       }
     },
     {
-      "id": 52,
+      "id": 51,
       "full_name": "AVAX / USDC",
       "description": "Avalanche",
       "type": "price-feed",
@@ -4692,7 +4649,7 @@
       }
     },
     {
-      "id": 53,
+      "id": 52,
       "full_name": "SHIB / USD",
       "description": "Shiba Inu",
       "type": "price-feed",
@@ -4835,7 +4792,7 @@
       }
     },
     {
-      "id": 54,
+      "id": 53,
       "full_name": "SHIB / USDT",
       "description": "Shiba Inu",
       "type": "price-feed",
@@ -4933,7 +4890,7 @@
       }
     },
     {
-      "id": 55,
+      "id": 54,
       "full_name": "SHIB / USDC",
       "description": "Shiba Inu",
       "type": "price-feed",
@@ -5011,7 +4968,7 @@
       }
     },
     {
-      "id": 56,
+      "id": 55,
       "full_name": "SUI / USD",
       "description": "Sui",
       "type": "price-feed",
@@ -5129,7 +5086,7 @@
       }
     },
     {
-      "id": 57,
+      "id": 56,
       "full_name": "SUI / USDT",
       "description": "Sui",
       "type": "price-feed",
@@ -5209,7 +5166,7 @@
       }
     },
     {
-      "id": 58,
+      "id": 57,
       "full_name": "SUI / USDC",
       "description": "Sui",
       "type": "price-feed",
@@ -5279,7 +5236,7 @@
       }
     },
     {
-      "id": 59,
+      "id": 58,
       "full_name": "BCH / BNB",
       "description": "Bitcoin Cash",
       "type": "price-feed",
@@ -5319,7 +5276,7 @@
       }
     },
     {
-      "id": 60,
+      "id": 59,
       "full_name": "BCH / USD",
       "description": "Bitcoin Cash",
       "type": "price-feed",
@@ -5445,7 +5402,7 @@
       }
     },
     {
-      "id": 61,
+      "id": 60,
       "full_name": "BCH / USDT",
       "description": "Bitcoin Cash",
       "type": "price-feed",
@@ -5538,7 +5495,7 @@
       }
     },
     {
-      "id": 62,
+      "id": 61,
       "full_name": "BCH / USDC",
       "description": "Bitcoin Cash",
       "type": "price-feed",
@@ -5616,7 +5573,7 @@
       }
     },
     {
-      "id": 63,
+      "id": 62,
       "full_name": "LTC / BNB",
       "description": "Litecoin",
       "type": "price-feed",
@@ -5656,7 +5613,7 @@
       }
     },
     {
-      "id": 64,
+      "id": 63,
       "full_name": "LTC / USD",
       "description": "Litecoin",
       "type": "price-feed",
@@ -5783,7 +5740,7 @@
       }
     },
     {
-      "id": 65,
+      "id": 64,
       "full_name": "LTC / USDT",
       "description": "Litecoin",
       "type": "price-feed",
@@ -5871,7 +5828,7 @@
       }
     },
     {
-      "id": 66,
+      "id": 65,
       "full_name": "LTC / USDC",
       "description": "Litecoin",
       "type": "price-feed",
@@ -5949,7 +5906,7 @@
       }
     },
     {
-      "id": 67,
+      "id": 66,
       "full_name": "TON / USD",
       "description": "Toncoin",
       "type": "price-feed",
@@ -6054,7 +6011,7 @@
       }
     },
     {
-      "id": 68,
+      "id": 67,
       "full_name": "TON / USDT",
       "description": "Toncoin",
       "type": "price-feed",
@@ -6132,7 +6089,7 @@
       }
     },
     {
-      "id": 69,
+      "id": 68,
       "full_name": "TON / USDC",
       "description": "Toncoin",
       "type": "price-feed",
@@ -6195,7 +6152,7 @@
       }
     },
     {
-      "id": 70,
+      "id": 69,
       "full_name": "OM / USD",
       "description": "MANTRA",
       "type": "price-feed",
@@ -6292,7 +6249,7 @@
       }
     },
     {
-      "id": 71,
+      "id": 70,
       "full_name": "OM / USDT",
       "description": "MANTRA",
       "type": "price-feed",
@@ -6362,7 +6319,7 @@
       }
     },
     {
-      "id": 72,
+      "id": 71,
       "full_name": "OM / USDC",
       "description": "MANTRA",
       "type": "price-feed",
@@ -6412,7 +6369,7 @@
       }
     },
     {
-      "id": 73,
+      "id": 72,
       "full_name": "DOT / USD",
       "description": "Polkadot",
       "type": "price-feed",
@@ -6538,7 +6495,7 @@
       }
     },
     {
-      "id": 74,
+      "id": 73,
       "full_name": "DOT / BNB",
       "description": "Polkadot",
       "type": "price-feed",
@@ -6578,7 +6535,7 @@
       }
     },
     {
-      "id": 75,
+      "id": 74,
       "full_name": "DOT / USDT",
       "description": "Polkadot",
       "type": "price-feed",
@@ -6671,7 +6628,7 @@
       }
     },
     {
-      "id": 76,
+      "id": 75,
       "full_name": "DOT / USDC",
       "description": "Polkadot",
       "type": "price-feed",
@@ -6744,7 +6701,7 @@
       }
     },
     {
-      "id": 77,
+      "id": 76,
       "full_name": "USDe / USD",
       "description": "Ethena USDe",
       "type": "price-feed",
@@ -6816,7 +6773,7 @@
       }
     },
     {
-      "id": 78,
+      "id": 77,
       "full_name": "USDE / USD",
       "description": "Ethena USDe",
       "type": "price-feed",
@@ -6888,7 +6845,7 @@
       }
     },
     {
-      "id": 79,
+      "id": 78,
       "full_name": "USDe / USDT",
       "description": "Ethena USDe",
       "type": "price-feed",
@@ -6948,7 +6905,7 @@
       }
     },
     {
-      "id": 80,
+      "id": 79,
       "full_name": "USDe / USDC",
       "description": "Ethena USDe",
       "type": "price-feed",
@@ -6993,7 +6950,7 @@
       }
     },
     {
-      "id": 81,
+      "id": 80,
       "full_name": "USDE / USDT",
       "description": "Ethena USDe",
       "type": "price-feed",
@@ -7053,7 +7010,7 @@
       }
     },
     {
-      "id": 82,
+      "id": 81,
       "full_name": "USDE / USDC",
       "description": "Ethena USDe",
       "type": "price-feed",
@@ -7098,7 +7055,7 @@
       }
     },
     {
-      "id": 83,
+      "id": 82,
       "full_name": "DAI / USD",
       "description": "DAI",
       "type": "price-feed",
@@ -7212,7 +7169,7 @@
       }
     },
     {
-      "id": 84,
+      "id": 83,
       "full_name": "DAI / BNB",
       "description": "DAI",
       "type": "price-feed",
@@ -7252,7 +7209,7 @@
       }
     },
     {
-      "id": 85,
+      "id": 84,
       "full_name": "DAI / USDT",
       "description": "DAI",
       "type": "price-feed",
@@ -7330,7 +7287,7 @@
       }
     },
     {
-      "id": 86,
+      "id": 85,
       "full_name": "DAI / USDC",
       "description": "DAI",
       "type": "price-feed",
@@ -7380,7 +7337,7 @@
       }
     },
     {
-      "id": 87,
+      "id": 86,
       "full_name": "HYPE / USD",
       "description": "Hyperliquid",
       "type": "price-feed",
@@ -7440,7 +7397,7 @@
       }
     },
     {
-      "id": 88,
+      "id": 87,
       "full_name": "HYPE / USDT",
       "description": "Hyperliquid",
       "type": "price-feed",
@@ -7490,7 +7447,7 @@
       }
     },
     {
-      "id": 89,
+      "id": 88,
       "full_name": "XMR / USD",
       "description": "Monero",
       "type": "price-feed",
@@ -7568,7 +7525,7 @@
       }
     },
     {
-      "id": 90,
+      "id": 89,
       "full_name": "XMR / USDT",
       "description": "Monero",
       "type": "price-feed",
@@ -7626,7 +7583,7 @@
       }
     },
     {
-      "id": 91,
+      "id": 90,
       "full_name": "XMR / USDC",
       "description": "Monero",
       "type": "price-feed",
@@ -7674,7 +7631,7 @@
       }
     },
     {
-      "id": 92,
+      "id": 91,
       "full_name": "UNI / USD",
       "description": "Uniswap",
       "type": "price-feed",
@@ -7805,7 +7762,7 @@
       }
     },
     {
-      "id": 93,
+      "id": 92,
       "full_name": "UNI / BNB",
       "description": "Uniswap",
       "type": "price-feed",
@@ -7845,7 +7802,7 @@
       }
     },
     {
-      "id": 94,
+      "id": 93,
       "full_name": "UNI / ETH",
       "description": "Uniswap",
       "type": "price-feed",
@@ -7898,7 +7855,7 @@
       }
     },
     {
-      "id": 95,
+      "id": 94,
       "full_name": "UNI / USDT",
       "description": "Uniswap",
       "type": "price-feed",
@@ -7983,7 +7940,7 @@
       }
     },
     {
-      "id": 96,
+      "id": 95,
       "full_name": "UNI / USDC",
       "description": "Uniswap",
       "type": "price-feed",
@@ -8048,50 +8005,7 @@
       }
     },
     {
-      "id": 97,
-      "full_name": "SUSDE / USD",
-      "description": "Ethena Staked USDE",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SUSDE",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "sUSDe"
-              ],
-              "id": [
-                29471
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SUSDE/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 98,
+      "id": 96,
       "full_name": "APT / USD",
       "description": "Aptos",
       "type": "price-feed",
@@ -8209,7 +8123,7 @@
       }
     },
     {
-      "id": 99,
+      "id": 97,
       "full_name": "APT / USDT",
       "description": "Aptos",
       "type": "price-feed",
@@ -8294,7 +8208,7 @@
       }
     },
     {
-      "id": 100,
+      "id": 98,
       "full_name": "APT / USDC",
       "description": "Aptos",
       "type": "price-feed",
@@ -8354,7 +8268,7 @@
       }
     },
     {
-      "id": 101,
+      "id": 99,
       "full_name": "NEAR / USD",
       "description": "NEAR Protocol",
       "type": "price-feed",
@@ -8477,7 +8391,7 @@
       }
     },
     {
-      "id": 102,
+      "id": 100,
       "full_name": "NEAR / USDT",
       "description": "NEAR Protocol",
       "type": "price-feed",
@@ -8567,7 +8481,7 @@
       }
     },
     {
-      "id": 103,
+      "id": 101,
       "full_name": "NEAR / USDC",
       "description": "NEAR Protocol",
       "type": "price-feed",
@@ -8637,7 +8551,7 @@
       }
     },
     {
-      "id": 104,
+      "id": 102,
       "full_name": "PEPE / USD",
       "description": "PEPE",
       "type": "price-feed",
@@ -8810,7 +8724,7 @@
       }
     },
     {
-      "id": 105,
+      "id": 103,
       "full_name": "PEPE / USDT",
       "description": "PEPE",
       "type": "price-feed",
@@ -8900,7 +8814,7 @@
       }
     },
     {
-      "id": 106,
+      "id": 104,
       "full_name": "PEPE / USDC",
       "description": "PEPE",
       "type": "price-feed",
@@ -8970,7 +8884,7 @@
       }
     },
     {
-      "id": 107,
+      "id": 105,
       "full_name": "ETC / USD",
       "description": "Ethereum",
       "type": "price-feed",
@@ -9088,7 +9002,7 @@
       }
     },
     {
-      "id": 108,
+      "id": 106,
       "full_name": "ETC / USDT",
       "description": "Ethereum",
       "type": "price-feed",
@@ -9173,7 +9087,7 @@
       }
     },
     {
-      "id": 109,
+      "id": 107,
       "full_name": "ETC / USDC",
       "description": "Ethereum",
       "type": "price-feed",
@@ -9223,7 +9137,7 @@
       }
     },
     {
-      "id": 110,
+      "id": 108,
       "full_name": "ONDO / USD",
       "description": "Ondo",
       "type": "price-feed",
@@ -9328,7 +9242,7 @@
       }
     },
     {
-      "id": 111,
+      "id": 109,
       "full_name": "ONDO / USDT",
       "description": "Ondo",
       "type": "price-feed",
@@ -9403,7 +9317,7 @@
       }
     },
     {
-      "id": 112,
+      "id": 110,
       "full_name": "ONDO / USDC",
       "description": "Ondo",
       "type": "price-feed",
@@ -9463,7 +9377,7 @@
       }
     },
     {
-      "id": 113,
+      "id": 111,
       "full_name": "ICP / USD",
       "description": "Internet Computer Protocol",
       "type": "price-feed",
@@ -9580,7 +9494,7 @@
       }
     },
     {
-      "id": 114,
+      "id": 112,
       "full_name": "ICP / USDT",
       "description": "Internet Computer Protocol",
       "type": "price-feed",
@@ -9665,7 +9579,7 @@
       }
     },
     {
-      "id": 115,
+      "id": 113,
       "full_name": "ICP / USDC",
       "description": "Internet Computer Protocol",
       "type": "price-feed",
@@ -9730,7 +9644,7 @@
       }
     },
     {
-      "id": 116,
+      "id": 114,
       "full_name": "AAVE / USD",
       "description": "Aave",
       "type": "price-feed",
@@ -9850,7 +9764,7 @@
       }
     },
     {
-      "id": 117,
+      "id": 115,
       "full_name": "AAVE / ETH",
       "description": "Aave",
       "type": "price-feed",
@@ -9903,7 +9817,7 @@
       }
     },
     {
-      "id": 118,
+      "id": 116,
       "full_name": "AAVE / USDT",
       "description": "Aave",
       "type": "price-feed",
@@ -9983,7 +9897,7 @@
       }
     },
     {
-      "id": 119,
+      "id": 117,
       "full_name": "AAVE / USDC",
       "description": "Aave",
       "type": "price-feed",
@@ -10038,7 +9952,7 @@
       }
     },
     {
-      "id": 120,
+      "id": 118,
       "full_name": "MNT / USD",
       "description": "Mantle",
       "type": "price-feed",
@@ -10119,7 +10033,7 @@
       }
     },
     {
-      "id": 121,
+      "id": 119,
       "full_name": "MNT / USDT",
       "description": "Mantle",
       "type": "price-feed",
@@ -10179,7 +10093,7 @@
       }
     },
     {
-      "id": 122,
+      "id": 120,
       "full_name": "MNT / USDC",
       "description": "Mantle",
       "type": "price-feed",
@@ -10219,50 +10133,7 @@
       }
     },
     {
-      "id": 123,
-      "full_name": "cbBTC / USD",
-      "description": "Coinbase Wrapped BTC",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "cbBTC",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "CBBTC"
-              ],
-              "id": [
-                32994
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "cbBTC/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 124,
+      "id": 121,
       "full_name": "TAO / USD",
       "description": "Bittensor",
       "type": "price-feed",
@@ -10354,7 +10225,7 @@
       }
     },
     {
-      "id": 125,
+      "id": 122,
       "full_name": "TAO / USDT",
       "description": "Bittensor",
       "type": "price-feed",
@@ -10414,7 +10285,7 @@
       }
     },
     {
-      "id": 126,
+      "id": 123,
       "full_name": "TAO / USDC",
       "description": "Bittensor",
       "type": "price-feed",
@@ -10464,7 +10335,7 @@
       }
     },
     {
-      "id": 127,
+      "id": 124,
       "full_name": "VET / USD",
       "description": "VeChain",
       "type": "price-feed",
@@ -10551,7 +10422,7 @@
       }
     },
     {
-      "id": 128,
+      "id": 125,
       "full_name": "VET / USDT",
       "description": "VeChain",
       "type": "price-feed",
@@ -10621,7 +10492,7 @@
       }
     },
     {
-      "id": 129,
+      "id": 126,
       "full_name": "FDUSD / USD",
       "description": "First Digital USD",
       "type": "price-feed",
@@ -10693,7 +10564,7 @@
       }
     },
     {
-      "id": 130,
+      "id": 127,
       "full_name": "FDUSD / USDT",
       "description": "First Digital USD",
       "type": "price-feed",
@@ -10753,7 +10624,7 @@
       }
     },
     {
-      "id": 131,
+      "id": 128,
       "full_name": "FDUSD / USDC",
       "description": "First Digital USD",
       "type": "price-feed",
@@ -10798,7 +10669,7 @@
       }
     },
     {
-      "id": 132,
+      "id": 129,
       "full_name": "TIA / USD",
       "description": "Celestia",
       "type": "price-feed",
@@ -10907,7 +10778,7 @@
       }
     },
     {
-      "id": 133,
+      "id": 130,
       "full_name": "TIA / USDT",
       "description": "Celestia",
       "type": "price-feed",
@@ -10982,7 +10853,7 @@
       }
     },
     {
-      "id": 134,
+      "id": 131,
       "full_name": "TIA / USDC",
       "description": "Celestia",
       "type": "price-feed",
@@ -11037,7 +10908,7 @@
       }
     },
     {
-      "id": 135,
+      "id": 132,
       "full_name": "POL / USD",
       "description": "POL",
       "type": "price-feed",
@@ -11150,7 +11021,7 @@
       }
     },
     {
-      "id": 136,
+      "id": 133,
       "full_name": "POL / ETH",
       "description": "Polygon",
       "type": "price-feed",
@@ -11195,7 +11066,7 @@
       }
     },
     {
-      "id": 137,
+      "id": 134,
       "full_name": "POL / USDT",
       "description": "POL",
       "type": "price-feed",
@@ -11275,7 +11146,7 @@
       }
     },
     {
-      "id": 138,
+      "id": 135,
       "full_name": "POL / USDC",
       "description": "POL",
       "type": "price-feed",
@@ -11325,7 +11196,7 @@
       }
     },
     {
-      "id": 139,
+      "id": 136,
       "full_name": "FIL / USD",
       "description": "Filecoin",
       "type": "price-feed",
@@ -11451,7 +11322,7 @@
       }
     },
     {
-      "id": 140,
+      "id": 137,
       "full_name": "FIL / ETH",
       "description": "Filecoin",
       "type": "price-feed",
@@ -11509,7 +11380,7 @@
       }
     },
     {
-      "id": 141,
+      "id": 138,
       "full_name": "FIL / USDT",
       "description": "Filecoin",
       "type": "price-feed",
@@ -11594,7 +11465,7 @@
       }
     },
     {
-      "id": 142,
+      "id": 139,
       "full_name": "FIL / USDC",
       "description": "Filecoin",
       "type": "price-feed",
@@ -11659,7 +11530,7 @@
       }
     },
     {
-      "id": 143,
+      "id": 140,
       "full_name": "LBTC / USD",
       "description": "LOMBARD STAKED BTC",
       "type": "price-feed",
@@ -11711,7 +11582,7 @@
       }
     },
     {
-      "id": 144,
+      "id": 141,
       "full_name": "LBTC / USDT",
       "description": "LOMBARD STAKED BTC",
       "type": "price-feed",
@@ -11751,7 +11622,7 @@
       }
     },
     {
-      "id": 145,
+      "id": 142,
       "full_name": "ALGO / USD",
       "description": "Algorand",
       "type": "price-feed",
@@ -11866,7 +11737,7 @@
       }
     },
     {
-      "id": 146,
+      "id": 143,
       "full_name": "ALGO / USDT",
       "description": "Algorand",
       "type": "price-feed",
@@ -11954,7 +11825,7 @@
       }
     },
     {
-      "id": 147,
+      "id": 144,
       "full_name": "ALGO / USDC",
       "description": "Algorand",
       "type": "price-feed",
@@ -12027,7 +11898,7 @@
       }
     },
     {
-      "id": 148,
+      "id": 145,
       "full_name": "RENDER / USD",
       "description": "Render",
       "type": "price-feed",
@@ -12141,7 +12012,7 @@
       }
     },
     {
-      "id": 149,
+      "id": 146,
       "full_name": "RENDER / USDT",
       "description": "Render",
       "type": "price-feed",
@@ -12226,7 +12097,7 @@
       }
     },
     {
-      "id": 150,
+      "id": 147,
       "full_name": "RENDER / USDC",
       "description": "Render",
       "type": "price-feed",
@@ -12276,7 +12147,7 @@
       }
     },
     {
-      "id": 151,
+      "id": 148,
       "full_name": "ATOM / USD",
       "description": "Cosmos",
       "type": "price-feed",
@@ -12399,7 +12270,7 @@
       }
     },
     {
-      "id": 152,
+      "id": 149,
       "full_name": "ATOM / USDT",
       "description": "Cosmos",
       "type": "price-feed",
@@ -12492,7 +12363,7 @@
       }
     },
     {
-      "id": 153,
+      "id": 150,
       "full_name": "ATOM / USDC",
       "description": "Cosmos",
       "type": "price-feed",
@@ -12565,7 +12436,7 @@
       }
     },
     {
-      "id": 154,
+      "id": 151,
       "full_name": "ARB / USD",
       "description": "Arbitrum",
       "type": "price-feed",
@@ -12690,7 +12561,7 @@
       }
     },
     {
-      "id": 155,
+      "id": 152,
       "full_name": "ARB / USDT",
       "description": "Arbitrum",
       "type": "price-feed",
@@ -12775,7 +12646,7 @@
       }
     },
     {
-      "id": 156,
+      "id": 153,
       "full_name": "ARB / USDC",
       "description": "Arbitrum",
       "type": "price-feed",
@@ -12835,7 +12706,7 @@
       }
     },
     {
-      "id": 157,
+      "id": 154,
       "full_name": "JUP / USD",
       "description": "Jupiter",
       "type": "price-feed",
@@ -12951,7 +12822,7 @@
       }
     },
     {
-      "id": 158,
+      "id": 155,
       "full_name": "JUP / USDT",
       "description": "Jupiter",
       "type": "price-feed",
@@ -13031,7 +12902,7 @@
       }
     },
     {
-      "id": 159,
+      "id": 156,
       "full_name": "JUP / USDC",
       "description": "Jupiter",
       "type": "price-feed",
@@ -13086,7 +12957,7 @@
       }
     },
     {
-      "id": 160,
+      "id": 157,
       "full_name": "OP / USD",
       "description": "Optimism",
       "type": "price-feed",
@@ -13205,7 +13076,7 @@
       }
     },
     {
-      "id": 161,
+      "id": 158,
       "full_name": "OP / USDT",
       "description": "Optimism",
       "type": "price-feed",
@@ -13290,7 +13161,7 @@
       }
     },
     {
-      "id": 162,
+      "id": 159,
       "full_name": "OP / USDC",
       "description": "Optimism",
       "type": "price-feed",
@@ -13360,7 +13231,7 @@
       }
     },
     {
-      "id": 163,
+      "id": 160,
       "full_name": "S / USD",
       "description": "Sonic",
       "type": "price-feed",
@@ -13452,7 +13323,7 @@
       }
     },
     {
-      "id": 164,
+      "id": 161,
       "full_name": "S / USDT",
       "description": "Sonic",
       "type": "price-feed",
@@ -13522,7 +13393,7 @@
       }
     },
     {
-      "id": 165,
+      "id": 162,
       "full_name": "S / USDC",
       "description": "Sonic",
       "type": "price-feed",
@@ -13572,7 +13443,7 @@
       }
     },
     {
-      "id": 166,
+      "id": 163,
       "full_name": "FET / USD",
       "description": "Fetch.ai",
       "type": "price-feed",
@@ -13693,7 +13564,7 @@
       }
     },
     {
-      "id": 167,
+      "id": 164,
       "full_name": "FET / USDT",
       "description": "Fetch.ai",
       "type": "price-feed",
@@ -13778,7 +13649,7 @@
       }
     },
     {
-      "id": 168,
+      "id": 165,
       "full_name": "FET / USDC",
       "description": "Fetch.ai",
       "type": "price-feed",
@@ -13838,7 +13709,7 @@
       }
     },
     {
-      "id": 169,
+      "id": 166,
       "full_name": "ENA / USD",
       "description": "Ethena",
       "type": "price-feed",
@@ -13937,7 +13808,7 @@
       }
     },
     {
-      "id": 170,
+      "id": 167,
       "full_name": "ENA / USDT",
       "description": "Ethena",
       "type": "price-feed",
@@ -14007,7 +13878,7 @@
       }
     },
     {
-      "id": 171,
+      "id": 168,
       "full_name": "ENA / USDC",
       "description": "Ethena",
       "type": "price-feed",
@@ -14062,50 +13933,7 @@
       }
     },
     {
-      "id": 172,
-      "full_name": "USD0 / USD",
-      "description": "Usual USD",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "USD0",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "USD0"
-              ],
-              "id": [
-                32307
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "USD0 / USD"
-        }
-      }
-    },
-    {
-      "id": 173,
+      "id": 169,
       "full_name": "MKR / USD",
       "description": "Maker",
       "type": "price-feed",
@@ -14222,7 +14050,7 @@
       }
     },
     {
-      "id": 174,
+      "id": 170,
       "full_name": "MKR / ETH",
       "description": "Maker",
       "type": "price-feed",
@@ -14262,7 +14090,7 @@
       }
     },
     {
-      "id": 175,
+      "id": 171,
       "full_name": "MKR / USDT",
       "description": "Maker",
       "type": "price-feed",
@@ -14342,7 +14170,7 @@
       }
     },
     {
-      "id": 176,
+      "id": 172,
       "full_name": "MKR / USDC",
       "description": "Maker",
       "type": "price-feed",
@@ -14382,7 +14210,7 @@
       }
     },
     {
-      "id": 177,
+      "id": 173,
       "full_name": "ZBU / USD",
       "description": "Zeebu",
       "type": "price-feed",
@@ -14442,7 +14270,7 @@
       }
     },
     {
-      "id": 178,
+      "id": 174,
       "full_name": "ZBU / USDT",
       "description": "Zeebu",
       "type": "price-feed",
@@ -14492,7 +14320,7 @@
       }
     },
     {
-      "id": 179,
+      "id": 175,
       "full_name": "STX / USD",
       "description": "Stacks",
       "type": "price-feed",
@@ -14599,7 +14427,7 @@
       }
     },
     {
-      "id": 180,
+      "id": 176,
       "full_name": "STX / USDT",
       "description": "Stacks",
       "type": "price-feed",
@@ -14679,7 +14507,7 @@
       }
     },
     {
-      "id": 181,
+      "id": 177,
       "full_name": "STX / USDC",
       "description": "Stacks",
       "type": "price-feed",
@@ -14734,7 +14562,7 @@
       }
     },
     {
-      "id": 182,
+      "id": 178,
       "full_name": "INJ / USD",
       "description": "Injective Protocol",
       "type": "price-feed",
@@ -14849,7 +14677,7 @@
       }
     },
     {
-      "id": 183,
+      "id": 179,
       "full_name": "INJ / USDT",
       "description": "Injective Protocol",
       "type": "price-feed",
@@ -14929,7 +14757,7 @@
       }
     },
     {
-      "id": 184,
+      "id": 180,
       "full_name": "INJ / USDC",
       "description": "Injective Protocol",
       "type": "price-feed",
@@ -14989,7 +14817,7 @@
       }
     },
     {
-      "id": 185,
+      "id": 181,
       "full_name": "IMX / USD",
       "description": "Immutable",
       "type": "price-feed",
@@ -15101,7 +14929,7 @@
       }
     },
     {
-      "id": 186,
+      "id": 182,
       "full_name": "IMX / USDT",
       "description": "Immutable",
       "type": "price-feed",
@@ -15186,7 +15014,7 @@
       }
     },
     {
-      "id": 187,
+      "id": 183,
       "full_name": "IMX / USDC",
       "description": "Immutable",
       "type": "price-feed",
@@ -15226,7 +15054,7 @@
       }
     },
     {
-      "id": 188,
+      "id": 184,
       "full_name": "QNT / USD",
       "description": "Quant",
       "type": "price-feed",
@@ -15332,7 +15160,7 @@
       }
     },
     {
-      "id": 189,
+      "id": 185,
       "full_name": "QNT / USDT",
       "description": "Quant",
       "type": "price-feed",
@@ -15412,7 +15240,7 @@
       }
     },
     {
-      "id": 190,
+      "id": 186,
       "full_name": "WLD / USD",
       "description": "Worldcoin",
       "type": "price-feed",
@@ -15513,7 +15341,7 @@
       }
     },
     {
-      "id": 191,
+      "id": 187,
       "full_name": "WLD / USDT",
       "description": "Worldcoin",
       "type": "price-feed",
@@ -15588,7 +15416,7 @@
       }
     },
     {
-      "id": 192,
+      "id": 188,
       "full_name": "WLD / USDC",
       "description": "Worldcoin",
       "type": "price-feed",
@@ -15648,7 +15476,7 @@
       }
     },
     {
-      "id": 193,
+      "id": 189,
       "full_name": "THETA / USD",
       "description": "Theta Token",
       "type": "price-feed",
@@ -15731,7 +15559,7 @@
       }
     },
     {
-      "id": 194,
+      "id": 190,
       "full_name": "THETA / USDT",
       "description": "Theta Token",
       "type": "price-feed",
@@ -15801,7 +15629,7 @@
       }
     },
     {
-      "id": 195,
+      "id": 191,
       "full_name": "THETA / USDC",
       "description": "Theta Token",
       "type": "price-feed",
@@ -15841,50 +15669,7 @@
       }
     },
     {
-      "id": 196,
-      "full_name": "USD0++ / USD",
-      "description": "",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "USD0++",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "",
-        "market_hours": null,
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "USD0++"
-              ],
-              "id": [
-                33981
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "USD0++ / USD"
-        }
-      }
-    },
-    {
-      "id": 197,
+      "id": 192,
       "full_name": "GRT / USD",
       "description": "The Graph",
       "type": "price-feed",
@@ -16000,7 +15785,7 @@
       }
     },
     {
-      "id": 198,
+      "id": 193,
       "full_name": "GRT / ETH",
       "description": "The Graph",
       "type": "price-feed",
@@ -16040,7 +15825,7 @@
       }
     },
     {
-      "id": 199,
+      "id": 194,
       "full_name": "GRT / USDT",
       "description": "The Graph",
       "type": "price-feed",
@@ -16120,7 +15905,7 @@
       }
     },
     {
-      "id": 200,
+      "id": 195,
       "full_name": "GRT / USDC",
       "description": "The Graph",
       "type": "price-feed",
@@ -16160,7 +15945,7 @@
       }
     },
     {
-      "id": 201,
+      "id": 196,
       "full_name": "SEI / USD",
       "description": "Sei",
       "type": "price-feed",
@@ -16263,7 +16048,7 @@
       }
     },
     {
-      "id": 202,
+      "id": 197,
       "full_name": "SEI / USDT",
       "description": "Sei",
       "type": "price-feed",
@@ -16333,7 +16118,7 @@
       }
     },
     {
-      "id": 203,
+      "id": 198,
       "full_name": "SEI / USDC",
       "description": "Sei",
       "type": "price-feed",
@@ -16383,7 +16168,7 @@
       }
     },
     {
-      "id": 204,
+      "id": 199,
       "full_name": "BONK / USD",
       "description": "Bonk",
       "type": "price-feed",
@@ -16513,7 +16298,7 @@
       }
     },
     {
-      "id": 205,
+      "id": 200,
       "full_name": "BONK / USDT",
       "description": "Bonk",
       "type": "price-feed",
@@ -16598,7 +16383,7 @@
       }
     },
     {
-      "id": 206,
+      "id": 201,
       "full_name": "BONK / USDC",
       "description": "Bonk",
       "type": "price-feed",
@@ -16653,7 +16438,7 @@
       }
     },
     {
-      "id": 207,
+      "id": 202,
       "full_name": "LDO / USD",
       "description": "Lido DAO",
       "type": "price-feed",
@@ -16773,7 +16558,7 @@
       }
     },
     {
-      "id": 208,
+      "id": 203,
       "full_name": "LDO / USDT",
       "description": "Lido DAO",
       "type": "price-feed",
@@ -16853,7 +16638,7 @@
       }
     },
     {
-      "id": 209,
+      "id": 204,
       "full_name": "LDO / USDC",
       "description": "Lido DAO",
       "type": "price-feed",
@@ -16913,7 +16698,7 @@
       }
     },
     {
-      "id": 210,
+      "id": 205,
       "full_name": "EOS / USD",
       "description": "EOS",
       "type": "price-feed",
@@ -17033,7 +16818,7 @@
       }
     },
     {
-      "id": 211,
+      "id": 206,
       "full_name": "EOS / BNB",
       "description": "EOS",
       "type": "price-feed",
@@ -17073,7 +16858,7 @@
       }
     },
     {
-      "id": 212,
+      "id": 207,
       "full_name": "EOS / USDT",
       "description": "EOS",
       "type": "price-feed",
@@ -17161,7 +16946,7 @@
       }
     },
     {
-      "id": 213,
+      "id": 208,
       "full_name": "EOS / USDC",
       "description": "EOS",
       "type": "price-feed",
@@ -17234,7 +17019,7 @@
       }
     },
     {
-      "id": 214,
+      "id": 209,
       "full_name": "GALA / USD",
       "description": "Gala",
       "type": "price-feed",
@@ -17348,7 +17133,7 @@
       }
     },
     {
-      "id": 215,
+      "id": 210,
       "full_name": "GALA / USDT",
       "description": "Gala",
       "type": "price-feed",
@@ -17428,7 +17213,7 @@
       }
     },
     {
-      "id": 216,
+      "id": 211,
       "full_name": "GALA / USDC",
       "description": "Gala",
       "type": "price-feed",
@@ -17478,7 +17263,7 @@
       }
     },
     {
-      "id": 217,
+      "id": 212,
       "full_name": "PYUSD / USD",
       "description": "PayPal USD",
       "type": "price-feed",
@@ -17567,7 +17352,7 @@
       }
     },
     {
-      "id": 218,
+      "id": 213,
       "full_name": "PYUSD / USDT",
       "description": "PayPal USD",
       "type": "price-feed",
@@ -17632,7 +17417,7 @@
       }
     },
     {
-      "id": 219,
+      "id": 214,
       "full_name": "XTZ / BNB",
       "description": "Tezos",
       "type": "price-feed",
@@ -17672,7 +17457,7 @@
       }
     },
     {
-      "id": 220,
+      "id": 215,
       "full_name": "XTZ / USD",
       "description": "Tezos",
       "type": "price-feed",
@@ -17798,7 +17583,7 @@
       }
     },
     {
-      "id": 221,
+      "id": 216,
       "full_name": "XTZ / USDT",
       "description": "Tezos",
       "type": "price-feed",
@@ -17891,7 +17676,7 @@
       }
     },
     {
-      "id": 222,
+      "id": 217,
       "full_name": "XTZ / USDC",
       "description": "Tezos",
       "type": "price-feed",
@@ -17944,7 +17729,7 @@
       }
     },
     {
-      "id": 223,
+      "id": 218,
       "full_name": "SAND / USD",
       "description": "The Sandbox",
       "type": "price-feed",
@@ -18063,7 +17848,7 @@
       }
     },
     {
-      "id": 224,
+      "id": 219,
       "full_name": "SAND / USDT",
       "description": "The Sandbox",
       "type": "price-feed",
@@ -18148,7 +17933,7 @@
       }
     },
     {
-      "id": 225,
+      "id": 220,
       "full_name": "SAND / USDC",
       "description": "The Sandbox",
       "type": "price-feed",
@@ -18198,7 +17983,7 @@
       }
     },
     {
-      "id": 226,
+      "id": 221,
       "full_name": "BERA / USD",
       "description": "Berachain",
       "type": "price-feed",
@@ -18308,7 +18093,7 @@
       }
     },
     {
-      "id": 227,
+      "id": 222,
       "full_name": "BERA / USDT",
       "description": "Berachain",
       "type": "price-feed",
@@ -18391,7 +18176,7 @@
       }
     },
     {
-      "id": 228,
+      "id": 223,
       "full_name": "BERA / USDC",
       "description": "Berachain",
       "type": "price-feed",
@@ -18439,7 +18224,7 @@
       }
     },
     {
-      "id": 229,
+      "id": 224,
       "full_name": "JTO / USD",
       "description": "Jito",
       "type": "price-feed",
@@ -18546,7 +18331,7 @@
       }
     },
     {
-      "id": 230,
+      "id": 225,
       "full_name": "JTO / USDT",
       "description": "Jito",
       "type": "price-feed",
@@ -18621,7 +18406,7 @@
       }
     },
     {
-      "id": 231,
+      "id": 226,
       "full_name": "JTO / USDC",
       "description": "Jito",
       "type": "price-feed",
@@ -18671,7 +18456,7 @@
       }
     },
     {
-      "id": 232,
+      "id": 227,
       "full_name": "FLOW / USD",
       "description": "FLOW (dapper labs)",
       "type": "price-feed",
@@ -18778,7 +18563,7 @@
       }
     },
     {
-      "id": 233,
+      "id": 228,
       "full_name": "FLOW / USDT",
       "description": "FLOW (dapper labs)",
       "type": "price-feed",
@@ -18863,7 +18648,7 @@
       }
     },
     {
-      "id": 234,
+      "id": 229,
       "full_name": "FLOW / USDC",
       "description": "FLOW (dapper labs)",
       "type": "price-feed",
@@ -18903,7 +18688,7 @@
       }
     },
     {
-      "id": 235,
+      "id": 230,
       "full_name": "FLOKI / USD",
       "description": "Floki Inu",
       "type": "price-feed",
@@ -19030,7 +18815,7 @@
       }
     },
     {
-      "id": 236,
+      "id": 231,
       "full_name": "FLOKI / USDT",
       "description": "Floki Inu",
       "type": "price-feed",
@@ -19110,7 +18895,7 @@
       }
     },
     {
-      "id": 237,
+      "id": 232,
       "full_name": "FLOKI / USDC",
       "description": "Floki Inu",
       "type": "price-feed",
@@ -19175,50 +18960,7 @@
       }
     },
     {
-      "id": 238,
-      "full_name": "ezETH / USD",
-      "description": "Renzo Restaked ETH",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ezETH",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "EZETH"
-              ],
-              "id": [
-                29520
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ezETH/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 239,
+      "id": 233,
       "full_name": "ENS / USD",
       "description": "Ethereum Name Service",
       "type": "price-feed",
@@ -19334,7 +19076,7 @@
       }
     },
     {
-      "id": 240,
+      "id": 234,
       "full_name": "ENS / USDT",
       "description": "Ethereum Name Service",
       "type": "price-feed",
@@ -19419,7 +19161,7 @@
       }
     },
     {
-      "id": 241,
+      "id": 235,
       "full_name": "ENS / USDC",
       "description": "Ethereum Name Service",
       "type": "price-feed",
@@ -19474,7 +19216,7 @@
       }
     },
     {
-      "id": 242,
+      "id": 236,
       "full_name": "MANA / USD",
       "description": "Decentraland",
       "type": "price-feed",
@@ -19596,7 +19338,7 @@
       }
     },
     {
-      "id": 243,
+      "id": 237,
       "full_name": "MANA / ETH",
       "description": "Decentraland",
       "type": "price-feed",
@@ -19646,7 +19388,7 @@
       }
     },
     {
-      "id": 244,
+      "id": 238,
       "full_name": "MANA / USDT",
       "description": "Decentraland",
       "type": "price-feed",
@@ -19739,7 +19481,7 @@
       }
     },
     {
-      "id": 245,
+      "id": 239,
       "full_name": "MANA / USDC",
       "description": "Decentraland",
       "type": "price-feed",
@@ -19797,7 +19539,7 @@
       }
     },
     {
-      "id": 246,
+      "id": 240,
       "full_name": "CRV / USD",
       "description": "Curve DAO",
       "type": "price-feed",
@@ -19916,7 +19658,7 @@
       }
     },
     {
-      "id": 247,
+      "id": 241,
       "full_name": "CRV / ETH",
       "description": "Curve DAO",
       "type": "price-feed",
@@ -19966,7 +19708,7 @@
       }
     },
     {
-      "id": 248,
+      "id": 242,
       "full_name": "CRV / USDT",
       "description": "Curve DAO",
       "type": "price-feed",
@@ -20046,7 +19788,7 @@
       }
     },
     {
-      "id": 249,
+      "id": 243,
       "full_name": "CRV / USDC",
       "description": "Curve DAO",
       "type": "price-feed",
@@ -20096,7 +19838,7 @@
       }
     },
     {
-      "id": 250,
+      "id": 244,
       "full_name": "PYTH / USD",
       "description": "Pyth Network",
       "type": "price-feed",
@@ -20203,7 +19945,7 @@
       }
     },
     {
-      "id": 251,
+      "id": 245,
       "full_name": "PYTH / USDT",
       "description": "Pyth Network",
       "type": "price-feed",
@@ -20278,7 +20020,7 @@
       }
     },
     {
-      "id": 252,
+      "id": 246,
       "full_name": "PYTH / USDC",
       "description": "Pyth Network",
       "type": "price-feed",
@@ -20323,7 +20065,7 @@
       }
     },
     {
-      "id": 253,
+      "id": 247,
       "full_name": "EGLD / USD",
       "description": "MultiversX",
       "type": "price-feed",
@@ -20440,7 +20182,7 @@
       }
     },
     {
-      "id": 254,
+      "id": 248,
       "full_name": "EGLD / USDT",
       "description": "MultiversX",
       "type": "price-feed",
@@ -20525,7 +20267,7 @@
       }
     },
     {
-      "id": 255,
+      "id": 249,
       "full_name": "EGLD / USDC",
       "description": "MultiversX",
       "type": "price-feed",
@@ -20570,7 +20312,7 @@
       }
     },
     {
-      "id": 256,
+      "id": 250,
       "full_name": "RON / USD",
       "description": "Ronin",
       "type": "price-feed",
@@ -20636,7 +20378,7 @@
       }
     },
     {
-      "id": 257,
+      "id": 251,
       "full_name": "RON / USDT",
       "description": "Ronin",
       "type": "price-feed",
@@ -20691,7 +20433,7 @@
       }
     },
     {
-      "id": 258,
+      "id": 252,
       "full_name": "RON / USDC",
       "description": "Ronin",
       "type": "price-feed",
@@ -20731,7 +20473,7 @@
       }
     },
     {
-      "id": 259,
+      "id": 253,
       "full_name": "AXS / USD",
       "description": "Axie Infinity",
       "type": "price-feed",
@@ -20843,7 +20585,7 @@
       }
     },
     {
-      "id": 260,
+      "id": 254,
       "full_name": "AXS / USDT",
       "description": "Axie Infinity",
       "type": "price-feed",
@@ -20928,7 +20670,7 @@
       }
     },
     {
-      "id": 261,
+      "id": 255,
       "full_name": "AXS / USDC",
       "description": "Axie Infinity",
       "type": "price-feed",
@@ -20968,7 +20710,7 @@
       }
     },
     {
-      "id": 262,
+      "id": 256,
       "full_name": "TUSD / USD",
       "description": "True USD",
       "type": "price-feed",
@@ -21066,7 +20808,7 @@
       }
     },
     {
-      "id": 263,
+      "id": 257,
       "full_name": "TUSD / ETH",
       "description": "TrueUSD",
       "type": "price-feed",
@@ -21106,7 +20848,7 @@
       }
     },
     {
-      "id": 264,
+      "id": 258,
       "full_name": "TUSD / USDT",
       "description": "True USD",
       "type": "price-feed",
@@ -21186,7 +20928,7 @@
       }
     },
     {
-      "id": 265,
+      "id": 259,
       "full_name": "ZEC / USD",
       "description": "ZCash",
       "type": "price-feed",
@@ -21276,7 +21018,7 @@
       }
     },
     {
-      "id": 266,
+      "id": 260,
       "full_name": "ZEC / USDT",
       "description": "ZCash",
       "type": "price-feed",
@@ -21331,7 +21073,7 @@
       }
     },
     {
-      "id": 267,
+      "id": 261,
       "full_name": "ZEC / USDC",
       "description": "ZCash",
       "type": "price-feed",
@@ -21376,7 +21118,7 @@
       }
     },
     {
-      "id": 268,
+      "id": 262,
       "full_name": "KAVA / USD",
       "description": "Kava",
       "type": "price-feed",
@@ -21481,7 +21223,7 @@
       }
     },
     {
-      "id": 269,
+      "id": 263,
       "full_name": "KAVA / USDT",
       "description": "Kava",
       "type": "price-feed",
@@ -21556,7 +21298,7 @@
       }
     },
     {
-      "id": 270,
+      "id": 264,
       "full_name": "DYDX / USD",
       "description": "dYdX",
       "type": "price-feed",
@@ -21654,7 +21396,7 @@
       }
     },
     {
-      "id": 271,
+      "id": 265,
       "full_name": "DYDX / USDT",
       "description": "dYdX",
       "type": "price-feed",
@@ -21729,7 +21471,7 @@
       }
     },
     {
-      "id": 272,
+      "id": 266,
       "full_name": "DYDX / USDC",
       "description": "dYdX",
       "type": "price-feed",
@@ -21779,7 +21521,7 @@
       }
     },
     {
-      "id": 273,
+      "id": 267,
       "full_name": "XCN / USD",
       "description": "Chain",
       "type": "price-feed",
@@ -21860,7 +21602,7 @@
       }
     },
     {
-      "id": 274,
+      "id": 268,
       "full_name": "XCN / USDT",
       "description": "Chain",
       "type": "price-feed",
@@ -21920,7 +21662,7 @@
       }
     },
     {
-      "id": 275,
+      "id": 269,
       "full_name": "WIF / USD",
       "description": "dogwifhat",
       "type": "price-feed",
@@ -22049,7 +21791,7 @@
       }
     },
     {
-      "id": 276,
+      "id": 270,
       "full_name": "WIF / USDT",
       "description": "dogwifhat",
       "type": "price-feed",
@@ -22129,7 +21871,7 @@
       }
     },
     {
-      "id": 277,
+      "id": 271,
       "full_name": "WIF / USDC",
       "description": "dogwifhat",
       "type": "price-feed",
@@ -22184,7 +21926,7 @@
       }
     },
     {
-      "id": 278,
+      "id": 272,
       "full_name": "STRK / USD",
       "description": "Starknet",
       "type": "price-feed",
@@ -22295,7 +22037,7 @@
       }
     },
     {
-      "id": 279,
+      "id": 273,
       "full_name": "STRK / USDT",
       "description": "Starknet",
       "type": "price-feed",
@@ -22370,7 +22112,7 @@
       }
     },
     {
-      "id": 280,
+      "id": 274,
       "full_name": "STRK / USDC",
       "description": "Starknet",
       "type": "price-feed",
@@ -22425,7 +22167,7 @@
       }
     },
     {
-      "id": 281,
+      "id": 275,
       "full_name": "CAKE / USD",
       "description": "PancakeSwap",
       "type": "price-feed",
@@ -22506,7 +22248,7 @@
       }
     },
     {
-      "id": 282,
+      "id": 276,
       "full_name": "CAKE / BNB",
       "description": "PancakeSwap",
       "type": "price-feed",
@@ -22546,7 +22288,7 @@
       }
     },
     {
-      "id": 283,
+      "id": 277,
       "full_name": "CAKE / USDT",
       "description": "PancakeSwap",
       "type": "price-feed",
@@ -22616,7 +22358,7 @@
       }
     },
     {
-      "id": 284,
+      "id": 278,
       "full_name": "CAKE / USDC",
       "description": "PancakeSwap",
       "type": "price-feed",
@@ -22656,7 +22398,7 @@
       }
     },
     {
-      "id": 285,
+      "id": 279,
       "full_name": "MATIC / USD",
       "description": "Polygon (MATIC)",
       "type": "price-feed",
@@ -22740,7 +22482,7 @@
       }
     },
     {
-      "id": 286,
+      "id": 280,
       "full_name": "MATIC / USDT",
       "description": "Polygon (MATIC)",
       "type": "price-feed",
@@ -22798,7 +22540,7 @@
       }
     },
     {
-      "id": 287,
+      "id": 281,
       "full_name": "MATIC / USDC",
       "description": "Polygon (MATIC)",
       "type": "price-feed",
@@ -22846,7 +22588,7 @@
       }
     },
     {
-      "id": 288,
+      "id": 282,
       "full_name": "AERO / USD",
       "description": "Aerodrome Finance",
       "type": "price-feed",
@@ -22936,7 +22678,7 @@
       }
     },
     {
-      "id": 289,
+      "id": 283,
       "full_name": "AERO / USDT",
       "description": "Aerodrome Finance",
       "type": "price-feed",
@@ -22996,7 +22738,7 @@
       }
     },
     {
-      "id": 290,
+      "id": 284,
       "full_name": "CHZ / USD",
       "description": "Chiliz",
       "type": "price-feed",
@@ -23115,7 +22857,7 @@
       }
     },
     {
-      "id": 291,
+      "id": 285,
       "full_name": "CHZ / USDT",
       "description": "Chiliz",
       "type": "price-feed",
@@ -23200,7 +22942,7 @@
       }
     },
     {
-      "id": 292,
+      "id": 286,
       "full_name": "CHZ / USDC",
       "description": "Chiliz",
       "type": "price-feed",
@@ -23250,7 +22992,7 @@
       }
     },
     {
-      "id": 293,
+      "id": 287,
       "full_name": "FRAX / USD",
       "description": "FRAX",
       "type": "price-feed",
@@ -23300,7 +23042,7 @@
       }
     },
     {
-      "id": 294,
+      "id": 288,
       "full_name": "FRAX / USDT",
       "description": "FRAX",
       "type": "price-feed",
@@ -23340,7 +23082,7 @@
       }
     },
     {
-      "id": 295,
+      "id": 289,
       "full_name": "CORE / USD",
       "description": "",
       "type": "price-feed",
@@ -23413,7 +23155,7 @@
       }
     },
     {
-      "id": 296,
+      "id": 290,
       "full_name": "CORE / USDT",
       "description": "",
       "type": "price-feed",
@@ -23473,7 +23215,7 @@
       }
     },
     {
-      "id": 297,
+      "id": 291,
       "full_name": "CORE / USDC",
       "description": "",
       "type": "price-feed",
@@ -23513,7 +23255,7 @@
       }
     },
     {
-      "id": 298,
+      "id": 292,
       "full_name": "RUNE / USD",
       "description": "THORChain",
       "type": "price-feed",
@@ -23608,7 +23350,7 @@
       }
     },
     {
-      "id": 299,
+      "id": 293,
       "full_name": "RUNE / USDT",
       "description": "THORChain",
       "type": "price-feed",
@@ -23678,7 +23420,7 @@
       }
     },
     {
-      "id": 300,
+      "id": 294,
       "full_name": "RUNE / USDC",
       "description": "THORChain",
       "type": "price-feed",
@@ -23728,7 +23470,7 @@
       }
     },
     {
-      "id": 301,
+      "id": 295,
       "full_name": "AR / USD",
       "description": "Arweave",
       "type": "price-feed",
@@ -23819,7 +23561,7 @@
       }
     },
     {
-      "id": 302,
+      "id": 296,
       "full_name": "AR / USDT",
       "description": "Arweave",
       "type": "price-feed",
@@ -23894,7 +23636,7 @@
       }
     },
     {
-      "id": 303,
+      "id": 297,
       "full_name": "AR / USDC",
       "description": "Arweave",
       "type": "price-feed",
@@ -23949,7 +23691,7 @@
       }
     },
     {
-      "id": 304,
+      "id": 298,
       "full_name": "CFX / USD",
       "description": "Conflux",
       "type": "price-feed",
@@ -24032,7 +23774,7 @@
       }
     },
     {
-      "id": 305,
+      "id": 299,
       "full_name": "CFX / USDT",
       "description": "Conflux",
       "type": "price-feed",
@@ -24097,7 +23839,7 @@
       }
     },
     {
-      "id": 306,
+      "id": 300,
       "full_name": "CFX / USDC",
       "description": "Conflux",
       "type": "price-feed",
@@ -24147,7 +23889,7 @@
       }
     },
     {
-      "id": 307,
+      "id": 301,
       "full_name": "FTT / ETH",
       "description": "FTX Token",
       "type": "price-feed",
@@ -24192,7 +23934,7 @@
       }
     },
     {
-      "id": 308,
+      "id": 302,
       "full_name": "FTT / USD",
       "description": "FTX Token",
       "type": "price-feed",
@@ -24268,7 +24010,7 @@
       }
     },
     {
-      "id": 309,
+      "id": 303,
       "full_name": "FTT / USDT",
       "description": "FTX Token",
       "type": "price-feed",
@@ -24333,7 +24075,7 @@
       }
     },
     {
-      "id": 310,
+      "id": 304,
       "full_name": "FTT / USDC",
       "description": "FTX Token",
       "type": "price-feed",
@@ -24373,7 +24115,7 @@
       }
     },
     {
-      "id": 311,
+      "id": 305,
       "full_name": "APE / USD",
       "description": "ApeCoin",
       "type": "price-feed",
@@ -24502,7 +24244,7 @@
       }
     },
     {
-      "id": 312,
+      "id": 306,
       "full_name": "APE / ETH",
       "description": "APECoin",
       "type": "price-feed",
@@ -24542,7 +24284,7 @@
       }
     },
     {
-      "id": 313,
+      "id": 307,
       "full_name": "APE / USDT",
       "description": "ApeCoin",
       "type": "price-feed",
@@ -24635,7 +24377,7 @@
       }
     },
     {
-      "id": 314,
+      "id": 308,
       "full_name": "APE / USDC",
       "description": "ApeCoin",
       "type": "price-feed",
@@ -24703,7 +24445,7 @@
       }
     },
     {
-      "id": 315,
+      "id": 309,
       "full_name": "VIRTUAL / USD",
       "description": "Virtuals Protocol",
       "type": "price-feed",
@@ -24798,7 +24540,7 @@
       }
     },
     {
-      "id": 316,
+      "id": 310,
       "full_name": "VIRTUAL / USDT",
       "description": "Virtuals Protocol",
       "type": "price-feed",
@@ -24876,7 +24618,7 @@
       }
     },
     {
-      "id": 317,
+      "id": 311,
       "full_name": "VIRTUAL / USDC",
       "description": "Virtuals Protocol",
       "type": "price-feed",
@@ -24924,7 +24666,7 @@
       }
     },
     {
-      "id": 318,
+      "id": 312,
       "full_name": "PENGU / USD",
       "description": "Pudgy Penguins",
       "type": "price-feed",
@@ -25036,7 +24778,7 @@
       }
     },
     {
-      "id": 319,
+      "id": 313,
       "full_name": "PENGU / USDT",
       "description": "Pudgy Penguins",
       "type": "price-feed",
@@ -25124,7 +24866,7 @@
       }
     },
     {
-      "id": 320,
+      "id": 314,
       "full_name": "PENGU / USDC",
       "description": "Pudgy Penguins",
       "type": "price-feed",
@@ -25177,7 +24919,7 @@
       }
     },
     {
-      "id": 321,
+      "id": 315,
       "full_name": "COMP / USD",
       "description": "Compound",
       "type": "price-feed",
@@ -25294,7 +25036,7 @@
       }
     },
     {
-      "id": 322,
+      "id": 316,
       "full_name": "COMP / USDT",
       "description": "Compound",
       "type": "price-feed",
@@ -25374,7 +25116,7 @@
       }
     },
     {
-      "id": 323,
+      "id": 317,
       "full_name": "COMP / USDC",
       "description": "Compound",
       "type": "price-feed",
@@ -25414,7 +25156,7 @@
       }
     },
     {
-      "id": 324,
+      "id": 318,
       "full_name": "AXL / USD",
       "description": "Axelar",
       "type": "price-feed",
@@ -25488,7 +25230,7 @@
       }
     },
     {
-      "id": 325,
+      "id": 319,
       "full_name": "AXL / USDT",
       "description": "Axelar",
       "type": "price-feed",
@@ -25543,7 +25285,7 @@
       }
     },
     {
-      "id": 326,
+      "id": 320,
       "full_name": "PENDLE / USD",
       "description": "Pendle",
       "type": "price-feed",
@@ -25641,7 +25383,7 @@
       }
     },
     {
-      "id": 327,
+      "id": 321,
       "full_name": "PENDLE / USDT",
       "description": "Pendle",
       "type": "price-feed",
@@ -25716,7 +25458,7 @@
       }
     },
     {
-      "id": 328,
+      "id": 322,
       "full_name": "PENDLE / USDC",
       "description": "Pendle",
       "type": "price-feed",
@@ -25766,7 +25508,7 @@
       }
     },
     {
-      "id": 329,
+      "id": 323,
       "full_name": "SPX / USD",
       "description": "SPX6900",
       "type": "price-feed",
@@ -25845,7 +25587,7 @@
       }
     },
     {
-      "id": 330,
+      "id": 324,
       "full_name": "SPX / USDT",
       "description": "SPX6900",
       "type": "price-feed",
@@ -25900,7 +25642,7 @@
       }
     },
     {
-      "id": 331,
+      "id": 325,
       "full_name": "GNO / USD",
       "description": "Gnosis",
       "type": "price-feed",
@@ -25984,7 +25726,7 @@
       }
     },
     {
-      "id": 332,
+      "id": 326,
       "full_name": "GNO / USDT",
       "description": "Gnosis",
       "type": "price-feed",
@@ -26044,7 +25786,7 @@
       }
     },
     {
-      "id": 333,
+      "id": 327,
       "full_name": "MORPHO / USD",
       "description": "Morpho",
       "type": "price-feed",
@@ -26139,7 +25881,7 @@
       }
     },
     {
-      "id": 334,
+      "id": 328,
       "full_name": "MORPHO / USDT",
       "description": "Morpho",
       "type": "price-feed",
@@ -26204,7 +25946,7 @@
       }
     },
     {
-      "id": 335,
+      "id": 329,
       "full_name": "MORPHO / USDC",
       "description": "Morpho",
       "type": "price-feed",
@@ -26244,7 +25986,7 @@
       }
     },
     {
-      "id": 336,
+      "id": 330,
       "full_name": "RSR / USD",
       "description": "Reserve Rights",
       "type": "price-feed",
@@ -26335,7 +26077,7 @@
       }
     },
     {
-      "id": 337,
+      "id": 331,
       "full_name": "RSR / USDT",
       "description": "Reserve Rights",
       "type": "price-feed",
@@ -26405,7 +26147,7 @@
       }
     },
     {
-      "id": 338,
+      "id": 332,
       "full_name": "RSR / USDC",
       "description": "Reserve Rights",
       "type": "price-feed",
@@ -26450,7 +26192,7 @@
       }
     },
     {
-      "id": 339,
+      "id": 333,
       "full_name": "BRETT / USD",
       "description": "Brett",
       "type": "price-feed",
@@ -26533,7 +26275,7 @@
       }
     },
     {
-      "id": 340,
+      "id": 334,
       "full_name": "BRETT / USDT",
       "description": "Brett",
       "type": "price-feed",
@@ -26593,7 +26335,7 @@
       }
     },
     {
-      "id": 341,
+      "id": 335,
       "full_name": "BRETT / USDC",
       "description": "Brett",
       "type": "price-feed",
@@ -26633,7 +26375,7 @@
       }
     },
     {
-      "id": 342,
+      "id": 336,
       "full_name": "BEAM / USD",
       "description": "Beam",
       "type": "price-feed",
@@ -26718,7 +26460,7 @@
       }
     },
     {
-      "id": 343,
+      "id": 337,
       "full_name": "BEAM / USDT",
       "description": "Beam",
       "type": "price-feed",
@@ -26783,7 +26525,7 @@
       }
     },
     {
-      "id": 344,
+      "id": 338,
       "full_name": "deUSD / USD",
       "description": "",
       "type": "price-feed",
@@ -26833,7 +26575,7 @@
       }
     },
     {
-      "id": 345,
+      "id": 339,
       "full_name": "deUSD / USDT",
       "description": "",
       "type": "price-feed",
@@ -26873,7 +26615,7 @@
       }
     },
     {
-      "id": 346,
+      "id": 340,
       "full_name": "SNX / USD",
       "description": "Synthetix Network",
       "type": "price-feed",
@@ -26979,7 +26721,7 @@
       }
     },
     {
-      "id": 347,
+      "id": 341,
       "full_name": "SNX / ETH",
       "description": "Synthetix Network",
       "type": "price-feed",
@@ -27029,7 +26771,7 @@
       }
     },
     {
-      "id": 348,
+      "id": 342,
       "full_name": "SNX / USDT",
       "description": "Synthetix Network",
       "type": "price-feed",
@@ -27109,7 +26851,7 @@
       }
     },
     {
-      "id": 349,
+      "id": 343,
       "full_name": "SNX / USDC",
       "description": "Synthetix Network",
       "type": "price-feed",
@@ -27149,7 +26891,7 @@
       }
     },
     {
-      "id": 350,
+      "id": 344,
       "full_name": "FARTCOIN / USD",
       "description": "Fartcoin",
       "type": "price-feed",
@@ -27235,7 +26977,7 @@
       }
     },
     {
-      "id": 351,
+      "id": 345,
       "full_name": "FARTCOIN / USDT",
       "description": "Fartcoin",
       "type": "price-feed",
@@ -27298,7 +27040,7 @@
       }
     },
     {
-      "id": 352,
+      "id": 346,
       "full_name": "FARTCOIN / USDC",
       "description": "Fartcoin",
       "type": "price-feed",
@@ -27346,7 +27088,7 @@
       }
     },
     {
-      "id": 353,
+      "id": 347,
       "full_name": "1INCH / USD",
       "description": "1inch",
       "type": "price-feed",
@@ -27452,7 +27194,7 @@
       }
     },
     {
-      "id": 354,
+      "id": 348,
       "full_name": "1INCH / USDT",
       "description": "1inch",
       "type": "price-feed",
@@ -27532,7 +27274,7 @@
       }
     },
     {
-      "id": 355,
+      "id": 349,
       "full_name": "1INCH / USDC",
       "description": "1inch",
       "type": "price-feed",
@@ -27572,7 +27314,7 @@
       }
     },
     {
-      "id": 356,
+      "id": 350,
       "full_name": "DASH / USD",
       "description": "Dash",
       "type": "price-feed",
@@ -27650,7 +27392,7 @@
       }
     },
     {
-      "id": 357,
+      "id": 351,
       "full_name": "DASH / USDT",
       "description": "Dash",
       "type": "price-feed",
@@ -27705,7 +27447,7 @@
       }
     },
     {
-      "id": 358,
+      "id": 352,
       "full_name": "EIGEN / USD",
       "description": "Eigenlayer",
       "type": "price-feed",
@@ -27816,7 +27558,7 @@
       }
     },
     {
-      "id": 359,
+      "id": 353,
       "full_name": "EIGEN / USDT",
       "description": "Eigenlayer",
       "type": "price-feed",
@@ -27891,7 +27633,7 @@
       }
     },
     {
-      "id": 360,
+      "id": 354,
       "full_name": "EIGEN / USDC",
       "description": "Eigenlayer",
       "type": "price-feed",
@@ -27936,7 +27678,7 @@
       }
     },
     {
-      "id": 361,
+      "id": 355,
       "full_name": "ZK / USD",
       "description": "ZKsync",
       "type": "price-feed",
@@ -28039,7 +27781,7 @@
       }
     },
     {
-      "id": 362,
+      "id": 356,
       "full_name": "ZK / USDT",
       "description": "ZKsync",
       "type": "price-feed",
@@ -28114,7 +27856,7 @@
       }
     },
     {
-      "id": 363,
+      "id": 357,
       "full_name": "ZK / USDC",
       "description": "ZKsync",
       "type": "price-feed",
@@ -28164,7 +27906,7 @@
       }
     },
     {
-      "id": 364,
+      "id": 358,
       "full_name": "KSM / USD",
       "description": "Kusama",
       "type": "price-feed",
@@ -28271,7 +28013,7 @@
       }
     },
     {
-      "id": 365,
+      "id": 359,
       "full_name": "KSM / USDT",
       "description": "Kusama",
       "type": "price-feed",
@@ -28356,7 +28098,7 @@
       }
     },
     {
-      "id": 366,
+      "id": 360,
       "full_name": "KSM / USDC",
       "description": "Kusama",
       "type": "price-feed",
@@ -28396,7 +28138,7 @@
       }
     },
     {
-      "id": 367,
+      "id": 361,
       "full_name": "SATS / USD",
       "description": "SATS (Ordinals)",
       "type": "price-feed",
@@ -28474,7 +28216,7 @@
       }
     },
     {
-      "id": 368,
+      "id": 362,
       "full_name": "SATS / USDT",
       "description": "SATS (Ordinals)",
       "type": "price-feed",
@@ -28539,7 +28281,7 @@
       }
     },
     {
-      "id": 369,
+      "id": 363,
       "full_name": "SATS / USDC",
       "description": "SATS (Ordinals)",
       "type": "price-feed",
@@ -28579,7 +28321,7 @@
       }
     },
     {
-      "id": 370,
+      "id": 364,
       "full_name": "ASTR / USD",
       "description": "Astar",
       "type": "price-feed",
@@ -28680,7 +28422,7 @@
       }
     },
     {
-      "id": 371,
+      "id": 365,
       "full_name": "ASTR / USDT",
       "description": "Astar",
       "type": "price-feed",
@@ -28760,7 +28502,7 @@
       }
     },
     {
-      "id": 372,
+      "id": 366,
       "full_name": "ASTR / USDC",
       "description": "Astar",
       "type": "price-feed",
@@ -28800,7 +28542,7 @@
       }
     },
     {
-      "id": 373,
+      "id": 367,
       "full_name": "ZIL / USD",
       "description": "Zilliqa",
       "type": "price-feed",
@@ -28893,7 +28635,7 @@
       }
     },
     {
-      "id": 374,
+      "id": 368,
       "full_name": "ZIL / USDT",
       "description": "Zilliqa",
       "type": "price-feed",
@@ -28973,7 +28715,7 @@
       }
     },
     {
-      "id": 375,
+      "id": 369,
       "full_name": "ZIL / USDC",
       "description": "Zilliqa",
       "type": "price-feed",
@@ -29018,7 +28760,7 @@
       }
     },
     {
-      "id": 376,
+      "id": 370,
       "full_name": "ATH / USD",
       "description": "Aethir",
       "type": "price-feed",
@@ -29115,7 +28857,7 @@
       }
     },
     {
-      "id": 377,
+      "id": 371,
       "full_name": "ATH / USDT",
       "description": "Aethir",
       "type": "price-feed",
@@ -29180,7 +28922,7 @@
       }
     },
     {
-      "id": 378,
+      "id": 372,
       "full_name": "ATH / USDC",
       "description": "Aethir",
       "type": "price-feed",
@@ -29220,7 +28962,7 @@
       }
     },
     {
-      "id": 379,
+      "id": 373,
       "full_name": "BLUR / USD",
       "description": "Blur",
       "type": "price-feed",
@@ -29327,7 +29069,7 @@
       }
     },
     {
-      "id": 380,
+      "id": 374,
       "full_name": "BLUR / USDT",
       "description": "Blur",
       "type": "price-feed",
@@ -29402,7 +29144,7 @@
       }
     },
     {
-      "id": 381,
+      "id": 375,
       "full_name": "BLUR / USDC",
       "description": "Blur",
       "type": "price-feed",
@@ -29452,7 +29194,7 @@
       }
     },
     {
-      "id": 382,
+      "id": 376,
       "full_name": "NOT / USD",
       "description": "Notcoin",
       "type": "price-feed",
@@ -29556,7 +29298,7 @@
       }
     },
     {
-      "id": 383,
+      "id": 377,
       "full_name": "NOT / USDT",
       "description": "Notcoin",
       "type": "price-feed",
@@ -29631,7 +29373,7 @@
       }
     },
     {
-      "id": 384,
+      "id": 378,
       "full_name": "NOT / USDC",
       "description": "Notcoin",
       "type": "price-feed",
@@ -29686,7 +29428,7 @@
       }
     },
     {
-      "id": 385,
+      "id": 379,
       "full_name": "USDD / USD",
       "description": "USDD",
       "type": "price-feed",
@@ -29747,7 +29489,7 @@
       }
     },
     {
-      "id": 386,
+      "id": 380,
       "full_name": "USDD / USDT",
       "description": "USDD",
       "type": "price-feed",
@@ -29797,7 +29539,7 @@
       }
     },
     {
-      "id": 387,
+      "id": 381,
       "full_name": "USDD / USDC",
       "description": "USDD",
       "type": "price-feed",
@@ -29837,7 +29579,7 @@
       }
     },
     {
-      "id": 388,
+      "id": 382,
       "full_name": "BAT / USD",
       "description": "Basic Attention Token",
       "type": "price-feed",
@@ -29955,7 +29697,7 @@
       }
     },
     {
-      "id": 389,
+      "id": 383,
       "full_name": "BAT / ETH",
       "description": "Basic Attention Token",
       "type": "price-feed",
@@ -30000,7 +29742,7 @@
       }
     },
     {
-      "id": 390,
+      "id": 384,
       "full_name": "BAT / USDT",
       "description": "Basic Attention Token",
       "type": "price-feed",
@@ -30085,7 +29827,7 @@
       }
     },
     {
-      "id": 391,
+      "id": 385,
       "full_name": "BAT / USDC",
       "description": "Basic Attention Token",
       "type": "price-feed",
@@ -30135,7 +29877,7 @@
       }
     },
     {
-      "id": 392,
+      "id": 386,
       "full_name": "MASK / USD",
       "description": "Mask Network",
       "type": "price-feed",
@@ -30247,7 +29989,7 @@
       }
     },
     {
-      "id": 393,
+      "id": 387,
       "full_name": "MASK / USDT",
       "description": "Mask Network",
       "type": "price-feed",
@@ -30332,7 +30074,7 @@
       }
     },
     {
-      "id": 394,
+      "id": 388,
       "full_name": "MASK / USDC",
       "description": "Mask Network",
       "type": "price-feed",
@@ -30372,7 +30114,7 @@
       }
     },
     {
-      "id": 395,
+      "id": 389,
       "full_name": "ID / USD",
       "description": "SPACE ID",
       "type": "price-feed",
@@ -30455,7 +30197,7 @@
       }
     },
     {
-      "id": 396,
+      "id": 390,
       "full_name": "ID / USDT",
       "description": "SPACE ID",
       "type": "price-feed",
@@ -30525,7 +30267,7 @@
       }
     },
     {
-      "id": 397,
+      "id": 391,
       "full_name": "ID / USDC",
       "description": "SPACE ID",
       "type": "price-feed",
@@ -30565,7 +30307,7 @@
       }
     },
     {
-      "id": 398,
+      "id": 392,
       "full_name": "ZRX / USD",
       "description": "0x",
       "type": "price-feed",
@@ -30685,7 +30427,7 @@
       }
     },
     {
-      "id": 399,
+      "id": 393,
       "full_name": "ZRX / ETH",
       "description": "0x",
       "type": "price-feed",
@@ -30725,7 +30467,7 @@
       }
     },
     {
-      "id": 400,
+      "id": 394,
       "full_name": "ZRX / USDT",
       "description": "0x",
       "type": "price-feed",
@@ -30805,7 +30547,7 @@
       }
     },
     {
-      "id": 401,
+      "id": 395,
       "full_name": "ZRX / USDC",
       "description": "0x",
       "type": "price-feed",
@@ -30845,7 +30587,7 @@
       }
     },
     {
-      "id": 402,
+      "id": 396,
       "full_name": "ZRO / USD",
       "description": "LayerZero",
       "type": "price-feed",
@@ -30958,7 +30700,7 @@
       }
     },
     {
-      "id": 403,
+      "id": 397,
       "full_name": "ZRO / USDT",
       "description": "LayerZero",
       "type": "price-feed",
@@ -31038,7 +30780,7 @@
       }
     },
     {
-      "id": 404,
+      "id": 398,
       "full_name": "ZRO / USDC",
       "description": "LayerZero",
       "type": "price-feed",
@@ -31088,7 +30830,7 @@
       }
     },
     {
-      "id": 405,
+      "id": 399,
       "full_name": "HOT / USD",
       "description": "Holo",
       "type": "price-feed",
@@ -31168,7 +30910,7 @@
       }
     },
     {
-      "id": 406,
+      "id": 400,
       "full_name": "HOT / USDT",
       "description": "Holo",
       "type": "price-feed",
@@ -31233,7 +30975,7 @@
       }
     },
     {
-      "id": 407,
+      "id": 401,
       "full_name": "WEMIX / USD",
       "description": "WEMIX",
       "type": "price-feed",
@@ -31308,7 +31050,7 @@
       }
     },
     {
-      "id": 408,
+      "id": 402,
       "full_name": "WEMIX / USDT",
       "description": "WEMIX",
       "type": "price-feed",
@@ -31368,7 +31110,7 @@
       }
     },
     {
-      "id": 409,
+      "id": 403,
       "full_name": "ORDI / USD",
       "description": "ORDI",
       "type": "price-feed",
@@ -31458,7 +31200,7 @@
       }
     },
     {
-      "id": 410,
+      "id": 404,
       "full_name": "ORDI / USDT",
       "description": "ORDI",
       "type": "price-feed",
@@ -31533,7 +31275,7 @@
       }
     },
     {
-      "id": 411,
+      "id": 405,
       "full_name": "ORDI / USDC",
       "description": "ORDI",
       "type": "price-feed",
@@ -31583,7 +31325,7 @@
       }
     },
     {
-      "id": 412,
+      "id": 406,
       "full_name": "CELO / USD",
       "description": "Celo",
       "type": "price-feed",
@@ -31679,7 +31421,7 @@
       }
     },
     {
-      "id": 413,
+      "id": 407,
       "full_name": "CELO / USDT",
       "description": "Celo",
       "type": "price-feed",
@@ -31754,7 +31496,7 @@
       }
     },
     {
-      "id": 414,
+      "id": 408,
       "full_name": "CELO / USDC",
       "description": "Celo",
       "type": "price-feed",
@@ -31794,7 +31536,7 @@
       }
     },
     {
-      "id": 415,
+      "id": 409,
       "full_name": "AI16Z / USD",
       "description": "ai16z",
       "type": "price-feed",
@@ -31883,7 +31625,7 @@
       }
     },
     {
-      "id": 416,
+      "id": 410,
       "full_name": "AI16Z / USDT",
       "description": "ai16z",
       "type": "price-feed",
@@ -31951,7 +31693,7 @@
       }
     },
     {
-      "id": 417,
+      "id": 411,
       "full_name": "AI16Z / USDC",
       "description": "ai16z",
       "type": "price-feed",
@@ -31999,7 +31741,7 @@
       }
     },
     {
-      "id": 418,
+      "id": 412,
       "full_name": "CVX / USD",
       "description": "Convex Finance",
       "type": "price-feed",
@@ -32093,7 +31835,7 @@
       }
     },
     {
-      "id": 419,
+      "id": 413,
       "full_name": "CVX / USDT",
       "description": "Convex Finance",
       "type": "price-feed",
@@ -32158,7 +31900,7 @@
       }
     },
     {
-      "id": 420,
+      "id": 414,
       "full_name": "CVX / USDC",
       "description": "Convex Finance",
       "type": "price-feed",
@@ -32198,7 +31940,7 @@
       }
     },
     {
-      "id": 421,
+      "id": 415,
       "full_name": "MOG / USD",
       "description": "Mog Coin",
       "type": "price-feed",
@@ -32292,7 +32034,7 @@
       }
     },
     {
-      "id": 422,
+      "id": 416,
       "full_name": "MOG / USDT",
       "description": "Mog Coin",
       "type": "price-feed",
@@ -32357,7 +32099,7 @@
       }
     },
     {
-      "id": 423,
+      "id": 417,
       "full_name": "ANKR / USD",
       "description": "Ankr",
       "type": "price-feed",
@@ -32463,7 +32205,7 @@
       }
     },
     {
-      "id": 424,
+      "id": 418,
       "full_name": "ANKR / USDT",
       "description": "Ankr",
       "type": "price-feed",
@@ -32538,7 +32280,7 @@
       }
     },
     {
-      "id": 425,
+      "id": 419,
       "full_name": "ANKR / USDC",
       "description": "Ankr",
       "type": "price-feed",
@@ -32578,7 +32320,7 @@
       }
     },
     {
-      "id": 426,
+      "id": 420,
       "full_name": "YFI / USD",
       "description": "Yearn Finance",
       "type": "price-feed",
@@ -32693,7 +32435,7 @@
       }
     },
     {
-      "id": 427,
+      "id": 421,
       "full_name": "YFI / BNB",
       "description": "Yearn Finance",
       "type": "price-feed",
@@ -32733,7 +32475,7 @@
       }
     },
     {
-      "id": 428,
+      "id": 422,
       "full_name": "YFI / ETH",
       "description": "Yearn Finance",
       "type": "price-feed",
@@ -32773,7 +32515,7 @@
       }
     },
     {
-      "id": 429,
+      "id": 423,
       "full_name": "YFI / USDT",
       "description": "Yearn Finance",
       "type": "price-feed",
@@ -32848,7 +32590,7 @@
       }
     },
     {
-      "id": 430,
+      "id": 424,
       "full_name": "YFI / USDC",
       "description": "Yearn Finance",
       "type": "price-feed",
@@ -32888,7 +32630,7 @@
       }
     },
     {
-      "id": 431,
+      "id": 425,
       "full_name": "ENJ / USD",
       "description": "Enjin Coin",
       "type": "price-feed",
@@ -32995,7 +32737,7 @@
       }
     },
     {
-      "id": 432,
+      "id": 426,
       "full_name": "ENJ / ETH",
       "description": "Enjin Coin",
       "type": "price-feed",
@@ -33040,7 +32782,7 @@
       }
     },
     {
-      "id": 433,
+      "id": 427,
       "full_name": "ENJ / USDT",
       "description": "Enjin Coin",
       "type": "price-feed",
@@ -33125,7 +32867,7 @@
       }
     },
     {
-      "id": 434,
+      "id": 428,
       "full_name": "ENJ / USDC",
       "description": "Enjin Coin",
       "type": "price-feed",
@@ -33165,7 +32907,7 @@
       }
     },
     {
-      "id": 435,
+      "id": 429,
       "full_name": "PNUT / USD",
       "description": "Peanut the Squirrel",
       "type": "price-feed",
@@ -33283,7 +33025,7 @@
       }
     },
     {
-      "id": 436,
+      "id": 430,
       "full_name": "PNUT / USDT",
       "description": "Peanut the Squirrel",
       "type": "price-feed",
@@ -33363,7 +33105,7 @@
       }
     },
     {
-      "id": 437,
+      "id": 431,
       "full_name": "PNUT / USDC",
       "description": "Peanut the Squirrel",
       "type": "price-feed",
@@ -33408,7 +33150,7 @@
       }
     },
     {
-      "id": 438,
+      "id": 432,
       "full_name": "ONE / USD",
       "description": "Harmony",
       "type": "price-feed",
@@ -33506,7 +33248,7 @@
       }
     },
     {
-      "id": 439,
+      "id": 433,
       "full_name": "ONE / USDT",
       "description": "Harmony",
       "type": "price-feed",
@@ -33586,7 +33328,7 @@
       }
     },
     {
-      "id": 440,
+      "id": 434,
       "full_name": "ONE / USDC",
       "description": "Harmony",
       "type": "price-feed",
@@ -33631,7 +33373,7 @@
       }
     },
     {
-      "id": 441,
+      "id": 435,
       "full_name": "MEW / USD",
       "description": "cat in a dogs world",
       "type": "price-feed",
@@ -33731,7 +33473,7 @@
       }
     },
     {
-      "id": 442,
+      "id": 436,
       "full_name": "MEW / USDT",
       "description": "cat in a dogs world",
       "type": "price-feed",
@@ -33801,7 +33543,7 @@
       }
     },
     {
-      "id": 443,
+      "id": 437,
       "full_name": "MEW / USDC",
       "description": "cat in a dogs world",
       "type": "price-feed",
@@ -33841,7 +33583,7 @@
       }
     },
     {
-      "id": 444,
+      "id": 438,
       "full_name": "SUSHI / USD",
       "description": "Sushi",
       "type": "price-feed",
@@ -33957,7 +33699,7 @@
       }
     },
     {
-      "id": 445,
+      "id": 439,
       "full_name": "SUSHI / ETH",
       "description": "Sushi",
       "type": "price-feed",
@@ -34002,7 +33744,7 @@
       }
     },
     {
-      "id": 446,
+      "id": 440,
       "full_name": "SUSHI / USDT",
       "description": "Sushi",
       "type": "price-feed",
@@ -34082,7 +33824,7 @@
       }
     },
     {
-      "id": 447,
+      "id": 441,
       "full_name": "SUSHI / USDC",
       "description": "Sushi",
       "type": "price-feed",
@@ -34122,7 +33864,7 @@
       }
     },
     {
-      "id": 448,
+      "id": 442,
       "full_name": "IOTX / USD",
       "description": "IoTeX",
       "type": "price-feed",
@@ -34214,7 +33956,7 @@
       }
     },
     {
-      "id": 449,
+      "id": 443,
       "full_name": "IOTX / USDT",
       "description": "IoTeX",
       "type": "price-feed",
@@ -34284,7 +34026,7 @@
       }
     },
     {
-      "id": 450,
+      "id": 444,
       "full_name": "ETHFI / USD",
       "description": "Ether.fi",
       "type": "price-feed",
@@ -34387,7 +34129,7 @@
       }
     },
     {
-      "id": 451,
+      "id": 445,
       "full_name": "ETHFI / USDT",
       "description": "Ether.fi",
       "type": "price-feed",
@@ -34457,7 +34199,7 @@
       }
     },
     {
-      "id": 452,
+      "id": 446,
       "full_name": "ETHFI / USDC",
       "description": "Ether.fi",
       "type": "price-feed",
@@ -34507,7 +34249,7 @@
       }
     },
     {
-      "id": 453,
+      "id": 447,
       "full_name": "WOO / USD",
       "description": "Woo Network",
       "type": "price-feed",
@@ -34607,7 +34349,7 @@
       }
     },
     {
-      "id": 454,
+      "id": 448,
       "full_name": "WOO / USDT",
       "description": "Woo Network",
       "type": "price-feed",
@@ -34682,7 +34424,7 @@
       }
     },
     {
-      "id": 455,
+      "id": 449,
       "full_name": "POPCAT / USD",
       "description": "POPCAT",
       "type": "price-feed",
@@ -34774,7 +34516,7 @@
       }
     },
     {
-      "id": 456,
+      "id": 450,
       "full_name": "POPCAT / USDT",
       "description": "POPCAT",
       "type": "price-feed",
@@ -34834,7 +34576,7 @@
       }
     },
     {
-      "id": 457,
+      "id": 451,
       "full_name": "TURBO / USD",
       "description": "Turbo",
       "type": "price-feed",
@@ -34941,7 +34683,7 @@
       }
     },
     {
-      "id": 458,
+      "id": 452,
       "full_name": "TURBO / USDT",
       "description": "Turbo",
       "type": "price-feed",
@@ -35011,7 +34753,7 @@
       }
     },
     {
-      "id": 459,
+      "id": 453,
       "full_name": "TURBO / USDC",
       "description": "Turbo",
       "type": "price-feed",
@@ -35061,7 +34803,7 @@
       }
     },
     {
-      "id": 460,
+      "id": 454,
       "full_name": "DGB / USD",
       "description": "Digibyte",
       "type": "price-feed",
@@ -35147,7 +34889,7 @@
       }
     },
     {
-      "id": 461,
+      "id": 455,
       "full_name": "DGB / USDT",
       "description": "Digibyte",
       "type": "price-feed",
@@ -35217,7 +34959,7 @@
       }
     },
     {
-      "id": 462,
+      "id": 456,
       "full_name": "DGB / USDC",
       "description": "Digibyte",
       "type": "price-feed",
@@ -35257,7 +34999,7 @@
       }
     },
     {
-      "id": 463,
+      "id": 457,
       "full_name": "LRC / ETH",
       "description": "Loopring",
       "type": "price-feed",
@@ -35302,7 +35044,7 @@
       }
     },
     {
-      "id": 464,
+      "id": 458,
       "full_name": "HMSTR / USD",
       "description": "Hamster Kombat",
       "type": "price-feed",
@@ -35396,7 +35138,7 @@
       }
     },
     {
-      "id": 465,
+      "id": 459,
       "full_name": "HMSTR / USDT",
       "description": "Hamster Kombat",
       "type": "price-feed",
@@ -35466,7 +35208,7 @@
       }
     },
     {
-      "id": 466,
+      "id": 460,
       "full_name": "HMSTR / USDC",
       "description": "Hamster Kombat",
       "type": "price-feed",
@@ -35516,7 +35258,7 @@
       }
     },
     {
-      "id": 467,
+      "id": 461,
       "full_name": "GMX / USD",
       "description": "GMX",
       "type": "price-feed",
@@ -35610,7 +35352,7 @@
       }
     },
     {
-      "id": 468,
+      "id": 462,
       "full_name": "GMX / USDT",
       "description": "GMX",
       "type": "price-feed",
@@ -35685,7 +35427,7 @@
       }
     },
     {
-      "id": 469,
+      "id": 463,
       "full_name": "EURC / USD",
       "description": "Circle EUR",
       "type": "price-feed",
@@ -35743,7 +35485,7 @@
       }
     },
     {
-      "id": 470,
+      "id": 464,
       "full_name": "EURC / USDC",
       "description": "Circle EUR",
       "type": "price-feed",
@@ -35788,50 +35530,7 @@
       }
     },
     {
-      "id": 471,
-      "full_name": "RLUSD / USD",
-      "description": "Ripple USD",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "RLUSD",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "RLUSD"
-              ],
-              "id": [
-                34387
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "RLUSD / USD"
-        }
-      }
-    },
-    {
-      "id": 472,
+      "id": 465,
       "full_name": "GMT / USD",
       "description": "STEPN",
       "type": "price-feed",
@@ -35934,7 +35633,7 @@
       }
     },
     {
-      "id": 473,
+      "id": 466,
       "full_name": "GMT / USDT",
       "description": "STEPN",
       "type": "price-feed",
@@ -36004,7 +35703,7 @@
       }
     },
     {
-      "id": 474,
+      "id": 467,
       "full_name": "GMT / USDC",
       "description": "STEPN",
       "type": "price-feed",
@@ -36054,7 +35753,7 @@
       }
     },
     {
-      "id": 475,
+      "id": 468,
       "full_name": "FXS / USD",
       "description": "Frax Share",
       "type": "price-feed",
@@ -36148,7 +35847,7 @@
       }
     },
     {
-      "id": 476,
+      "id": 469,
       "full_name": "FXS / USDT",
       "description": "Frax Share",
       "type": "price-feed",
@@ -36218,7 +35917,7 @@
       }
     },
     {
-      "id": 477,
+      "id": 470,
       "full_name": "ONT / USD",
       "description": "Ontology",
       "type": "price-feed",
@@ -36306,7 +36005,7 @@
       }
     },
     {
-      "id": 478,
+      "id": 471,
       "full_name": "ONT / USDT",
       "description": "Ontology",
       "type": "price-feed",
@@ -36376,7 +36075,7 @@
       }
     },
     {
-      "id": 479,
+      "id": 472,
       "full_name": "ONT / USDC",
       "description": "Ontology",
       "type": "price-feed",
@@ -36426,7 +36125,7 @@
       }
     },
     {
-      "id": 480,
+      "id": 473,
       "full_name": "SXP / USD",
       "description": "Swipe",
       "type": "price-feed",
@@ -36501,7 +36200,7 @@
       }
     },
     {
-      "id": 481,
+      "id": 474,
       "full_name": "SXP / USDT",
       "description": "Swipe",
       "type": "price-feed",
@@ -36566,7 +36265,7 @@
       }
     },
     {
-      "id": 482,
+      "id": 475,
       "full_name": "POLYX / USD",
       "description": "Polymesh",
       "type": "price-feed",
@@ -36642,7 +36341,7 @@
       }
     },
     {
-      "id": 483,
+      "id": 476,
       "full_name": "POLYX / USDT",
       "description": "Polymesh",
       "type": "price-feed",
@@ -36702,7 +36401,7 @@
       }
     },
     {
-      "id": 484,
+      "id": 477,
       "full_name": "BAND / BNB",
       "description": "Band Protocol",
       "type": "price-feed",
@@ -36742,7 +36441,7 @@
       }
     },
     {
-      "id": 485,
+      "id": 478,
       "full_name": "BAND / USD",
       "description": "Band Protocol",
       "type": "price-feed",
@@ -36838,7 +36537,7 @@
       }
     },
     {
-      "id": 486,
+      "id": 479,
       "full_name": "BAND / USDT",
       "description": "Band Protocol",
       "type": "price-feed",
@@ -36908,7 +36607,7 @@
       }
     },
     {
-      "id": 487,
+      "id": 480,
       "full_name": "BAND / USDC",
       "description": "Band Protocol",
       "type": "price-feed",
@@ -36948,7 +36647,7 @@
       }
     },
     {
-      "id": 488,
+      "id": 481,
       "full_name": "ARKM / USD",
       "description": "Arkham",
       "type": "price-feed",
@@ -37055,7 +36754,7 @@
       }
     },
     {
-      "id": 489,
+      "id": 482,
       "full_name": "ARKM / USDT",
       "description": "Arkham",
       "type": "price-feed",
@@ -37130,7 +36829,7 @@
       }
     },
     {
-      "id": 490,
+      "id": 483,
       "full_name": "ARKM / USDC",
       "description": "Arkham",
       "type": "price-feed",
@@ -37180,7 +36879,7 @@
       }
     },
     {
-      "id": 491,
+      "id": 484,
       "full_name": "IO / USD",
       "description": "io.net",
       "type": "price-feed",
@@ -37268,7 +36967,7 @@
       }
     },
     {
-      "id": 492,
+      "id": 485,
       "full_name": "IO / USDT",
       "description": "io.net",
       "type": "price-feed",
@@ -37338,7 +37037,7 @@
       }
     },
     {
-      "id": 493,
+      "id": 486,
       "full_name": "IO / USDC",
       "description": "io.net",
       "type": "price-feed",
@@ -37378,7 +37077,7 @@
       }
     },
     {
-      "id": 494,
+      "id": 487,
       "full_name": "STORJ / USD",
       "description": "Storj",
       "type": "price-feed",
@@ -37484,7 +37183,7 @@
       }
     },
     {
-      "id": 495,
+      "id": 488,
       "full_name": "STORJ / USDT",
       "description": "Storj",
       "type": "price-feed",
@@ -37559,7 +37258,7 @@
       }
     },
     {
-      "id": 496,
+      "id": 489,
       "full_name": "STORJ / USDC",
       "description": "Storj",
       "type": "price-feed",
@@ -37599,7 +37298,7 @@
       }
     },
     {
-      "id": 497,
+      "id": 490,
       "full_name": "RPL / USD",
       "description": "Rocket Pool",
       "type": "price-feed",
@@ -37698,7 +37397,7 @@
       }
     },
     {
-      "id": 498,
+      "id": 491,
       "full_name": "RPL / USDT",
       "description": "Rocket Pool",
       "type": "price-feed",
@@ -37768,7 +37467,7 @@
       }
     },
     {
-      "id": 499,
+      "id": 492,
       "full_name": "RPL / USDC",
       "description": "Rocket Pool",
       "type": "price-feed",
@@ -37808,7 +37507,7 @@
       }
     },
     {
-      "id": 500,
+      "id": 493,
       "full_name": "USUAL / USD",
       "description": "Usual",
       "type": "price-feed",
@@ -37887,7 +37586,7 @@
       }
     },
     {
-      "id": 501,
+      "id": 494,
       "full_name": "USUAL / USDT",
       "description": "Usual",
       "type": "price-feed",
@@ -37947,7 +37646,7 @@
       }
     },
     {
-      "id": 502,
+      "id": 495,
       "full_name": "USUAL / USDC",
       "description": "Usual",
       "type": "price-feed",
@@ -37987,7 +37686,7 @@
       }
     },
     {
-      "id": 503,
+      "id": 496,
       "full_name": "AEVO / USD",
       "description": "Aevo",
       "type": "price-feed",
@@ -38081,7 +37780,7 @@
       }
     },
     {
-      "id": 504,
+      "id": 497,
       "full_name": "AEVO / USDT",
       "description": "Aevo",
       "type": "price-feed",
@@ -38151,7 +37850,7 @@
       }
     },
     {
-      "id": 505,
+      "id": 498,
       "full_name": "AEVO / USDC",
       "description": "Aevo",
       "type": "price-feed",
@@ -38191,7 +37890,7 @@
       }
     },
     {
-      "id": 506,
+      "id": 499,
       "full_name": "METIS / USD",
       "description": "Metis",
       "type": "price-feed",
@@ -38280,7 +37979,7 @@
       }
     },
     {
-      "id": 507,
+      "id": 500,
       "full_name": "METIS / USDT",
       "description": "Metis",
       "type": "price-feed",
@@ -38355,7 +38054,7 @@
       }
     },
     {
-      "id": 508,
+      "id": 501,
       "full_name": "METIS / USDC",
       "description": "Metis",
       "type": "price-feed",
@@ -38395,7 +38094,7 @@
       }
     },
     {
-      "id": 509,
+      "id": 502,
       "full_name": "NEIRO / USD",
       "description": "Neiro",
       "type": "price-feed",
@@ -38506,7 +38205,7 @@
       }
     },
     {
-      "id": 510,
+      "id": 503,
       "full_name": "NEIRO / USDT",
       "description": "Neiro",
       "type": "price-feed",
@@ -38581,7 +38280,7 @@
       }
     },
     {
-      "id": 511,
+      "id": 504,
       "full_name": "NEIRO / USDC",
       "description": "Neiro",
       "type": "price-feed",
@@ -38626,7 +38325,7 @@
       }
     },
     {
-      "id": 512,
+      "id": 505,
       "full_name": "MEME / USD",
       "description": "Memecoin",
       "type": "price-feed",
@@ -38723,7 +38422,7 @@
       }
     },
     {
-      "id": 513,
+      "id": 506,
       "full_name": "MEME / USDT",
       "description": "Memecoin",
       "type": "price-feed",
@@ -38788,7 +38487,7 @@
       }
     },
     {
-      "id": 514,
+      "id": 507,
       "full_name": "MEME / USDC",
       "description": "Memecoin",
       "type": "price-feed",
@@ -38828,7 +38527,7 @@
       }
     },
     {
-      "id": 515,
+      "id": 508,
       "full_name": "UMA / USD",
       "description": "UMA",
       "type": "price-feed",
@@ -38932,7 +38631,7 @@
       }
     },
     {
-      "id": 516,
+      "id": 509,
       "full_name": "UMA / USDT",
       "description": "UMA",
       "type": "price-feed",
@@ -39002,7 +38701,7 @@
       }
     },
     {
-      "id": 517,
+      "id": 510,
       "full_name": "UMA / USDC",
       "description": "UMA",
       "type": "price-feed",
@@ -39042,7 +38741,7 @@
       }
     },
     {
-      "id": 518,
+      "id": 511,
       "full_name": "AVAIL / USD",
       "description": "Avail",
       "type": "price-feed",
@@ -39112,7 +38811,7 @@
       }
     },
     {
-      "id": 519,
+      "id": 512,
       "full_name": "AVAIL / USDT",
       "description": "Avail",
       "type": "price-feed",
@@ -39172,7 +38871,7 @@
       }
     },
     {
-      "id": 520,
+      "id": 513,
       "full_name": "MANTA / USD",
       "description": "Manta Network",
       "type": "price-feed",
@@ -39249,7 +38948,7 @@
       }
     },
     {
-      "id": 521,
+      "id": 514,
       "full_name": "MANTA / USDT",
       "description": "Manta Network",
       "type": "price-feed",
@@ -39314,7 +39013,7 @@
       }
     },
     {
-      "id": 522,
+      "id": 515,
       "full_name": "MANTA / USDC",
       "description": "Manta Network",
       "type": "price-feed",
@@ -39359,7 +39058,7 @@
       }
     },
     {
-      "id": 523,
+      "id": 516,
       "full_name": "ALT / USD",
       "description": "Altlayer",
       "type": "price-feed",
@@ -39443,7 +39142,7 @@
       }
     },
     {
-      "id": 524,
+      "id": 517,
       "full_name": "ALT / USDT",
       "description": "Altlayer",
       "type": "price-feed",
@@ -39498,7 +39197,7 @@
       }
     },
     {
-      "id": 525,
+      "id": 518,
       "full_name": "ALT / USDC",
       "description": "Altlayer",
       "type": "price-feed",
@@ -39543,7 +39242,7 @@
       }
     },
     {
-      "id": 526,
+      "id": 519,
       "full_name": "SPELL / USD",
       "description": "Spell Token",
       "type": "price-feed",
@@ -39643,7 +39342,7 @@
       }
     },
     {
-      "id": 527,
+      "id": 520,
       "full_name": "SPELL / USDT",
       "description": "Spell Token",
       "type": "price-feed",
@@ -39718,7 +39417,7 @@
       }
     },
     {
-      "id": 528,
+      "id": 521,
       "full_name": "BOME / USD",
       "description": "BOOK OF MEME",
       "type": "price-feed",
@@ -39817,7 +39516,7 @@
       }
     },
     {
-      "id": 529,
+      "id": 522,
       "full_name": "BOME / USDT",
       "description": "BOOK OF MEME",
       "type": "price-feed",
@@ -39892,7 +39591,7 @@
       }
     },
     {
-      "id": 530,
+      "id": 523,
       "full_name": "BOME / USDC",
       "description": "BOOK OF MEME",
       "type": "price-feed",
@@ -39937,7 +39636,7 @@
       }
     },
     {
-      "id": 531,
+      "id": 524,
       "full_name": "IQ / USD",
       "description": "IQ",
       "type": "price-feed",
@@ -40013,7 +39712,7 @@
       }
     },
     {
-      "id": 532,
+      "id": 525,
       "full_name": "IQ / USDT",
       "description": "IQ",
       "type": "price-feed",
@@ -40073,7 +39772,7 @@
       }
     },
     {
-      "id": 533,
+      "id": 526,
       "full_name": "IQ / USDC",
       "description": "IQ",
       "type": "price-feed",
@@ -40113,7 +39812,7 @@
       }
     },
     {
-      "id": 534,
+      "id": 527,
       "full_name": "AIXBT / USD",
       "description": "aixbt by Virtuals",
       "type": "price-feed",
@@ -40210,7 +39909,7 @@
       }
     },
     {
-      "id": 535,
+      "id": 528,
       "full_name": "AIXBT / USDT",
       "description": "aixbt by Virtuals",
       "type": "price-feed",
@@ -40280,7 +39979,7 @@
       }
     },
     {
-      "id": 536,
+      "id": 529,
       "full_name": "AIXBT / USDC",
       "description": "aixbt by Virtuals",
       "type": "price-feed",
@@ -40325,7 +40024,7 @@
       }
     },
     {
-      "id": 537,
+      "id": 530,
       "full_name": "VELO / USD",
       "description": "Velo",
       "type": "price-feed",
@@ -40413,7 +40112,7 @@
       }
     },
     {
-      "id": 538,
+      "id": 531,
       "full_name": "VELO / USDT",
       "description": "Velo",
       "type": "price-feed",
@@ -40478,7 +40177,7 @@
       }
     },
     {
-      "id": 539,
+      "id": 532,
       "full_name": "VELO / USDC",
       "description": "Velo",
       "type": "price-feed",
@@ -40518,7 +40217,7 @@
       }
     },
     {
-      "id": 540,
+      "id": 533,
       "full_name": "BAL / USD",
       "description": "Balancer",
       "type": "price-feed",
@@ -40618,7 +40317,7 @@
       }
     },
     {
-      "id": 541,
+      "id": 534,
       "full_name": "BAL / USDT",
       "description": "Balancer",
       "type": "price-feed",
@@ -40688,7 +40387,7 @@
       }
     },
     {
-      "id": 542,
+      "id": 535,
       "full_name": "BAL / USDC",
       "description": "Balancer",
       "type": "price-feed",
@@ -40728,7 +40427,7 @@
       }
     },
     {
-      "id": 543,
+      "id": 536,
       "full_name": "XVS / BNB",
       "description": "Venus",
       "type": "price-feed",
@@ -40768,7 +40467,7 @@
       }
     },
     {
-      "id": 544,
+      "id": 537,
       "full_name": "XVS / USD",
       "description": "Venus",
       "type": "price-feed",
@@ -40828,7 +40527,7 @@
       }
     },
     {
-      "id": 545,
+      "id": 538,
       "full_name": "XVS / USDT",
       "description": "Venus",
       "type": "price-feed",
@@ -40878,7 +40577,7 @@
       }
     },
     {
-      "id": 546,
+      "id": 539,
       "full_name": "CHR / USD",
       "description": "Chromaway",
       "type": "price-feed",
@@ -40965,7 +40664,7 @@
       }
     },
     {
-      "id": 547,
+      "id": 540,
       "full_name": "CHR / USDT",
       "description": "Chromaway",
       "type": "price-feed",
@@ -41030,7 +40729,7 @@
       }
     },
     {
-      "id": 548,
+      "id": 541,
       "full_name": "ONG / USD",
       "description": "Ontology Gas",
       "type": "price-feed",
@@ -41105,7 +40804,7 @@
       }
     },
     {
-      "id": 549,
+      "id": 542,
       "full_name": "ONG / USDT",
       "description": "Ontology Gas",
       "type": "price-feed",
@@ -41165,7 +40864,7 @@
       }
     },
     {
-      "id": 550,
+      "id": 543,
       "full_name": "BLAST / USD",
       "description": "Blast",
       "type": "price-feed",
@@ -41258,7 +40957,7 @@
       }
     },
     {
-      "id": 551,
+      "id": 544,
       "full_name": "BLAST / USDT",
       "description": "Blast",
       "type": "price-feed",
@@ -41323,7 +41022,7 @@
       }
     },
     {
-      "id": 552,
+      "id": 545,
       "full_name": "BIGTIME / USD",
       "description": "Big Time",
       "type": "price-feed",
@@ -41419,7 +41118,7 @@
       }
     },
     {
-      "id": 553,
+      "id": 546,
       "full_name": "BIGTIME / USDT",
       "description": "Big Time",
       "type": "price-feed",
@@ -41489,7 +41188,7 @@
       }
     },
     {
-      "id": 554,
+      "id": 547,
       "full_name": "BIGTIME / USDC",
       "description": "Big Time",
       "type": "price-feed",
@@ -41529,7 +41228,7 @@
       }
     },
     {
-      "id": 555,
+      "id": 548,
       "full_name": "ILV / USD",
       "description": "Illuvium",
       "type": "price-feed",
@@ -41621,7 +41320,7 @@
       }
     },
     {
-      "id": 556,
+      "id": 549,
       "full_name": "ILV / USDT",
       "description": "Illuvium",
       "type": "price-feed",
@@ -41696,7 +41395,7 @@
       }
     },
     {
-      "id": 557,
+      "id": 550,
       "full_name": "USDP / USD",
       "description": "Pax Dollar",
       "type": "price-feed",
@@ -41763,7 +41462,7 @@
       }
     },
     {
-      "id": 558,
+      "id": 551,
       "full_name": "USDP / USDT",
       "description": "Pax Dollar",
       "type": "price-feed",
@@ -41818,7 +41517,7 @@
       }
     },
     {
-      "id": 559,
+      "id": 552,
       "full_name": "PEOPLE / USD",
       "description": "ConstitutionDAO",
       "type": "price-feed",
@@ -41903,7 +41602,7 @@
       }
     },
     {
-      "id": 560,
+      "id": 553,
       "full_name": "PEOPLE / USDT",
       "description": "ConstitutionDAO",
       "type": "price-feed",
@@ -41973,7 +41672,7 @@
       }
     },
     {
-      "id": 561,
+      "id": 554,
       "full_name": "PEOPLE / USDC",
       "description": "ConstitutionDAO",
       "type": "price-feed",
@@ -42023,52 +41722,7 @@
       }
     },
     {
-      "id": 562,
-      "full_name": "USDX / USD",
-      "description": "",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "USDX",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "",
-        "market_hours": "",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "USDX",
-                "USDX"
-              ],
-              "id": [
-                34060,
-                6651
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "USDX / USD"
-        }
-      }
-    },
-    {
-      "id": 563,
+      "id": 555,
       "full_name": "TRB / USD",
       "description": "Tellor Tributes",
       "type": "price-feed",
@@ -42153,7 +41807,7 @@
       }
     },
     {
-      "id": 564,
+      "id": 556,
       "full_name": "TRB / USDT",
       "description": "Tellor Tributes",
       "type": "price-feed",
@@ -42218,7 +41872,7 @@
       }
     },
     {
-      "id": 565,
+      "id": 557,
       "full_name": "TRB / USDC",
       "description": "Tellor Tributes",
       "type": "price-feed",
@@ -42268,7 +41922,7 @@
       }
     },
     {
-      "id": 566,
+      "id": 558,
       "full_name": "PIXEL / USD",
       "description": "Pixels",
       "type": "price-feed",
@@ -42353,7 +42007,7 @@
       }
     },
     {
-      "id": 567,
+      "id": 559,
       "full_name": "PIXEL / USDT",
       "description": "Pixels",
       "type": "price-feed",
@@ -42423,7 +42077,7 @@
       }
     },
     {
-      "id": 568,
+      "id": 560,
       "full_name": "PIXEL / USDC",
       "description": "Pixels",
       "type": "price-feed",
@@ -42468,7 +42122,7 @@
       }
     },
     {
-      "id": 569,
+      "id": 561,
       "full_name": "XAI / USD",
       "description": "Xai",
       "type": "price-feed",
@@ -42560,7 +42214,7 @@
       }
     },
     {
-      "id": 570,
+      "id": 562,
       "full_name": "XAI / USDT",
       "description": "Xai",
       "type": "price-feed",
@@ -42625,7 +42279,7 @@
       }
     },
     {
-      "id": 571,
+      "id": 563,
       "full_name": "SLP / USD",
       "description": "Smooth Love Potion",
       "type": "price-feed",
@@ -42717,7 +42371,7 @@
       }
     },
     {
-      "id": 572,
+      "id": 564,
       "full_name": "SLP / USDT",
       "description": "Smooth Love Potion",
       "type": "price-feed",
@@ -42797,7 +42451,7 @@
       }
     },
     {
-      "id": 573,
+      "id": 565,
       "full_name": "SLP / USDC",
       "description": "Smooth Love Potion",
       "type": "price-feed",
@@ -42837,7 +42491,7 @@
       }
     },
     {
-      "id": 574,
+      "id": 566,
       "full_name": "USDtb / USD",
       "description": "",
       "type": "price-feed",
@@ -42887,7 +42541,7 @@
       }
     },
     {
-      "id": 575,
+      "id": 567,
       "full_name": "USDtb / USDT",
       "description": "",
       "type": "price-feed",
@@ -42927,7 +42581,7 @@
       }
     },
     {
-      "id": 576,
+      "id": 568,
       "full_name": "HSK / USD",
       "description": "HashKey Platform Token",
       "type": "price-feed",
@@ -42987,7 +42641,7 @@
       }
     },
     {
-      "id": 577,
+      "id": 569,
       "full_name": "HSK / USDT",
       "description": "HashKey Platform Token",
       "type": "price-feed",
@@ -43037,7 +42691,7 @@
       }
     },
     {
-      "id": 578,
+      "id": 570,
       "full_name": "JOE / USD",
       "description": "Trader Joe",
       "type": "price-feed",
@@ -43119,7 +42773,7 @@
       }
     },
     {
-      "id": 579,
+      "id": 571,
       "full_name": "JOE / USDT",
       "description": "Trader Joe",
       "type": "price-feed",
@@ -43179,7 +42833,7 @@
       }
     },
     {
-      "id": 580,
+      "id": 572,
       "full_name": "JOE / USDC",
       "description": "Trader Joe",
       "type": "price-feed",
@@ -43219,7 +42873,7 @@
       }
     },
     {
-      "id": 581,
+      "id": 573,
       "full_name": "SCR / USD",
       "description": "Scroll",
       "type": "price-feed",
@@ -43307,7 +42961,7 @@
       }
     },
     {
-      "id": 582,
+      "id": 574,
       "full_name": "SCR / USDT",
       "description": "Scroll",
       "type": "price-feed",
@@ -43382,7 +43036,7 @@
       }
     },
     {
-      "id": 583,
+      "id": 575,
       "full_name": "SCR / USDC",
       "description": "Scroll",
       "type": "price-feed",
@@ -43422,7 +43076,7 @@
       }
     },
     {
-      "id": 584,
+      "id": 576,
       "full_name": "DOGS / USD",
       "description": "DOGS",
       "type": "price-feed",
@@ -43532,7 +43186,7 @@
       }
     },
     {
-      "id": 585,
+      "id": 577,
       "full_name": "DOGS / USDT",
       "description": "DOGS",
       "type": "price-feed",
@@ -43607,7 +43261,7 @@
       }
     },
     {
-      "id": 586,
+      "id": 578,
       "full_name": "DOGS / USDC",
       "description": "DOGS",
       "type": "price-feed",
@@ -43657,7 +43311,7 @@
       }
     },
     {
-      "id": 587,
+      "id": 579,
       "full_name": "EDU / USD",
       "description": "Open Campus",
       "type": "price-feed",
@@ -43722,7 +43376,7 @@
       }
     },
     {
-      "id": 588,
+      "id": 580,
       "full_name": "EDU / USDT",
       "description": "Open Campus",
       "type": "price-feed",
@@ -43777,7 +43431,7 @@
       }
     },
     {
-      "id": 589,
+      "id": 581,
       "full_name": "ANON / USD",
       "description": "",
       "type": "price-feed",
@@ -43844,7 +43498,7 @@
       }
     },
     {
-      "id": 590,
+      "id": 582,
       "full_name": "ANON / USDT",
       "description": "",
       "type": "price-feed",
@@ -43889,7 +43543,7 @@
       }
     },
     {
-      "id": 591,
+      "id": 583,
       "full_name": "C98 / USD",
       "description": "C98",
       "type": "price-feed",
@@ -43983,7 +43637,7 @@
       }
     },
     {
-      "id": 592,
+      "id": 584,
       "full_name": "C98 / USDT",
       "description": "C98",
       "type": "price-feed",
@@ -44053,7 +43707,7 @@
       }
     },
     {
-      "id": 593,
+      "id": 585,
       "full_name": "KNC / USD",
       "description": "Kyber Network Crystal v2",
       "type": "price-feed",
@@ -44152,7 +43806,7 @@
       }
     },
     {
-      "id": 594,
+      "id": 586,
       "full_name": "KNC / ETH",
       "description": "Kyber Network Crystal",
       "type": "price-feed",
@@ -44197,7 +43851,7 @@
       }
     },
     {
-      "id": 595,
+      "id": 587,
       "full_name": "KNC / USDT",
       "description": "Kyber Network Crystal v2",
       "type": "price-feed",
@@ -44267,7 +43921,7 @@
       }
     },
     {
-      "id": 596,
+      "id": 588,
       "full_name": "KNC / USDC",
       "description": "Kyber Network Crystal v2",
       "type": "price-feed",
@@ -44307,7 +43961,7 @@
       }
     },
     {
-      "id": 597,
+      "id": 589,
       "full_name": "BB / USD",
       "description": "BounceBit",
       "type": "price-feed",
@@ -44390,7 +44044,7 @@
       }
     },
     {
-      "id": 598,
+      "id": 590,
       "full_name": "BB / USDT",
       "description": "BounceBit",
       "type": "price-feed",
@@ -44455,7 +44109,7 @@
       }
     },
     {
-      "id": 599,
+      "id": 591,
       "full_name": "BB / USDC",
       "description": "BounceBit",
       "type": "price-feed",
@@ -44500,7 +44154,7 @@
       }
     },
     {
-      "id": 600,
+      "id": 592,
       "full_name": "BUSD / USD",
       "description": "Binance USD",
       "type": "price-feed",
@@ -44560,7 +44214,7 @@
       }
     },
     {
-      "id": 601,
+      "id": 593,
       "full_name": "BUSD / USDT",
       "description": "Binance USD",
       "type": "price-feed",
@@ -44605,50 +44259,7 @@
       }
     },
     {
-      "id": 602,
-      "full_name": "USDL / USD",
-      "description": "",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "USDL",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "",
-        "market_hours": "",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "USDL"
-              ],
-              "id": [
-                32454
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "USDL / USD"
-        }
-      }
-    },
-    {
-      "id": 603,
+      "id": 594,
       "full_name": "WIN / USD",
       "description": "WINkLink",
       "type": "price-feed",
@@ -44729,7 +44340,7 @@
       }
     },
     {
-      "id": 604,
+      "id": 595,
       "full_name": "WIN / USDT",
       "description": "WINkLink",
       "type": "price-feed",
@@ -44794,7 +44405,7 @@
       }
     },
     {
-      "id": 605,
+      "id": 596,
       "full_name": "WIN / USDC",
       "description": "WINkLink",
       "type": "price-feed",
@@ -44834,7 +44445,7 @@
       }
     },
     {
-      "id": 606,
+      "id": 597,
       "full_name": "MOVR / USD",
       "description": "Moonriver",
       "type": "price-feed",
@@ -44929,7 +44540,7 @@
       }
     },
     {
-      "id": 607,
+      "id": 598,
       "full_name": "MOVR / USDT",
       "description": "Moonriver",
       "type": "price-feed",
@@ -45004,7 +44615,7 @@
       }
     },
     {
-      "id": 608,
+      "id": 599,
       "full_name": "MOVR / USDC",
       "description": "Moonriver",
       "type": "price-feed",
@@ -45044,7 +44655,7 @@
       }
     },
     {
-      "id": 609,
+      "id": 600,
       "full_name": "GOAT / USD",
       "description": "Goatseus Maximus",
       "type": "price-feed",
@@ -45146,7 +44757,7 @@
       }
     },
     {
-      "id": 610,
+      "id": 601,
       "full_name": "GOAT / USDT",
       "description": "Goatseus Maximus",
       "type": "price-feed",
@@ -45216,7 +44827,7 @@
       }
     },
     {
-      "id": 611,
+      "id": 602,
       "full_name": "AI / USD",
       "description": "Sleepless AI",
       "type": "price-feed",
@@ -45292,7 +44903,7 @@
       }
     },
     {
-      "id": 612,
+      "id": 603,
       "full_name": "AI / USDT",
       "description": "Sleepless AI",
       "type": "price-feed",
@@ -45342,7 +44953,7 @@
       }
     },
     {
-      "id": 613,
+      "id": 604,
       "full_name": "OMNI / USD",
       "description": "Omni Network",
       "type": "price-feed",
@@ -45441,7 +45052,7 @@
       }
     },
     {
-      "id": 614,
+      "id": 605,
       "full_name": "OMNI / USDT",
       "description": "Omni Network",
       "type": "price-feed",
@@ -45506,7 +45117,7 @@
       }
     },
     {
-      "id": 615,
+      "id": 606,
       "full_name": "OMNI / USDC",
       "description": "Omni Network",
       "type": "price-feed",
@@ -45551,7 +45162,7 @@
       }
     },
     {
-      "id": 616,
+      "id": 607,
       "full_name": "BONE / USD",
       "description": "Bone ShibaSwap",
       "type": "price-feed",
@@ -45625,7 +45236,7 @@
       }
     },
     {
-      "id": 617,
+      "id": 608,
       "full_name": "BONE / USDT",
       "description": "Bone ShibaSwap",
       "type": "price-feed",
@@ -45685,7 +45296,7 @@
       }
     },
     {
-      "id": 618,
+      "id": 609,
       "full_name": "BONE / USDC",
       "description": "Bone ShibaSwap",
       "type": "price-feed",
@@ -45725,7 +45336,7 @@
       }
     },
     {
-      "id": 619,
+      "id": 610,
       "full_name": "REZ / USD",
       "description": "Renzo",
       "type": "price-feed",
@@ -45810,7 +45421,7 @@
       }
     },
     {
-      "id": 620,
+      "id": 611,
       "full_name": "REZ / USDT",
       "description": "Renzo",
       "type": "price-feed",
@@ -45870,7 +45481,7 @@
       }
     },
     {
-      "id": 621,
+      "id": 612,
       "full_name": "REZ / USDC",
       "description": "Renzo",
       "type": "price-feed",
@@ -45915,7 +45526,7 @@
       }
     },
     {
-      "id": 622,
+      "id": 613,
       "full_name": "DODO / USD",
       "description": "Dodo",
       "type": "price-feed",
@@ -45994,7 +45605,7 @@
       }
     },
     {
-      "id": 623,
+      "id": 614,
       "full_name": "DODO / USDT",
       "description": "Dodo",
       "type": "price-feed",
@@ -46059,52 +45670,7 @@
       }
     },
     {
-      "id": 624,
-      "full_name": "LUSD / USD",
-      "description": "Liquity USD",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "LUSD",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "LUSD",
-                "LUSD"
-              ],
-              "id": [
-                19714,
-                9566
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "LUSD / USD"
-        }
-      }
-    },
-    {
-      "id": 625,
+      "id": 615,
       "full_name": "QI / USD",
       "description": "Benqi",
       "type": "price-feed",
@@ -46184,7 +45750,7 @@
       }
     },
     {
-      "id": 626,
+      "id": 616,
       "full_name": "QI / USDT",
       "description": "Benqi",
       "type": "price-feed",
@@ -46244,7 +45810,7 @@
       }
     },
     {
-      "id": 627,
+      "id": 617,
       "full_name": "CYBER / USD",
       "description": "CYBER",
       "type": "price-feed",
@@ -46334,7 +45900,7 @@
       }
     },
     {
-      "id": 628,
+      "id": 618,
       "full_name": "CYBER / USDT",
       "description": "CYBER",
       "type": "price-feed",
@@ -46399,7 +45965,7 @@
       }
     },
     {
-      "id": 629,
+      "id": 619,
       "full_name": "MERL / USD",
       "description": "Merlin Chain",
       "type": "price-feed",
@@ -46476,7 +46042,7 @@
       }
     },
     {
-      "id": 630,
+      "id": 620,
       "full_name": "MERL / USDT",
       "description": "Merlin Chain",
       "type": "price-feed",
@@ -46541,7 +46107,7 @@
       }
     },
     {
-      "id": 631,
+      "id": 621,
       "full_name": "MERL / USDC",
       "description": "Merlin Chain",
       "type": "price-feed",
@@ -46581,7 +46147,7 @@
       }
     },
     {
-      "id": 632,
+      "id": 622,
       "full_name": "DEGEN / USD",
       "description": "Degen (Base)",
       "type": "price-feed",
@@ -46671,7 +46237,7 @@
       }
     },
     {
-      "id": 633,
+      "id": 623,
       "full_name": "DEGEN / USDT",
       "description": "Degen (Base)",
       "type": "price-feed",
@@ -46731,7 +46297,7 @@
       }
     },
     {
-      "id": 634,
+      "id": 624,
       "full_name": "HIGH / USD",
       "description": "Highstreet",
       "type": "price-feed",
@@ -46812,7 +46378,7 @@
       }
     },
     {
-      "id": 635,
+      "id": 625,
       "full_name": "HIGH / USDT",
       "description": "Highstreet",
       "type": "price-feed",
@@ -46877,7 +46443,7 @@
       }
     },
     {
-      "id": 636,
+      "id": 626,
       "full_name": "COQ / USD",
       "description": "Coq Inu",
       "type": "price-feed",
@@ -46952,7 +46518,7 @@
       }
     },
     {
-      "id": 637,
+      "id": 627,
       "full_name": "COQ / USDT",
       "description": "Coq Inu",
       "type": "price-feed",
@@ -47012,7 +46578,7 @@
       }
     },
     {
-      "id": 638,
+      "id": 628,
       "full_name": "GNS / USD",
       "description": "Gains Network",
       "type": "price-feed",
@@ -47087,7 +46653,7 @@
       }
     },
     {
-      "id": 639,
+      "id": 629,
       "full_name": "GNS / USDT",
       "description": "Gains Network",
       "type": "price-feed",
@@ -47147,7 +46713,7 @@
       }
     },
     {
-      "id": 640,
+      "id": 630,
       "full_name": "GRIFFAIN / USD",
       "description": "GRIFFAIN",
       "type": "price-feed",
@@ -47220,7 +46786,7 @@
       }
     },
     {
-      "id": 641,
+      "id": 631,
       "full_name": "GRIFFAIN / USDT",
       "description": "GRIFFAIN",
       "type": "price-feed",
@@ -47275,7 +46841,7 @@
       }
     },
     {
-      "id": 642,
+      "id": 632,
       "full_name": "OGN / USD",
       "description": "Origin Protocol",
       "type": "price-feed",
@@ -47369,7 +46935,7 @@
       }
     },
     {
-      "id": 643,
+      "id": 633,
       "full_name": "OGN / USDT",
       "description": "Origin Protocol",
       "type": "price-feed",
@@ -47434,7 +47000,7 @@
       }
     },
     {
-      "id": 644,
+      "id": 634,
       "full_name": "MAGIC / USD",
       "description": "Magic",
       "type": "price-feed",
@@ -47532,7 +47098,7 @@
       }
     },
     {
-      "id": 645,
+      "id": 635,
       "full_name": "MAGIC / USDT",
       "description": "Magic",
       "type": "price-feed",
@@ -47612,7 +47178,7 @@
       }
     },
     {
-      "id": 646,
+      "id": 636,
       "full_name": "MAGIC / USDC",
       "description": "Magic",
       "type": "price-feed",
@@ -47652,7 +47218,7 @@
       }
     },
     {
-      "id": 647,
+      "id": 637,
       "full_name": "STG / USD",
       "description": "Stargate Finance",
       "type": "price-feed",
@@ -47757,7 +47323,7 @@
       }
     },
     {
-      "id": 648,
+      "id": 638,
       "full_name": "STG / USDT",
       "description": "Stargate Finance",
       "type": "price-feed",
@@ -47832,50 +47398,7 @@
       }
     },
     {
-      "id": 649,
-      "full_name": "DPI / USD",
-      "description": "DefiPulse Index",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "DPI",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "DPI"
-              ],
-              "id": [
-                7055
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "DPI / USD"
-        }
-      }
-    },
-    {
-      "id": 650,
+      "id": 639,
       "full_name": "MOODENG / USD",
       "description": "Moo Deng",
       "type": "price-feed",
@@ -47976,7 +47499,7 @@
       }
     },
     {
-      "id": 651,
+      "id": 640,
       "full_name": "MOODENG / USDT",
       "description": "Moo Deng",
       "type": "price-feed",
@@ -48036,7 +47559,7 @@
       }
     },
     {
-      "id": 652,
+      "id": 641,
       "full_name": "MOODENG / USDC",
       "description": "Moo Deng",
       "type": "price-feed",
@@ -48076,7 +47599,7 @@
       }
     },
     {
-      "id": 653,
+      "id": 642,
       "full_name": "BADGER / USD",
       "description": "Badger DAO",
       "type": "price-feed",
@@ -48166,7 +47689,7 @@
       }
     },
     {
-      "id": 654,
+      "id": 643,
       "full_name": "BADGER / USDT",
       "description": "Badger DAO",
       "type": "price-feed",
@@ -48231,7 +47754,7 @@
       }
     },
     {
-      "id": 655,
+      "id": 644,
       "full_name": "BADGER / USDC",
       "description": "Badger DAO",
       "type": "price-feed",
@@ -48271,7 +47794,7 @@
       }
     },
     {
-      "id": 656,
+      "id": 645,
       "full_name": "ACE / USD",
       "description": "Fusionist",
       "type": "price-feed",
@@ -48355,7 +47878,7 @@
       }
     },
     {
-      "id": 657,
+      "id": 646,
       "full_name": "ACE / USDT",
       "description": "Fusionist",
       "type": "price-feed",
@@ -48420,7 +47943,7 @@
       }
     },
     {
-      "id": 658,
+      "id": 647,
       "full_name": "ACE / USDC",
       "description": "Fusionist",
       "type": "price-feed",
@@ -48460,7 +47983,7 @@
       }
     },
     {
-      "id": 659,
+      "id": 648,
       "full_name": "CUSD / USD",
       "description": "Celo Dollar",
       "type": "price-feed",
@@ -48517,7 +48040,7 @@
       }
     },
     {
-      "id": 660,
+      "id": 649,
       "full_name": "CUSD / USDT",
       "description": "Celo Dollar",
       "type": "price-feed",
@@ -48562,7 +48085,7 @@
       }
     },
     {
-      "id": 661,
+      "id": 650,
       "full_name": "MAV / USD",
       "description": "Maverick Protocol",
       "type": "price-feed",
@@ -48639,7 +48162,7 @@
       }
     },
     {
-      "id": 662,
+      "id": 651,
       "full_name": "MAV / USDT",
       "description": "Maverick Protocol",
       "type": "price-feed",
@@ -48699,7 +48222,7 @@
       }
     },
     {
-      "id": 663,
+      "id": 652,
       "full_name": "ALPHA / USD",
       "description": "Alpha Finance",
       "type": "price-feed",
@@ -48794,7 +48317,7 @@
       }
     },
     {
-      "id": 664,
+      "id": 653,
       "full_name": "ALPHA / USDT",
       "description": "Alpha Finance",
       "type": "price-feed",
@@ -48859,7 +48382,7 @@
       }
     },
     {
-      "id": 665,
+      "id": 654,
       "full_name": "ALPHA / USDC",
       "description": "Alpha Finance",
       "type": "price-feed",
@@ -48899,7 +48422,7 @@
       }
     },
     {
-      "id": 666,
+      "id": 655,
       "full_name": "LISTA / USD",
       "description": "",
       "type": "price-feed",
@@ -48969,7 +48492,7 @@
       }
     },
     {
-      "id": 667,
+      "id": 656,
       "full_name": "LISTA / USDT",
       "description": "",
       "type": "price-feed",
@@ -49029,7 +48552,7 @@
       }
     },
     {
-      "id": 668,
+      "id": 657,
       "full_name": "AMPL / USD",
       "description": "Ampleforth",
       "type": "price-feed",
@@ -49084,7 +48607,7 @@
       }
     },
     {
-      "id": 669,
+      "id": 658,
       "full_name": "AMPL / USDT",
       "description": "Ampleforth",
       "type": "price-feed",
@@ -49129,7 +48652,7 @@
       }
     },
     {
-      "id": 670,
+      "id": 659,
       "full_name": "HOOK / USD",
       "description": "Hooked Protocol",
       "type": "price-feed",
@@ -49199,7 +48722,7 @@
       }
     },
     {
-      "id": 671,
+      "id": 660,
       "full_name": "HOOK / USDT",
       "description": "Hooked Protocol",
       "type": "price-feed",
@@ -49259,7 +48782,7 @@
       }
     },
     {
-      "id": 672,
+      "id": 661,
       "full_name": "ZEREBRO / USD",
       "description": "Zerebro",
       "type": "price-feed",
@@ -49337,7 +48860,7 @@
       }
     },
     {
-      "id": 673,
+      "id": 662,
       "full_name": "ZEREBRO / USDT",
       "description": "Zerebro",
       "type": "price-feed",
@@ -49397,7 +48920,7 @@
       }
     },
     {
-      "id": 674,
+      "id": 663,
       "full_name": "ORDER / USD",
       "description": "Orderly Network",
       "type": "price-feed",
@@ -49467,7 +48990,7 @@
       }
     },
     {
-      "id": 675,
+      "id": 664,
       "full_name": "ORDER / USDT",
       "description": "Orderly Network",
       "type": "price-feed",
@@ -49527,7 +49050,7 @@
       }
     },
     {
-      "id": 676,
+      "id": 665,
       "full_name": "RDNT / USD",
       "description": "Radiant Capital",
       "type": "price-feed",
@@ -49613,7 +49136,7 @@
       }
     },
     {
-      "id": 677,
+      "id": 666,
       "full_name": "RDNT / USDT",
       "description": "Radiant Capital",
       "type": "price-feed",
@@ -49683,7 +49206,7 @@
       }
     },
     {
-      "id": 678,
+      "id": 667,
       "full_name": "RDNT / USDC",
       "description": "Radiant Capital",
       "type": "price-feed",
@@ -49723,7 +49246,7 @@
       }
     },
     {
-      "id": 679,
+      "id": 668,
       "full_name": "MLN / USD",
       "description": "Enzyme",
       "type": "price-feed",
@@ -49808,7 +49331,7 @@
       }
     },
     {
-      "id": 680,
+      "id": 669,
       "full_name": "MLN / ETH",
       "description": "Melon",
       "type": "price-feed",
@@ -49848,7 +49371,7 @@
       }
     },
     {
-      "id": 681,
+      "id": 670,
       "full_name": "MLN / USDT",
       "description": "Enzyme",
       "type": "price-feed",
@@ -49903,7 +49426,7 @@
       }
     },
     {
-      "id": 682,
+      "id": 671,
       "full_name": "MLN / USDC",
       "description": "Enzyme",
       "type": "price-feed",
@@ -49943,7 +49466,7 @@
       }
     },
     {
-      "id": 683,
+      "id": 672,
       "full_name": "QUICK / USD",
       "description": "Quickswap",
       "type": "price-feed",
@@ -50025,7 +49548,7 @@
       }
     },
     {
-      "id": 684,
+      "id": 673,
       "full_name": "QUICK / USDT",
       "description": "Quickswap",
       "type": "price-feed",
@@ -50085,7 +49608,7 @@
       }
     },
     {
-      "id": 685,
+      "id": 674,
       "full_name": "ALCX / USD",
       "description": "Alchemix",
       "type": "price-feed",
@@ -50165,7 +49688,7 @@
       }
     },
     {
-      "id": 686,
+      "id": 675,
       "full_name": "ALCX / USDT",
       "description": "Alchemix",
       "type": "price-feed",
@@ -50220,7 +49743,7 @@
       }
     },
     {
-      "id": 687,
+      "id": 676,
       "full_name": "ALCX / USDC",
       "description": "Alchemix",
       "type": "price-feed",
@@ -50260,7 +49783,7 @@
       }
     },
     {
-      "id": 688,
+      "id": 677,
       "full_name": "PERP / USD",
       "description": "Perpetual Protocol",
       "type": "price-feed",
@@ -50361,7 +49884,7 @@
       }
     },
     {
-      "id": 689,
+      "id": 678,
       "full_name": "PERP / USDT",
       "description": "Perpetual Protocol",
       "type": "price-feed",
@@ -50436,7 +49959,7 @@
       }
     },
     {
-      "id": 690,
+      "id": 679,
       "full_name": "PERP / USDC",
       "description": "Perpetual Protocol",
       "type": "price-feed",
@@ -50476,7 +49999,7 @@
       }
     },
     {
-      "id": 691,
+      "id": 680,
       "full_name": "GHST / ETH",
       "description": "Aavegotchi",
       "type": "price-feed",
@@ -50516,7 +50039,7 @@
       }
     },
     {
-      "id": 692,
+      "id": 681,
       "full_name": "GHST / USD",
       "description": "Aavegotchi",
       "type": "price-feed",
@@ -50606,7 +50129,7 @@
       }
     },
     {
-      "id": 693,
+      "id": 682,
       "full_name": "GHST / USDT",
       "description": "Aavegotchi",
       "type": "price-feed",
@@ -50666,7 +50189,7 @@
       }
     },
     {
-      "id": 694,
+      "id": 683,
       "full_name": "GHST / USDC",
       "description": "Aavegotchi",
       "type": "price-feed",
@@ -50706,7 +50229,7 @@
       }
     },
     {
-      "id": 695,
+      "id": 684,
       "full_name": "BSW / USD",
       "description": "Biswap",
       "type": "price-feed",
@@ -50778,7 +50301,7 @@
       }
     },
     {
-      "id": 696,
+      "id": 685,
       "full_name": "BSW / USDT",
       "description": "Biswap",
       "type": "price-feed",
@@ -50838,7 +50361,7 @@
       }
     },
     {
-      "id": 697,
+      "id": 686,
       "full_name": "NULS / USD",
       "description": "Nuls",
       "type": "price-feed",
@@ -50905,7 +50428,7 @@
       }
     },
     {
-      "id": 698,
+      "id": 687,
       "full_name": "NULS / USDT",
       "description": "Nuls",
       "type": "price-feed",
@@ -50960,7 +50483,7 @@
       }
     },
     {
-      "id": 699,
+      "id": 688,
       "full_name": "NULS / USDC",
       "description": "Nuls",
       "type": "price-feed",
@@ -51000,7 +50523,7 @@
       }
     },
     {
-      "id": 700,
+      "id": 689,
       "full_name": "WING / USD",
       "description": "Wing Finance",
       "type": "price-feed",
@@ -51067,7 +50590,7 @@
       }
     },
     {
-      "id": 701,
+      "id": 690,
       "full_name": "WING / USDT",
       "description": "Wing Finance",
       "type": "price-feed",
@@ -51122,7 +50645,7 @@
       }
     },
     {
-      "id": 702,
+      "id": 691,
       "full_name": "TOKEN / USD",
       "description": "TokenFi",
       "type": "price-feed",
@@ -51200,7 +50723,7 @@
       }
     },
     {
-      "id": 703,
+      "id": 692,
       "full_name": "TOKEN / USDT",
       "description": "TokenFi",
       "type": "price-feed",
@@ -51255,7 +50778,7 @@
       }
     },
     {
-      "id": 704,
+      "id": 693,
       "full_name": "LINA / USD",
       "description": "Linear",
       "type": "price-feed",
@@ -51325,7 +50848,7 @@
       }
     },
     {
-      "id": 705,
+      "id": 694,
       "full_name": "LINA / USDT",
       "description": "Linear",
       "type": "price-feed",
@@ -51385,7 +50908,7 @@
       }
     },
     {
-      "id": 706,
+      "id": 695,
       "full_name": "TRUMP / USD",
       "description": "Official Trump",
       "type": "price-feed",
@@ -51553,7 +51076,7 @@
       }
     },
     {
-      "id": 707,
+      "id": 696,
       "full_name": "TRUMP / USDT",
       "description": "Official Trump",
       "type": "price-feed",
@@ -51646,7 +51169,7 @@
       }
     },
     {
-      "id": 708,
+      "id": 697,
       "full_name": "TRUMP / USDC",
       "description": "Official Trump",
       "type": "price-feed",
@@ -51714,7 +51237,7 @@
       }
     },
     {
-      "id": 709,
+      "id": 698,
       "full_name": "ULTI / USD",
       "description": "Ultiverse",
       "type": "price-feed",
@@ -51790,7 +51313,7 @@
       }
     },
     {
-      "id": 710,
+      "id": 699,
       "full_name": "ULTI / USDT",
       "description": "Ultiverse",
       "type": "price-feed",
@@ -51855,7 +51378,7 @@
       }
     },
     {
-      "id": 711,
+      "id": 700,
       "full_name": "ALPACA / USD",
       "description": "Alpaca Finance",
       "type": "price-feed",
@@ -51920,7 +51443,7 @@
       }
     },
     {
-      "id": 712,
+      "id": 701,
       "full_name": "ALPACA / USDT",
       "description": "Alpaca Finance",
       "type": "price-feed",
@@ -51975,7 +51498,7 @@
       }
     },
     {
-      "id": 713,
+      "id": 702,
       "full_name": "REN / USD",
       "description": "Ren",
       "type": "price-feed",
@@ -52073,7 +51596,7 @@
       }
     },
     {
-      "id": 714,
+      "id": 703,
       "full_name": "REN / USDT",
       "description": "Ren",
       "type": "price-feed",
@@ -52143,7 +51666,7 @@
       }
     },
     {
-      "id": 715,
+      "id": 704,
       "full_name": "MAVIA / USD",
       "description": "Heroes of Mavia",
       "type": "price-feed",
@@ -52219,7 +51742,7 @@
       }
     },
     {
-      "id": 716,
+      "id": 705,
       "full_name": "MAVIA / USDT",
       "description": "Heroes of Mavia",
       "type": "price-feed",
@@ -52284,7 +51807,7 @@
       }
     },
     {
-      "id": 717,
+      "id": 706,
       "full_name": "KLIMA / USD",
       "description": "",
       "type": "price-feed",
@@ -52339,7 +51862,7 @@
       }
     },
     {
-      "id": 718,
+      "id": 707,
       "full_name": "KLIMA / USDT",
       "description": "",
       "type": "price-feed",
@@ -52384,7 +51907,7 @@
       }
     },
     {
-      "id": 719,
+      "id": 708,
       "full_name": "SKY / USD",
       "description": "Sky",
       "type": "price-feed",
@@ -52449,7 +51972,7 @@
       }
     },
     {
-      "id": 720,
+      "id": 709,
       "full_name": "SKY / USDT",
       "description": "Sky",
       "type": "price-feed",
@@ -52494,7 +52017,7 @@
       }
     },
     {
-      "id": 721,
+      "id": 710,
       "full_name": "WELL / USD",
       "description": "Moonwell",
       "type": "price-feed",
@@ -52577,7 +52100,7 @@
       }
     },
     {
-      "id": 722,
+      "id": 711,
       "full_name": "WELL / USDT",
       "description": "Moonwell",
       "type": "price-feed",
@@ -52637,7 +52160,7 @@
       }
     },
     {
-      "id": 723,
+      "id": 712,
       "full_name": "FOXY / USD",
       "description": "Foxy",
       "type": "price-feed",
@@ -52704,7 +52227,7 @@
       }
     },
     {
-      "id": 724,
+      "id": 713,
       "full_name": "FOXY / USDT",
       "description": "Foxy",
       "type": "price-feed",
@@ -52759,7 +52282,7 @@
       }
     },
     {
-      "id": 725,
+      "id": 714,
       "full_name": "MELANIA / USD",
       "description": "Melania Meme",
       "type": "price-feed",
@@ -52844,7 +52367,7 @@
       }
     },
     {
-      "id": 726,
+      "id": 715,
       "full_name": "MELANIA / USDT",
       "description": "Melania Meme",
       "type": "price-feed",
@@ -52912,7 +52435,7 @@
       }
     },
     {
-      "id": 727,
+      "id": 716,
       "full_name": "MELANIA / USDC",
       "description": "Melania Meme",
       "type": "price-feed",
@@ -52960,7 +52483,7 @@
       }
     },
     {
-      "id": 728,
+      "id": 717,
       "full_name": "MICHI / USD",
       "description": "michi",
       "type": "price-feed",
@@ -53028,7 +52551,7 @@
       }
     },
     {
-      "id": 729,
+      "id": 718,
       "full_name": "MICHI / USDT",
       "description": "michi",
       "type": "price-feed",
@@ -53078,93 +52601,7 @@
       }
     },
     {
-      "id": 730,
-      "full_name": "AUSD / USD",
-      "description": "AUSD",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AUSD",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "AUSD"
-              ],
-              "id": [
-                32864
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AUSD / USD"
-        }
-      }
-    },
-    {
-      "id": 731,
-      "full_name": "USR / USD",
-      "description": "",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "USR",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "",
-        "market_hours": "",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "USR"
-              ],
-              "id": [
-                32873
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "USR / USD"
-        }
-      }
-    },
-    {
-      "id": 732,
+      "id": 719,
       "full_name": "NEIROETH / USD",
       "description": "Neiro",
       "type": "price-feed",
@@ -53215,7 +52652,7 @@
       }
     },
     {
-      "id": 733,
+      "id": 720,
       "full_name": "NEIROETH / USDT",
       "description": "Neiro",
       "type": "price-feed",
@@ -53260,7 +52697,7 @@
       }
     },
     {
-      "id": 734,
+      "id": 721,
       "full_name": "VVV / USD",
       "description": "Venice Token",
       "type": "price-feed",
@@ -53323,7 +52760,7 @@
       }
     },
     {
-      "id": 735,
+      "id": 722,
       "full_name": "VVV / USDT",
       "description": "Venice Token",
       "type": "price-feed",
@@ -53373,7 +52810,7 @@
       }
     },
     {
-      "id": 736,
+      "id": 723,
       "full_name": "IP / USD",
       "description": "Story",
       "type": "price-feed",
@@ -53458,7 +52895,7 @@
       }
     },
     {
-      "id": 737,
+      "id": 724,
       "full_name": "IP / USDT",
       "description": "Story",
       "type": "price-feed",
@@ -53523,7 +52960,7 @@
       }
     },
     {
-      "id": 738,
+      "id": 725,
       "full_name": "FTM / USD",
       "description": "Fantom",
       "type": "price-feed",
@@ -53582,7 +53019,7 @@
       }
     },
     {
-      "id": 739,
+      "id": 726,
       "full_name": "FTM / USDT",
       "description": "Fantom",
       "type": "price-feed",
@@ -53627,7 +53064,7 @@
       }
     },
     {
-      "id": 740,
+      "id": 727,
       "full_name": "FTM / USDC",
       "description": "Fantom",
       "type": "price-feed",
@@ -53667,7 +53104,7 @@
       }
     },
     {
-      "id": 741,
+      "id": 728,
       "full_name": "RNDR / USD",
       "description": "Render",
       "type": "price-feed",
@@ -53724,7 +53161,7 @@
       }
     },
     {
-      "id": 742,
+      "id": 729,
       "full_name": "RNDR / USDT",
       "description": "Render",
       "type": "price-feed",
@@ -53774,7 +53211,7 @@
       }
     },
     {
-      "id": 743,
+      "id": 730,
       "full_name": "RNDR / USDC",
       "description": "Render",
       "type": "price-feed",

--- a/config/feeds_config_new.json
+++ b/config/feeds_config_new.json
@@ -3671,49 +3671,6 @@
     },
     {
       "id": 40,
-      "full_name": "wstETH / USD",
-      "description": "wstETH",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "wstETH",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "WSTETH"
-              ],
-              "id": [
-                12409
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "wstETH/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 41,
       "full_name": "HBAR / USD",
       "description": "Hedera Hashgraph",
       "type": "price-feed",
@@ -3814,7 +3771,7 @@
       }
     },
     {
-      "id": 42,
+      "id": 41,
       "full_name": "HBAR / USDT",
       "description": "Hedera Hashgraph",
       "type": "price-feed",
@@ -3899,7 +3856,7 @@
       }
     },
     {
-      "id": 43,
+      "id": 42,
       "full_name": "HBAR / USDC",
       "description": "Hedera Hashgraph",
       "type": "price-feed",
@@ -3945,6 +3902,49 @@
         },
         "compatibility_info": {
           "chainlink": "HBAR / USD"
+        }
+      }
+    },
+    {
+      "id": 43,
+      "full_name": "WSTETH / USD",
+      "description": "Wrapped stETH",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "WSTETH",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "WSTETH"
+              ],
+              "id": [
+                12409
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "WSTETH/USD-RefPrice-mainnet-production"
         }
       }
     },
@@ -4693,944 +4693,6 @@
     },
     {
       "id": 53,
-      "full_name": "SUI / USD",
-      "description": "Sui",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SUI",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "SUIUSDC",
-                "SUIUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "SUIUSDT"
-              ]
-            },
-            "Bitfinex": {
-              "symbol": [
-                "SUIUSD"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "SUIUSDC_SPBL",
-                "SUIUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "SUIUSDC",
-                "SUIUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "SUI-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "SUIUSD-PERP",
-                "SUI_USD",
-                "SUI_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "SUI_USDC",
-                "SUI_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "SUIUSD"
-              ],
-              "wsname": [
-                "SUI/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "SUI-USDC",
-                "SUI-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "SUIUSDC",
-                "SUIUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "SUI-USD",
-                "SUI-USDC",
-                "SUI-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "SUI"
-              ],
-              "id": [
-                20947
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SUI/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 54,
-      "full_name": "SUI / USDT",
-      "description": "Sui",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SUI",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "SUIUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "SUIUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "SUIUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "SUIUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "SUI_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "SUI_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "SUI-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "SUIUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "SUI-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SUI/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 55,
-      "full_name": "SUI / USDC",
-      "description": "Sui",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SUI",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "SUIUSDC"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "SUIUSDC_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "SUIUSDC"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "SUI_USDC"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "SUI-USDC"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "SUIUSDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "SUI-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SUI/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 56,
-      "full_name": "BCH / BNB",
-      "description": "Bitcoin Cash",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "BCH",
-          "quote": "BNB"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "BCHBNB"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "BCH / BNB"
-        }
-      }
-    },
-    {
-      "id": 57,
-      "full_name": "BCH / USD",
-      "description": "Bitcoin Cash",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "BCH",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "BCHUSDC",
-                "BCHUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "BCHUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "BCHUSDC_SPBL",
-                "BCHUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "BCHUSDC",
-                "BCHUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "BCH-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "BCHUSD-PERP",
-                "BCH_USD",
-                "BCH_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "BCH_USDC",
-                "BCH_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "BCHUSD"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "BCHUSD",
-                "BCHUSDC",
-                "BCHUSDT"
-              ],
-              "wsname": [
-                "BCH/USD",
-                "BCH/USDC",
-                "BCH/USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "BCH-USDC",
-                "BCH-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "BCHUSDC",
-                "BCHUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "BCH-USDC",
-                "BCH-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-BCH"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "BCH"
-              ],
-              "id": [
-                1831
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "BCH / USD"
-        }
-      }
-    },
-    {
-      "id": 58,
-      "full_name": "BCH / USDT",
-      "description": "Bitcoin Cash",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "BCH",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "BCHUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "BCHUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "BCHUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "BCHUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "BCH_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "BCH_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "BCHUSDT"
-              ],
-              "wsname": [
-                "BCH/USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "BCH-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "BCHUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "BCH-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-BCH"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "BCH / USD"
-        }
-      }
-    },
-    {
-      "id": 59,
-      "full_name": "BCH / USDC",
-      "description": "Bitcoin Cash",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "BCH",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "BCHUSDC"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "BCHUSDC_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "BCHUSDC"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "BCH_USDC"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "BCHUSDC"
-              ],
-              "wsname": [
-                "BCH/USDC"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "BCH-USDC"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "BCHUSDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "BCH-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "BCH / USD"
-        }
-      }
-    },
-    {
-      "id": 60,
-      "full_name": "LTC / BNB",
-      "description": "Litecoin",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "LTC",
-          "quote": "BNB"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "LTCBNB"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "LTC / BNB"
-        }
-      }
-    },
-    {
-      "id": 61,
-      "full_name": "LTC / USD",
-      "description": "Litecoin",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "LTC",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "LTCUSDC",
-                "LTCUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "LTCUSDT"
-              ]
-            },
-            "Bitfinex": {
-              "symbol": [
-                "LTCUSD"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "LTCUSDC_SPBL",
-                "LTCUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "LTCUSDC",
-                "LTCUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "LTC-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "LTCUSD-PERP",
-                "LTC_USD",
-                "LTC_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "LTC_USDC",
-                "LTC_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "LTCUSD"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "LTCUSDC",
-                "LTCUSDT",
-                "XLTCZUSD"
-              ],
-              "wsname": [
-                "LTC/USD",
-                "LTC/USDC",
-                "LTC/USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "LTC-USDC",
-                "LTC-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "LTCUSDC",
-                "LTCUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "LTC-USD",
-                "LTC-USDC",
-                "LTC-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "LTC"
-              ],
-              "id": [
-                2
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "LTC / USD"
-        }
-      }
-    },
-    {
-      "id": 62,
-      "full_name": "LTC / USDT",
-      "description": "Litecoin",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "LTC",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "LTCUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "LTCUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "LTCUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "LTCUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "LTC_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "LTC_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "LTCUSDT"
-              ],
-              "wsname": [
-                "LTC/USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "LTC-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "LTCUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "LTC-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "LTC / USD"
-        }
-      }
-    },
-    {
-      "id": 63,
-      "full_name": "LTC / USDC",
-      "description": "Litecoin",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "LTC",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "LTCUSDC"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "LTCUSDC_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "LTCUSDC"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "LTC_USDC"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "LTCUSDC"
-              ],
-              "wsname": [
-                "LTC/USDC"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "LTC-USDC"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "LTCUSDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "LTC-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "LTC / USD"
-        }
-      }
-    },
-    {
-      "id": 64,
       "full_name": "SHIB / USD",
       "description": "Shiba Inu",
       "type": "price-feed",
@@ -5773,7 +4835,7 @@
       }
     },
     {
-      "id": 65,
+      "id": 54,
       "full_name": "SHIB / USDT",
       "description": "Shiba Inu",
       "type": "price-feed",
@@ -5871,7 +4933,7 @@
       }
     },
     {
-      "id": 66,
+      "id": 55,
       "full_name": "SHIB / USDC",
       "description": "Shiba Inu",
       "type": "price-feed",
@@ -5945,6 +5007,944 @@
         },
         "compatibility_info": {
           "chainlink": "SHIB / USD"
+        }
+      }
+    },
+    {
+      "id": 56,
+      "full_name": "SUI / USD",
+      "description": "Sui",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "SUI",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "SUIUSDC",
+                "SUIUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "SUIUSDT"
+              ]
+            },
+            "Bitfinex": {
+              "symbol": [
+                "SUIUSD"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "SUIUSDC_SPBL",
+                "SUIUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "SUIUSDC",
+                "SUIUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "SUI-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "SUIUSD-PERP",
+                "SUI_USD",
+                "SUI_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "SUI_USDC",
+                "SUI_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "SUIUSD"
+              ],
+              "wsname": [
+                "SUI/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "SUI-USDC",
+                "SUI-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "SUIUSDC",
+                "SUIUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "SUI-USD",
+                "SUI-USDC",
+                "SUI-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "SUI"
+              ],
+              "id": [
+                20947
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "SUI/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 57,
+      "full_name": "SUI / USDT",
+      "description": "Sui",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "SUI",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "SUIUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "SUIUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "SUIUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "SUIUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "SUI_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "SUI_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "SUI-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "SUIUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "SUI-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "SUI/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 58,
+      "full_name": "SUI / USDC",
+      "description": "Sui",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "SUI",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "SUIUSDC"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "SUIUSDC_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "SUIUSDC"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "SUI_USDC"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "SUI-USDC"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "SUIUSDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "SUI-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "SUI/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 59,
+      "full_name": "BCH / BNB",
+      "description": "Bitcoin Cash",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "BCH",
+          "quote": "BNB"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "BCHBNB"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "BCH / BNB"
+        }
+      }
+    },
+    {
+      "id": 60,
+      "full_name": "BCH / USD",
+      "description": "Bitcoin Cash",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "BCH",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "BCHUSDC",
+                "BCHUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "BCHUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "BCHUSDC_SPBL",
+                "BCHUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "BCHUSDC",
+                "BCHUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "BCH-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "BCHUSD-PERP",
+                "BCH_USD",
+                "BCH_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "BCH_USDC",
+                "BCH_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "BCHUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "BCHUSD",
+                "BCHUSDC",
+                "BCHUSDT"
+              ],
+              "wsname": [
+                "BCH/USD",
+                "BCH/USDC",
+                "BCH/USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "BCH-USDC",
+                "BCH-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "BCHUSDC",
+                "BCHUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "BCH-USDC",
+                "BCH-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-BCH"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "BCH"
+              ],
+              "id": [
+                1831
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "BCH / USD"
+        }
+      }
+    },
+    {
+      "id": 61,
+      "full_name": "BCH / USDT",
+      "description": "Bitcoin Cash",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "BCH",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "BCHUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "BCHUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "BCHUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "BCHUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "BCH_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "BCH_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "BCHUSDT"
+              ],
+              "wsname": [
+                "BCH/USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "BCH-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "BCHUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "BCH-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-BCH"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "BCH / USD"
+        }
+      }
+    },
+    {
+      "id": 62,
+      "full_name": "BCH / USDC",
+      "description": "Bitcoin Cash",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "BCH",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "BCHUSDC"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "BCHUSDC_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "BCHUSDC"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "BCH_USDC"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "BCHUSDC"
+              ],
+              "wsname": [
+                "BCH/USDC"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "BCH-USDC"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "BCHUSDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "BCH-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "BCH / USD"
+        }
+      }
+    },
+    {
+      "id": 63,
+      "full_name": "LTC / BNB",
+      "description": "Litecoin",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "LTC",
+          "quote": "BNB"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "LTCBNB"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "LTC / BNB"
+        }
+      }
+    },
+    {
+      "id": 64,
+      "full_name": "LTC / USD",
+      "description": "Litecoin",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "LTC",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "LTCUSDC",
+                "LTCUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "LTCUSDT"
+              ]
+            },
+            "Bitfinex": {
+              "symbol": [
+                "LTCUSD"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "LTCUSDC_SPBL",
+                "LTCUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "LTCUSDC",
+                "LTCUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "LTC-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "LTCUSD-PERP",
+                "LTC_USD",
+                "LTC_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "LTC_USDC",
+                "LTC_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "LTCUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "LTCUSDC",
+                "LTCUSDT",
+                "XLTCZUSD"
+              ],
+              "wsname": [
+                "LTC/USD",
+                "LTC/USDC",
+                "LTC/USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "LTC-USDC",
+                "LTC-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "LTCUSDC",
+                "LTCUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "LTC-USD",
+                "LTC-USDC",
+                "LTC-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "LTC"
+              ],
+              "id": [
+                2
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "LTC / USD"
+        }
+      }
+    },
+    {
+      "id": 65,
+      "full_name": "LTC / USDT",
+      "description": "Litecoin",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "LTC",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "LTCUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "LTCUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "LTCUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "LTCUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "LTC_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "LTC_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "LTCUSDT"
+              ],
+              "wsname": [
+                "LTC/USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "LTC-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "LTCUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "LTC-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "LTC / USD"
+        }
+      }
+    },
+    {
+      "id": 66,
+      "full_name": "LTC / USDC",
+      "description": "Litecoin",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "LTC",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "LTCUSDC"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "LTCUSDC_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "LTCUSDC"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "LTC_USDC"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "LTCUSDC"
+              ],
+              "wsname": [
+                "LTC/USDC"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "LTC-USDC"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "LTCUSDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "LTC-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "LTC / USD"
         }
       }
     },
@@ -6196,6 +6196,223 @@
     },
     {
       "id": 70,
+      "full_name": "OM / USD",
+      "description": "MANTRA",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "OM",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "OMUSDC",
+                "OMUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "OMUSDC_SPBL",
+                "OMUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "OMUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "OMUSD-PERP",
+                "OM_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "OM_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "OMUSD"
+              ],
+              "wsname": [
+                "OM/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "OM-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "OMUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "OM-USDC",
+                "OM-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "OM"
+              ],
+              "id": [
+                6536
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "OM/USD-RefPrice-mainnet-production"
+        }
+      }
+    },
+    {
+      "id": 71,
+      "full_name": "OM / USDT",
+      "description": "MANTRA",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "OM",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "OMUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "OMUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "OMUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "OM_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "OM-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "OMUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "OM-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "OM/USD-RefPrice-mainnet-production"
+        }
+      }
+    },
+    {
+      "id": 72,
+      "full_name": "OM / USDC",
+      "description": "MANTRA",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "OM",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "OMUSDC"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "OMUSDC_SPBL"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "OM-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "OM/USD-RefPrice-mainnet-production"
+        }
+      }
+    },
+    {
+      "id": 73,
       "full_name": "DOT / USD",
       "description": "Polkadot",
       "type": "price-feed",
@@ -6321,7 +6538,7 @@
       }
     },
     {
-      "id": 71,
+      "id": 74,
       "full_name": "DOT / BNB",
       "description": "Polkadot",
       "type": "price-feed",
@@ -6361,7 +6578,7 @@
       }
     },
     {
-      "id": 72,
+      "id": 75,
       "full_name": "DOT / USDT",
       "description": "Polkadot",
       "type": "price-feed",
@@ -6454,7 +6671,7 @@
       }
     },
     {
-      "id": 73,
+      "id": 76,
       "full_name": "DOT / USDC",
       "description": "Polkadot",
       "type": "price-feed",
@@ -6523,223 +6740,6 @@
         },
         "compatibility_info": {
           "chainlink": "DOT / USD"
-        }
-      }
-    },
-    {
-      "id": 74,
-      "full_name": "OM / USD",
-      "description": "MANTRA",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "OM",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "OMUSDC",
-                "OMUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "OMUSDC_SPBL",
-                "OMUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "OMUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "OMUSD-PERP",
-                "OM_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "OM_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "OMUSD"
-              ],
-              "wsname": [
-                "OM/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "OM-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "OMUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "OM-USDC",
-                "OM-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "OM"
-              ],
-              "id": [
-                6536
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "OM/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 75,
-      "full_name": "OM / USDT",
-      "description": "MANTRA",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "OM",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "OMUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "OMUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "OMUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "OM_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "OM-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "OMUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "OM-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "OM/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 76,
-      "full_name": "OM / USDC",
-      "description": "MANTRA",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "OM",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "OMUSDC"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "OMUSDC_SPBL"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "OM-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "OM/USD-RefPrice-mainnet-production"
         }
       }
     },
@@ -8638,1068 +8638,6 @@
     },
     {
       "id": 104,
-      "full_name": "ETC / USD",
-      "description": "Ethereum",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ETC",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ETCUSDC",
-                "ETCUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "ETCUSDT"
-              ]
-            },
-            "Bitfinex": {
-              "symbol": [
-                "ETCUSD"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ETCUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ETCUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "ETC-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ETCUSD-PERP",
-                "ETC_USD",
-                "ETC_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ETC_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "XETCZUSD"
-              ],
-              "wsname": [
-                "ETC/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ETC-USDC",
-                "ETC-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ETCUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ETC-USDC",
-                "ETC-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-ETC"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "ETC"
-              ],
-              "id": [
-                1321
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ETC / USD"
-        }
-      }
-    },
-    {
-      "id": 105,
-      "full_name": "ETC / USDT",
-      "description": "Ethereum",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ETC",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ETCUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "ETCUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ETCUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ETCUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ETC_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ETC_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ETC-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ETCUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ETC-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-ETC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ETC / USD"
-        }
-      }
-    },
-    {
-      "id": 106,
-      "full_name": "ETC / USDC",
-      "description": "Ethereum",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ETC",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ETCUSDC"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ETC-USDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ETC-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ETC / USD"
-        }
-      }
-    },
-    {
-      "id": 107,
-      "full_name": "AAVE / USD",
-      "description": "Aave",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AAVE",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "AAVEUSDC",
-                "AAVEUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "AAVEUSDT"
-              ]
-            },
-            "Bitfinex": {
-              "symbol": [
-                "AAVE:USD"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "AAVEUSDC_SPBL",
-                "AAVEUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "AAVEUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "AAVE-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "AAVEUSD-PERP",
-                "AAVE_USD",
-                "AAVE_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "AAVE_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "AAVEUSD"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "AAVEUSD"
-              ],
-              "wsname": [
-                "AAVE/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "AAVE-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "AAVEUSDC",
-                "AAVEUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "AAVE-USD",
-                "AAVE-USDC",
-                "AAVE-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "AAVE"
-              ],
-              "id": [
-                7278
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AAVE / USD"
-        }
-      }
-    },
-    {
-      "id": 108,
-      "full_name": "AAVE / ETH",
-      "description": "Aave",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AAVE",
-          "quote": "ETH"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "AAVEETH"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "AAVE_ETH"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "AAVEETH"
-              ],
-              "wsname": [
-                "AAVE/ETH"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AAVE / ETH"
-        }
-      }
-    },
-    {
-      "id": 109,
-      "full_name": "AAVE / USDT",
-      "description": "Aave",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AAVE",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "AAVEUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "AAVEUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "AAVEUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "AAVEUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "AAVE_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "AAVE_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "AAVE-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "AAVEUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "AAVE-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AAVE / USD"
-        }
-      }
-    },
-    {
-      "id": 110,
-      "full_name": "AAVE / USDC",
-      "description": "Aave",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AAVE",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "AAVEUSDC"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "AAVEUSDC_SPBL"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "AAVEUSDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "AAVE-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AAVE / USD"
-        }
-      }
-    },
-    {
-      "id": 111,
-      "full_name": "ONDO / USD",
-      "description": "Ondo",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ONDO",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "ONDOUSDC_SPBL",
-                "ONDOUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ONDOUSDC",
-                "ONDOUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "ONDO-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ONDOUSD-PERP",
-                "ONDO_USD",
-                "ONDO_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ONDO_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "ONDOUSD"
-              ],
-              "wsname": [
-                "ONDO/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ONDO-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ONDOUSDC",
-                "ONDOUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ONDO-USDC",
-                "ONDO-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-ONDO"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "ONDO"
-              ],
-              "id": [
-                21159
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ONDO/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 112,
-      "full_name": "ONDO / USDT",
-      "description": "Ondo",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ONDO",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "ONDOUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ONDOUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ONDO_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ONDO_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ONDO-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ONDOUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ONDO-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-ONDO"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ONDO/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 113,
-      "full_name": "ONDO / USDC",
-      "description": "Ondo",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ONDO",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "ONDOUSDC_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ONDOUSDC"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ONDOUSDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ONDO-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ONDO/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 114,
-      "full_name": "ICP / USD",
-      "description": "Internet Computer Protocol",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ICP",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ICPUSDC",
-                "ICPUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "ICPUSDT"
-              ]
-            },
-            "Bitfinex": {
-              "symbol": [
-                "ICPUSD"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ICPUSDC_SPBL",
-                "ICPUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ICPUSDC",
-                "ICPUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "ICP-USD",
-                "ICP-USDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ICPUSD-PERP",
-                "ICP_USD",
-                "ICP_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ICP_USDC",
-                "ICP_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "ICPUSD"
-              ],
-              "wsname": [
-                "ICP/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ICP-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ICPUSDC",
-                "ICPUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ICP-USDC",
-                "ICP-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "ICP"
-              ],
-              "id": [
-                8916
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ICP / USD"
-        }
-      }
-    },
-    {
-      "id": 115,
-      "full_name": "ICP / USDT",
-      "description": "Internet Computer Protocol",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ICP",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ICPUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "ICPUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ICPUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ICPUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "ICP-USDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ICP_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ICP_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ICP-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ICPUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ICP-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ICP / USD"
-        }
-      }
-    },
-    {
-      "id": 116,
-      "full_name": "ICP / USDC",
-      "description": "Internet Computer Protocol",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ICP",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ICPUSDC"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ICPUSDC_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ICPUSDC"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ICP_USDC"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ICPUSDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ICP-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ICP / USD"
-        }
-      }
-    },
-    {
-      "id": 117,
       "full_name": "PEPE / USD",
       "description": "PEPE",
       "type": "price-feed",
@@ -9872,7 +8810,7 @@
       }
     },
     {
-      "id": 118,
+      "id": 105,
       "full_name": "PEPE / USDT",
       "description": "PEPE",
       "type": "price-feed",
@@ -9962,7 +8900,7 @@
       }
     },
     {
-      "id": 119,
+      "id": 106,
       "full_name": "PEPE / USDC",
       "description": "PEPE",
       "type": "price-feed",
@@ -10028,6 +8966,1074 @@
         },
         "compatibility_info": {
           "chainlink": "PEPE/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 107,
+      "full_name": "ETC / USD",
+      "description": "Ethereum",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ETC",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ETCUSDC",
+                "ETCUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "ETCUSDT"
+              ]
+            },
+            "Bitfinex": {
+              "symbol": [
+                "ETCUSD"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ETCUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ETCUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "ETC-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ETCUSD-PERP",
+                "ETC_USD",
+                "ETC_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ETC_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "XETCZUSD"
+              ],
+              "wsname": [
+                "ETC/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ETC-USDC",
+                "ETC-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ETCUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ETC-USDC",
+                "ETC-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-ETC"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "ETC"
+              ],
+              "id": [
+                1321
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ETC / USD"
+        }
+      }
+    },
+    {
+      "id": 108,
+      "full_name": "ETC / USDT",
+      "description": "Ethereum",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ETC",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ETCUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "ETCUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ETCUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ETCUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ETC_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ETC_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ETC-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ETCUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ETC-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-ETC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ETC / USD"
+        }
+      }
+    },
+    {
+      "id": 109,
+      "full_name": "ETC / USDC",
+      "description": "Ethereum",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ETC",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ETCUSDC"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ETC-USDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ETC-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ETC / USD"
+        }
+      }
+    },
+    {
+      "id": 110,
+      "full_name": "ONDO / USD",
+      "description": "Ondo",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ONDO",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "ONDOUSDC_SPBL",
+                "ONDOUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ONDOUSDC",
+                "ONDOUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "ONDO-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ONDOUSD-PERP",
+                "ONDO_USD",
+                "ONDO_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ONDO_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "ONDOUSD"
+              ],
+              "wsname": [
+                "ONDO/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ONDO-USDC",
+                "ONDO-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ONDOUSDC",
+                "ONDOUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ONDO-USDC",
+                "ONDO-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-ONDO"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "ONDO"
+              ],
+              "id": [
+                21159
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ONDO/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 111,
+      "full_name": "ONDO / USDT",
+      "description": "Ondo",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ONDO",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "ONDOUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ONDOUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ONDO_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ONDO_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ONDO-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ONDOUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ONDO-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-ONDO"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ONDO/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 112,
+      "full_name": "ONDO / USDC",
+      "description": "Ondo",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ONDO",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "ONDOUSDC_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ONDOUSDC"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ONDO-USDC"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ONDOUSDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ONDO-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ONDO/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 113,
+      "full_name": "ICP / USD",
+      "description": "Internet Computer Protocol",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ICP",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ICPUSDC",
+                "ICPUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "ICPUSDT"
+              ]
+            },
+            "Bitfinex": {
+              "symbol": [
+                "ICPUSD"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ICPUSDC_SPBL",
+                "ICPUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ICPUSDC",
+                "ICPUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "ICP-USD",
+                "ICP-USDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ICPUSD-PERP",
+                "ICP_USD",
+                "ICP_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ICP_USDC",
+                "ICP_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "ICPUSD"
+              ],
+              "wsname": [
+                "ICP/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ICP-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ICPUSDC",
+                "ICPUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ICP-USDC",
+                "ICP-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "ICP"
+              ],
+              "id": [
+                8916
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ICP / USD"
+        }
+      }
+    },
+    {
+      "id": 114,
+      "full_name": "ICP / USDT",
+      "description": "Internet Computer Protocol",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ICP",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ICPUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "ICPUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ICPUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ICPUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "ICP-USDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ICP_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ICP_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ICP-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ICPUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ICP-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ICP / USD"
+        }
+      }
+    },
+    {
+      "id": 115,
+      "full_name": "ICP / USDC",
+      "description": "Internet Computer Protocol",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ICP",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ICPUSDC"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ICPUSDC_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ICPUSDC"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ICP_USDC"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ICPUSDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ICP-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ICP / USD"
+        }
+      }
+    },
+    {
+      "id": 116,
+      "full_name": "AAVE / USD",
+      "description": "Aave",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AAVE",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "AAVEUSDC",
+                "AAVEUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "AAVEUSDT"
+              ]
+            },
+            "Bitfinex": {
+              "symbol": [
+                "AAVE:USD"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "AAVEUSDC_SPBL",
+                "AAVEUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "AAVEUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "AAVE-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "AAVEUSD-PERP",
+                "AAVE_USD",
+                "AAVE_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "AAVE_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "AAVEUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "AAVEUSD"
+              ],
+              "wsname": [
+                "AAVE/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "AAVE-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "AAVEUSDC",
+                "AAVEUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "AAVE-USD",
+                "AAVE-USDC",
+                "AAVE-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "AAVE"
+              ],
+              "id": [
+                7278
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AAVE / USD"
+        }
+      }
+    },
+    {
+      "id": 117,
+      "full_name": "AAVE / ETH",
+      "description": "Aave",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AAVE",
+          "quote": "ETH"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "AAVEETH"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "AAVE_ETH"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "AAVEETH"
+              ],
+              "wsname": [
+                "AAVE/ETH"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AAVE / ETH"
+        }
+      }
+    },
+    {
+      "id": 118,
+      "full_name": "AAVE / USDT",
+      "description": "Aave",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AAVE",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "AAVEUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "AAVEUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "AAVEUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "AAVEUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "AAVE_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "AAVE_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "AAVE-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "AAVEUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "AAVE-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AAVE / USD"
+        }
+      }
+    },
+    {
+      "id": 119,
+      "full_name": "AAVE / USDC",
+      "description": "Aave",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AAVE",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "AAVEUSDC"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "AAVEUSDC_SPBL"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "AAVEUSDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "AAVE-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AAVE / USD"
         }
       }
     },
@@ -10214,163 +10220,6 @@
     },
     {
       "id": 123,
-      "full_name": "VET / USD",
-      "description": "VeChain",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "VET",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "VETUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "VETUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "VETUSDT_SPBL"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "VET-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "VETUSD-PERP",
-                "VET_USD",
-                "VET_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "VET_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "VET-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "VETUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "VET"
-              ],
-              "id": [
-                3077
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "VET / USD"
-        }
-      }
-    },
-    {
-      "id": 124,
-      "full_name": "VET / USDT",
-      "description": "VeChain",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "VET",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "VETUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "VETUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "VETUSDT_SPBL"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "VET_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "VET_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "VET-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "VETUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "VET / USD"
-        }
-      }
-    },
-    {
-      "id": 125,
       "full_name": "cbBTC / USD",
       "description": "Coinbase Wrapped BTC",
       "type": "price-feed",
@@ -10413,184 +10262,7 @@
       }
     },
     {
-      "id": 126,
-      "full_name": "FDUSD / USD",
-      "description": "First Digital USD",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "FDUSD",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "FDUSDUSDC",
-                "FDUSDUSDT"
-              ]
-            },
-            "BinanceTR": {
-              "symbol": [
-                "FDUSD_USDC",
-                "FDUSD_USDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "FDUSDUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "FDUSD_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "FDUSDUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "FDUSD"
-              ],
-              "id": [
-                26081
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "FDUSD / USD"
-        }
-      }
-    },
-    {
-      "id": 127,
-      "full_name": "FDUSD / USDT",
-      "description": "First Digital USD",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "FDUSD",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "FDUSDUSDT"
-              ]
-            },
-            "BinanceTR": {
-              "symbol": [
-                "FDUSD_USDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "FDUSDUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "FDUSD_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "FDUSDUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "FDUSD / USD"
-        }
-      }
-    },
-    {
-      "id": 128,
-      "full_name": "FDUSD / USDC",
-      "description": "First Digital USD",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "FDUSD",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "FDUSDUSDC"
-              ]
-            },
-            "BinanceTR": {
-              "symbol": [
-                "FDUSD_USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "FDUSD / USD"
-        }
-      }
-    },
-    {
-      "id": 129,
+      "id": 124,
       "full_name": "TAO / USD",
       "description": "Bittensor",
       "type": "price-feed",
@@ -10682,7 +10354,7 @@
       }
     },
     {
-      "id": 130,
+      "id": 125,
       "full_name": "TAO / USDT",
       "description": "Bittensor",
       "type": "price-feed",
@@ -10742,7 +10414,7 @@
       }
     },
     {
-      "id": 131,
+      "id": 126,
       "full_name": "TAO / USDC",
       "description": "Bittensor",
       "type": "price-feed",
@@ -10792,7 +10464,580 @@
       }
     },
     {
+      "id": 127,
+      "full_name": "VET / USD",
+      "description": "VeChain",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "VET",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "VETUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "VETUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "VETUSDT_SPBL"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "VET-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "VETUSD-PERP",
+                "VET_USD",
+                "VET_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "VET_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "VET-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "VETUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "VET"
+              ],
+              "id": [
+                3077
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "VET / USD"
+        }
+      }
+    },
+    {
+      "id": 128,
+      "full_name": "VET / USDT",
+      "description": "VeChain",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "VET",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "VETUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "VETUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "VETUSDT_SPBL"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "VET_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "VET_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "VET-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "VETUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "VET / USD"
+        }
+      }
+    },
+    {
+      "id": 129,
+      "full_name": "FDUSD / USD",
+      "description": "First Digital USD",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "FDUSD",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "FDUSDUSDC",
+                "FDUSDUSDT"
+              ]
+            },
+            "BinanceTR": {
+              "symbol": [
+                "FDUSD_USDC",
+                "FDUSD_USDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "FDUSDUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "FDUSD_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "FDUSDUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "FDUSD"
+              ],
+              "id": [
+                26081
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "FDUSD / USD"
+        }
+      }
+    },
+    {
+      "id": 130,
+      "full_name": "FDUSD / USDT",
+      "description": "First Digital USD",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "FDUSD",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "FDUSDUSDT"
+              ]
+            },
+            "BinanceTR": {
+              "symbol": [
+                "FDUSD_USDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "FDUSDUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "FDUSD_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "FDUSDUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "FDUSD / USD"
+        }
+      }
+    },
+    {
+      "id": 131,
+      "full_name": "FDUSD / USDC",
+      "description": "First Digital USD",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "FDUSD",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "FDUSDUSDC"
+              ]
+            },
+            "BinanceTR": {
+              "symbol": [
+                "FDUSD_USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "FDUSD / USD"
+        }
+      }
+    },
+    {
       "id": 132,
+      "full_name": "TIA / USD",
+      "description": "Celestia",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "TIA",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "TIAUSDC",
+                "TIAUSDT"
+              ]
+            },
+            "Bitfinex": {
+              "symbol": [
+                "TIAUSD"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "TIAUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "TIAUSDC",
+                "TIAUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "TIA-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "TIAUSD-PERP",
+                "TIA_USD",
+                "TIA_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "TIA_USDC",
+                "TIA_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "TIAUSD"
+              ],
+              "wsname": [
+                "TIA/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "TIA-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "TIAUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "TIA-USDC",
+                "TIA-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "TIA"
+              ],
+              "id": [
+                22861
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "TIA/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 133,
+      "full_name": "TIA / USDT",
+      "description": "Celestia",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "TIA",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "TIAUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "TIAUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "TIAUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "TIA_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "TIA_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "TIA-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "TIAUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "TIA-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "TIA/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 134,
+      "full_name": "TIA / USDC",
+      "description": "Celestia",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "TIA",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "TIAUSDC"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "TIAUSDC"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "TIA_USDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "TIA-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "TIA/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 135,
       "full_name": "POL / USD",
       "description": "POL",
       "type": "price-feed",
@@ -10905,7 +11150,7 @@
       }
     },
     {
-      "id": 133,
+      "id": 136,
       "full_name": "POL / ETH",
       "description": "Polygon",
       "type": "price-feed",
@@ -10950,7 +11195,7 @@
       }
     },
     {
-      "id": 134,
+      "id": 137,
       "full_name": "POL / USDT",
       "description": "POL",
       "type": "price-feed",
@@ -11030,7 +11275,7 @@
       }
     },
     {
-      "id": 135,
+      "id": 138,
       "full_name": "POL / USDC",
       "description": "POL",
       "type": "price-feed",
@@ -11080,7 +11325,7 @@
       }
     },
     {
-      "id": 136,
+      "id": 139,
       "full_name": "FIL / USD",
       "description": "Filecoin",
       "type": "price-feed",
@@ -11206,7 +11451,7 @@
       }
     },
     {
-      "id": 137,
+      "id": 140,
       "full_name": "FIL / ETH",
       "description": "Filecoin",
       "type": "price-feed",
@@ -11264,7 +11509,7 @@
       }
     },
     {
-      "id": 138,
+      "id": 141,
       "full_name": "FIL / USDT",
       "description": "Filecoin",
       "type": "price-feed",
@@ -11349,7 +11594,7 @@
       }
     },
     {
-      "id": 139,
+      "id": 142,
       "full_name": "FIL / USDC",
       "description": "Filecoin",
       "type": "price-feed",
@@ -11414,7 +11659,99 @@
       }
     },
     {
-      "id": 140,
+      "id": 143,
+      "full_name": "LBTC / USD",
+      "description": "LOMBARD STAKED BTC",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "LBTC",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "MEXC": {
+              "symbol": [
+                "LBTCUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "LBTC",
+                "LBTC"
+              ],
+              "id": [
+                2335,
+                33652
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "LBTC/USD-RefPrice-mainnet-production"
+        }
+      }
+    },
+    {
+      "id": 144,
+      "full_name": "LBTC / USDT",
+      "description": "LOMBARD STAKED BTC",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "LBTC",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "MEXC": {
+              "symbol": [
+                "LBTCUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "LBTC/USD-RefPrice-mainnet-production"
+        }
+      }
+    },
+    {
+      "id": 145,
       "full_name": "ALGO / USD",
       "description": "Algorand",
       "type": "price-feed",
@@ -11529,7 +11866,7 @@
       }
     },
     {
-      "id": 141,
+      "id": 146,
       "full_name": "ALGO / USDT",
       "description": "Algorand",
       "type": "price-feed",
@@ -11617,7 +11954,7 @@
       }
     },
     {
-      "id": 142,
+      "id": 147,
       "full_name": "ALGO / USDC",
       "description": "Algorand",
       "type": "price-feed",
@@ -11686,339 +12023,6 @@
         },
         "compatibility_info": {
           "chainlink": "ALGO/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 143,
-      "full_name": "TIA / USD",
-      "description": "Celestia",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "TIA",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "TIAUSDC",
-                "TIAUSDT"
-              ]
-            },
-            "Bitfinex": {
-              "symbol": [
-                "TIAUSD"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "TIAUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "TIAUSDC",
-                "TIAUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "TIA-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "TIAUSD-PERP",
-                "TIA_USD",
-                "TIA_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "TIA_USDC",
-                "TIA_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "TIAUSD"
-              ],
-              "wsname": [
-                "TIA/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "TIA-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "TIAUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "TIA-USDC",
-                "TIA-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "TIA",
-                "TIA"
-              ],
-              "id": [
-                18411,
-                22861
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "TIA/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 144,
-      "full_name": "TIA / USDT",
-      "description": "Celestia",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "TIA",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "TIAUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "TIAUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "TIAUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "TIA_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "TIA_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "TIA-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "TIAUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "TIA-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "TIA/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 145,
-      "full_name": "TIA / USDC",
-      "description": "Celestia",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "TIA",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "TIAUSDC"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "TIAUSDC"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "TIA_USDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "TIA-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "TIA/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 146,
-      "full_name": "LBTC / USD",
-      "description": "LOMBARD STAKED BTC",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "LBTC",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "MEXC": {
-              "symbol": [
-                "LBTCUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "LBTC",
-                "LBTC"
-              ],
-              "id": [
-                2335,
-                33652
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "LBTC/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 147,
-      "full_name": "LBTC / USDT",
-      "description": "LOMBARD STAKED BTC",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "LBTC",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "MEXC": {
-              "symbol": [
-                "LBTCUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "LBTC/USD-RefPrice-mainnet-production"
         }
       }
     },
@@ -12273,6 +12277,295 @@
     },
     {
       "id": 151,
+      "full_name": "ATOM / USD",
+      "description": "Cosmos",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ATOM",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ATOMUSDC",
+                "ATOMUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "ATOMUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ATOMUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ATOMUSDC",
+                "ATOMUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "ATOM-USD",
+                "ATOM-USDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ATOMUSD-PERP",
+                "ATOM_USD",
+                "ATOM_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ATOM_USDC",
+                "ATOM_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "ATOMUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "ATOMUSD",
+                "ATOMUSDC",
+                "ATOMUSDT"
+              ],
+              "wsname": [
+                "ATOM/USD",
+                "ATOM/USDC",
+                "ATOM/USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ATOM-USDC",
+                "ATOM-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ATOMUSDC",
+                "ATOMUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ATOM-USDC",
+                "ATOM-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "ATOM",
+                "ATOM"
+              ],
+              "id": [
+                30019,
+                3794
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ATOM / USD"
+        }
+      }
+    },
+    {
+      "id": 152,
+      "full_name": "ATOM / USDT",
+      "description": "Cosmos",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ATOM",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ATOMUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "ATOMUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ATOMUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ATOMUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "ATOM-USDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ATOM_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ATOM_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "ATOMUSDT"
+              ],
+              "wsname": [
+                "ATOM/USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ATOM-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ATOMUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ATOM-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ATOM / USD"
+        }
+      }
+    },
+    {
+      "id": 153,
+      "full_name": "ATOM / USDC",
+      "description": "Cosmos",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ATOM",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ATOMUSDC"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ATOMUSDC"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ATOM_USDC"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "ATOMUSDC"
+              ],
+              "wsname": [
+                "ATOM/USDC"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ATOM-USDC"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ATOMUSDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ATOM-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ATOM / USD"
+        }
+      }
+    },
+    {
+      "id": 154,
       "full_name": "ARB / USD",
       "description": "Arbitrum",
       "type": "price-feed",
@@ -12397,7 +12690,7 @@
       }
     },
     {
-      "id": 152,
+      "id": 155,
       "full_name": "ARB / USDT",
       "description": "Arbitrum",
       "type": "price-feed",
@@ -12482,7 +12775,7 @@
       }
     },
     {
-      "id": 153,
+      "id": 156,
       "full_name": "ARB / USDC",
       "description": "Arbitrum",
       "type": "price-feed",
@@ -12542,9 +12835,9 @@
       }
     },
     {
-      "id": 154,
-      "full_name": "ATOM / USD",
-      "description": "Cosmos",
+      "id": 157,
+      "full_name": "JUP / USD",
+      "description": "Jupiter",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -12561,113 +12854,106 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "ATOM",
+          "base": "JUP",
           "quote": "USD"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
             "Binance": {
               "symbol": [
-                "ATOMUSDC",
-                "ATOMUSDT"
+                "JUPUSDC",
+                "JUPUSDT"
               ]
             },
-            "BinanceUS": {
+            "Bitfinex": {
               "symbol": [
-                "ATOMUSDT"
+                "JUPUSD"
               ]
             },
             "Bitget": {
               "symbol": [
-                "ATOMUSDT_SPBL"
+                "JUPUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "ATOMUSDC",
-                "ATOMUSDT"
+                "JUPUSDT"
               ]
             },
             "Coinbase": {
               "id": [
-                "ATOM-USD",
-                "ATOM-USDT"
+                "JUP-USD"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "ATOMUSD-PERP",
-                "ATOM_USD",
-                "ATOM_USDT"
+                "JUPUSD-PERP",
+                "JUP_USD",
+                "JUP_USDT"
               ]
             },
             "GateIo": {
               "id": [
-                "ATOM_USDC",
-                "ATOM_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "ATOMUSD"
+                "JUP_USDC",
+                "JUP_USDT"
               ]
             },
             "Kraken": {
               "pair": [
-                "ATOMUSD",
-                "ATOMUSDC",
-                "ATOMUSDT"
+                "JUPUSD"
               ],
               "wsname": [
-                "ATOM/USD",
-                "ATOM/USDC",
-                "ATOM/USDT"
+                "JUP/USD"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "ATOM-USDC",
-                "ATOM-USDT"
+                "JUP-USDC",
+                "JUP-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "ATOMUSDC",
-                "ATOMUSDT"
+                "JUPUSDT"
               ]
             },
             "OKX": {
               "instId": [
-                "ATOM-USDC",
-                "ATOM-USDT"
+                "JUP-USDC",
+                "JUP-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-JUP"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "ATOM",
-                "ATOM"
+                "JUP",
+                "JUP"
               ],
               "id": [
-                30019,
-                3794
+                1503,
+                29210
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "ATOM / USD"
+          "chainlink": "JUP/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 155,
-      "full_name": "ATOM / USDT",
-      "description": "Cosmos",
+      "id": 158,
+      "full_name": "JUP / USDT",
+      "description": "Jupiter",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -12684,83 +12970,70 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "ATOM",
+          "base": "JUP",
           "quote": "USDT"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
             "Binance": {
               "symbol": [
-                "ATOMUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "ATOMUSDT"
+                "JUPUSDT"
               ]
             },
             "Bitget": {
               "symbol": [
-                "ATOMUSDT_SPBL"
+                "JUPUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "ATOMUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "ATOM-USDT"
+                "JUPUSDT"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "ATOM_USDT"
+                "JUP_USDT"
               ]
             },
             "GateIo": {
               "id": [
-                "ATOM_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "ATOMUSDT"
-              ],
-              "wsname": [
-                "ATOM/USDT"
+                "JUP_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "ATOM-USDT"
+                "JUP-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "ATOMUSDT"
+                "JUPUSDT"
               ]
             },
             "OKX": {
               "instId": [
-                "ATOM-USDT"
+                "JUP-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-JUP"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "ATOM / USD"
+          "chainlink": "JUP/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 156,
-      "full_name": "ATOM / USDC",
-      "description": "Cosmos",
+      "id": 159,
+      "full_name": "JUP / USDC",
+      "description": "Jupiter",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -12777,61 +13050,43 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "ATOM",
+          "base": "JUP",
           "quote": "USDC"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
             "Binance": {
               "symbol": [
-                "ATOMUSDC"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ATOMUSDC"
+                "JUPUSDC"
               ]
             },
             "GateIo": {
               "id": [
-                "ATOM_USDC"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "ATOMUSDC"
-              ],
-              "wsname": [
-                "ATOM/USDC"
+                "JUP_USDC"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "ATOM-USDC"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ATOMUSDC"
+                "JUP-USDC"
               ]
             },
             "OKX": {
               "instId": [
-                "ATOM-USDC"
+                "JUP-USDC"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "ATOM / USD"
+          "chainlink": "JUP/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 157,
+      "id": 160,
       "full_name": "OP / USD",
       "description": "Optimism",
       "type": "price-feed",
@@ -12950,7 +13205,7 @@
       }
     },
     {
-      "id": 158,
+      "id": 161,
       "full_name": "OP / USDT",
       "description": "Optimism",
       "type": "price-feed",
@@ -13035,7 +13290,7 @@
       }
     },
     {
-      "id": 159,
+      "id": 162,
       "full_name": "OP / USDC",
       "description": "Optimism",
       "type": "price-feed",
@@ -13105,476 +13360,7 @@
       }
     },
     {
-      "id": 160,
-      "full_name": "ENA / USD",
-      "description": "Ethena",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ENA",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ENAUSDC",
-                "ENAUSDT"
-              ]
-            },
-            "Bitfinex": {
-              "symbol": [
-                "ENAUSD"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ENAUSDC_SPBL",
-                "ENAUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ENAUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ENAUSD-PERP",
-                "ENA_USD",
-                "ENA_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ENA_USDC",
-                "ENA_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "ENAUSD"
-              ],
-              "wsname": [
-                "ENA/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ENA-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ENAUSDC",
-                "ENAUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "ENA"
-              ],
-              "id": [
-                30171
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ENA/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 161,
-      "full_name": "ENA / USDT",
-      "description": "Ethena",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ENA",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ENAUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ENAUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ENAUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ENA_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ENA_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ENA-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ENAUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ENA/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 162,
-      "full_name": "ENA / USDC",
-      "description": "Ethena",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ENA",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ENAUSDC"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ENAUSDC_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ENA_USDC"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ENAUSDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ENA/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
       "id": 163,
-      "full_name": "JUP / USD",
-      "description": "Jupiter",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "JUP",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "JUPUSDC",
-                "JUPUSDT"
-              ]
-            },
-            "Bitfinex": {
-              "symbol": [
-                "JUPUSD"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "JUPUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "JUPUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "JUP-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "JUPUSD-PERP",
-                "JUP_USD",
-                "JUP_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "JUP_USDC",
-                "JUP_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "JUPUSD"
-              ],
-              "wsname": [
-                "JUP/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "JUP-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "JUPUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "JUP-USDC",
-                "JUP-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-JUP"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "JUP",
-                "JUP"
-              ],
-              "id": [
-                1503,
-                29210
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "JUP/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 164,
-      "full_name": "JUP / USDT",
-      "description": "Jupiter",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "JUP",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "JUPUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "JUPUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "JUPUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "JUP_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "JUP_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "JUP-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "JUPUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "JUP-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-JUP"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "JUP/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 165,
-      "full_name": "JUP / USDC",
-      "description": "Jupiter",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "JUP",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "JUPUSDC"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "JUP_USDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "JUP-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "JUP/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 166,
       "full_name": "S / USD",
       "description": "Sonic",
       "type": "price-feed",
@@ -13666,7 +13452,7 @@
       }
     },
     {
-      "id": 167,
+      "id": 164,
       "full_name": "S / USDT",
       "description": "Sonic",
       "type": "price-feed",
@@ -13736,7 +13522,7 @@
       }
     },
     {
-      "id": 168,
+      "id": 165,
       "full_name": "S / USDC",
       "description": "Sonic",
       "type": "price-feed",
@@ -13786,7 +13572,7 @@
       }
     },
     {
-      "id": 169,
+      "id": 166,
       "full_name": "FET / USD",
       "description": "Fetch.ai",
       "type": "price-feed",
@@ -13907,7 +13693,7 @@
       }
     },
     {
-      "id": 170,
+      "id": 167,
       "full_name": "FET / USDT",
       "description": "Fetch.ai",
       "type": "price-feed",
@@ -13992,7 +13778,7 @@
       }
     },
     {
-      "id": 171,
+      "id": 168,
       "full_name": "FET / USDC",
       "description": "Fetch.ai",
       "type": "price-feed",
@@ -14052,7 +13838,274 @@
       }
     },
     {
+      "id": 169,
+      "full_name": "ENA / USD",
+      "description": "Ethena",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ENA",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ENAUSDC",
+                "ENAUSDT"
+              ]
+            },
+            "Bitfinex": {
+              "symbol": [
+                "ENAUSD"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ENAUSDC_SPBL",
+                "ENAUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ENAUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ENAUSD-PERP",
+                "ENA_USD",
+                "ENA_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ENA_USDC",
+                "ENA_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "ENAUSD"
+              ],
+              "wsname": [
+                "ENA/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ENA-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ENAUSDC",
+                "ENAUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "ENA"
+              ],
+              "id": [
+                30171
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ENA/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 170,
+      "full_name": "ENA / USDT",
+      "description": "Ethena",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ENA",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ENAUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ENAUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ENAUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ENA_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ENA_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ENA-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ENAUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ENA/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 171,
+      "full_name": "ENA / USDC",
+      "description": "Ethena",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ENA",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ENAUSDC"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ENAUSDC_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ENA_USDC"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ENAUSDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ENA/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
       "id": 172,
+      "full_name": "USD0 / USD",
+      "description": "Usual USD",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "USD0",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "USD0"
+              ],
+              "id": [
+                32307
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "USD0 / USD"
+        }
+      }
+    },
+    {
+      "id": 173,
       "full_name": "MKR / USD",
       "description": "Maker",
       "type": "price-feed",
@@ -14169,7 +14222,7 @@
       }
     },
     {
-      "id": 173,
+      "id": 174,
       "full_name": "MKR / ETH",
       "description": "Maker",
       "type": "price-feed",
@@ -14209,7 +14262,7 @@
       }
     },
     {
-      "id": 174,
+      "id": 175,
       "full_name": "MKR / USDT",
       "description": "Maker",
       "type": "price-feed",
@@ -14289,7 +14342,7 @@
       }
     },
     {
-      "id": 175,
+      "id": 176,
       "full_name": "MKR / USDC",
       "description": "Maker",
       "type": "price-feed",
@@ -14329,9 +14382,9 @@
       }
     },
     {
-      "id": 176,
-      "full_name": "USD0 / USD",
-      "description": "Usual USD",
+      "id": 177,
+      "full_name": "ZBU / USD",
+      "description": "Zeebu",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -14348,31 +14401,98 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "USD0",
+          "base": "ZBU",
           "quote": "USD"
         },
         "decimals": 8,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "ZBUUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ZBU_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ZBUUSDT"
+              ]
+            }
+          },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "USD0"
+                "ZBU"
               ],
               "id": [
-                32307
+                27765
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "USD0 / USD"
+          "chainlink": "ZBU / USD"
         }
       }
     },
     {
-      "id": 177,
+      "id": 178,
+      "full_name": "ZBU / USDT",
+      "description": "Zeebu",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ZBU",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "ZBUUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ZBU_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ZBUUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ZBU / USD"
+        }
+      }
+    },
+    {
+      "id": 179,
       "full_name": "STX / USD",
       "description": "Stacks",
       "type": "price-feed",
@@ -14479,7 +14599,7 @@
       }
     },
     {
-      "id": 178,
+      "id": 180,
       "full_name": "STX / USDT",
       "description": "Stacks",
       "type": "price-feed",
@@ -14559,7 +14679,7 @@
       }
     },
     {
-      "id": 179,
+      "id": 181,
       "full_name": "STX / USDC",
       "description": "Stacks",
       "type": "price-feed",
@@ -14614,7 +14734,7 @@
       }
     },
     {
-      "id": 180,
+      "id": 182,
       "full_name": "INJ / USD",
       "description": "Injective Protocol",
       "type": "price-feed",
@@ -14729,7 +14849,7 @@
       }
     },
     {
-      "id": 181,
+      "id": 183,
       "full_name": "INJ / USDT",
       "description": "Injective Protocol",
       "type": "price-feed",
@@ -14809,7 +14929,7 @@
       }
     },
     {
-      "id": 182,
+      "id": 184,
       "full_name": "INJ / USDC",
       "description": "Injective Protocol",
       "type": "price-feed",
@@ -14869,9 +14989,9 @@
       }
     },
     {
-      "id": 183,
-      "full_name": "SEI / USD",
-      "description": "Sei",
+      "id": 185,
+      "full_name": "IMX / USD",
+      "description": "Immutable",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -14888,7 +15008,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "SEI",
+          "base": "IMX",
           "quote": "USD"
         },
         "decimals": 18,
@@ -14898,83 +15018,92 @@
           "exchanges": {
             "Binance": {
               "symbol": [
-                "SEIUSDC",
-                "SEIUSDT"
+                "IMXUSDT"
               ]
             },
-            "Bitfinex": {
+            "BinanceUS": {
               "symbol": [
-                "SEIUSD"
+                "IMXUSDT"
               ]
             },
             "Bitget": {
               "symbol": [
-                "SEIUSDT_SPBL"
+                "IMXUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "SEIUSDC",
-                "SEIUSDT"
+                "IMXUSDT"
               ]
             },
             "Coinbase": {
               "id": [
-                "SEI-USD"
+                "IMX-USD",
+                "IMX-USDT"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "SEIUSD-PERP",
-                "SEI_USD",
-                "SEI_USDT"
+                "IMXUSD-PERP",
+                "IMX_USD",
+                "IMX_USDT"
               ]
             },
             "GateIo": {
               "id": [
-                "SEI_USDC",
-                "SEI_USDT"
+                "IMX_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "IMXUSD"
               ]
             },
             "Kraken": {
               "pair": [
-                "SEIUSD"
+                "IMXUSD"
               ],
               "wsname": [
-                "SEI/USD"
+                "IMX/USD"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "SEI-USDT"
+                "IMX-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "SEIUSDT"
+                "IMXUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "IMX-USDC",
+                "IMX-USDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "SEI"
+                "IMX"
               ],
               "id": [
-                23149
+                10603
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "SEI/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "IMX/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 184,
-      "full_name": "SEI / USDT",
-      "description": "Sei",
+      "id": 186,
+      "full_name": "IMX / USDT",
+      "description": "Immutable",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -14991,7 +15120,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "SEI",
+          "base": "IMX",
           "quote": "USDT"
         },
         "decimals": 18,
@@ -15001,50 +15130,65 @@
           "exchanges": {
             "Binance": {
               "symbol": [
-                "SEIUSDT"
+                "IMXUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "IMXUSDT"
               ]
             },
             "Bitget": {
               "symbol": [
-                "SEIUSDT_SPBL"
+                "IMXUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "SEIUSDT"
+                "IMXUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "IMX-USDT"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "SEI_USDT"
+                "IMX_USDT"
               ]
             },
             "GateIo": {
               "id": [
-                "SEI_USDT"
+                "IMX_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "SEI-USDT"
+                "IMX-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "SEIUSDT"
+                "IMXUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "IMX-USDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "SEI/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "IMX/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 185,
-      "full_name": "SEI / USDC",
-      "description": "Sei",
+      "id": 187,
+      "full_name": "IMX / USDC",
+      "description": "Immutable",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -15061,7 +15205,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "SEI",
+          "base": "IMX",
           "quote": "USDC"
         },
         "decimals": 18,
@@ -15069,135 +15213,15 @@
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "SEIUSDC"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "SEIUSDC"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "SEI_USDC"
+            "OKX": {
+              "instId": [
+                "IMX-USDC"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "SEI/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 186,
-      "full_name": "ZBU / USD",
-      "description": "Zeebu",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ZBU",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "ZBUUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ZBU_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ZBUUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "ZBU"
-              ],
-              "id": [
-                27765
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ZBU / USD"
-        }
-      }
-    },
-    {
-      "id": 187,
-      "full_name": "ZBU / USDT",
-      "description": "Zeebu",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ZBU",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "ZBUUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ZBU_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ZBUUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ZBU / USD"
+          "chainlink": "IMX/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
@@ -15389,8 +15413,8 @@
     },
     {
       "id": 190,
-      "full_name": "IMX / USD",
-      "description": "Immutable",
+      "full_name": "WLD / USD",
+      "description": "Worldcoin",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -15407,7 +15431,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "IMX",
+          "base": "WLD",
           "quote": "USD"
         },
         "decimals": 18,
@@ -15417,92 +15441,81 @@
           "exchanges": {
             "Binance": {
               "symbol": [
-                "IMXUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "IMXUSDT"
+                "WLDUSDC",
+                "WLDUSDT"
               ]
             },
             "Bitget": {
               "symbol": [
-                "IMXUSDT_SPBL"
+                "WLDUSDC_SPBL",
+                "WLDUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "IMXUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "IMX-USD",
-                "IMX-USDT"
+                "WLDUSDC",
+                "WLDUSDT"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "IMXUSD-PERP",
-                "IMX_USD",
-                "IMX_USDT"
+                "WLDUSD-PERP",
+                "WLD_USD",
+                "WLD_USDT"
               ]
             },
             "GateIo": {
               "id": [
-                "IMX_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "IMXUSD"
+                "WLD_USDC",
+                "WLD_USDT"
               ]
             },
             "Kraken": {
               "pair": [
-                "IMXUSD"
+                "WLDUSD"
               ],
               "wsname": [
-                "IMX/USD"
+                "WLD/USD"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "IMX-USDT"
+                "WLD-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "IMXUSDT"
+                "WLDUSDT"
               ]
             },
             "OKX": {
               "instId": [
-                "IMX-USDC",
-                "IMX-USDT"
+                "WLD-USD",
+                "WLD-USDC",
+                "WLD-USDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "IMX"
+                "WLD"
               ],
               "id": [
-                10603
+                13502
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "IMX/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "WLD/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
       "id": 191,
-      "full_name": "IMX / USDT",
-      "description": "Immutable",
+      "full_name": "WLD / USDT",
+      "description": "Worldcoin",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -15519,7 +15532,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "IMX",
+          "base": "WLD",
           "quote": "USDT"
         },
         "decimals": 18,
@@ -15529,65 +15542,55 @@
           "exchanges": {
             "Binance": {
               "symbol": [
-                "IMXUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "IMXUSDT"
+                "WLDUSDT"
               ]
             },
             "Bitget": {
               "symbol": [
-                "IMXUSDT_SPBL"
+                "WLDUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "IMXUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "IMX-USDT"
+                "WLDUSDT"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "IMX_USDT"
+                "WLD_USDT"
               ]
             },
             "GateIo": {
               "id": [
-                "IMX_USDT"
+                "WLD_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "IMX-USDT"
+                "WLD-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "IMXUSDT"
+                "WLDUSDT"
               ]
             },
             "OKX": {
               "instId": [
-                "IMX-USDT"
+                "WLD-USDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "IMX/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "WLD/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
       "id": 192,
-      "full_name": "IMX / USDC",
-      "description": "Immutable",
+      "full_name": "WLD / USDC",
+      "description": "Worldcoin",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -15604,7 +15607,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "IMX",
+          "base": "WLD",
           "quote": "USDC"
         },
         "decimals": 18,
@@ -15612,15 +15615,35 @@
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
+            "Binance": {
+              "symbol": [
+                "WLDUSDC"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "WLDUSDC_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "WLDUSDC"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "WLD_USDC"
+              ]
+            },
             "OKX": {
               "instId": [
-                "IMX-USDC"
+                "WLD-USDC"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "IMX/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "WLD/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
@@ -15862,266 +15885,6 @@
     },
     {
       "id": 197,
-      "full_name": "LDO / USD",
-      "description": "Lido DAO",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "LDO",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "LDOUSDC",
-                "LDOUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "LDOUSDT"
-              ]
-            },
-            "Bitfinex": {
-              "symbol": [
-                "LDOUSD"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "LDOUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "LDOUSDC",
-                "LDOUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "LDO-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "LDOUSD-PERP",
-                "LDO_USD",
-                "LDO_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "LDO_USDC",
-                "LDO_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "LDOUSD"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "LDOUSD"
-              ],
-              "wsname": [
-                "LDO/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "LDO-USDC",
-                "LDO-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "LDOUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "LDO-USDC",
-                "LDO-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "LDO"
-              ],
-              "id": [
-                8000
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "LDO/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 198,
-      "full_name": "LDO / USDT",
-      "description": "Lido DAO",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "LDO",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "LDOUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "LDOUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "LDOUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "LDOUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "LDO_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "LDO_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "LDO-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "LDOUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "LDO-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "LDO/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 199,
-      "full_name": "LDO / USDC",
-      "description": "Lido DAO",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "LDO",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "LDOUSDC"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "LDOUSDC"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "LDO_USDC"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "LDO-USDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "LDO-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "LDO/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 200,
       "full_name": "GRT / USD",
       "description": "The Graph",
       "type": "price-feed",
@@ -16237,7 +16000,7 @@
       }
     },
     {
-      "id": 201,
+      "id": 198,
       "full_name": "GRT / ETH",
       "description": "The Graph",
       "type": "price-feed",
@@ -16277,7 +16040,7 @@
       }
     },
     {
-      "id": 202,
+      "id": 199,
       "full_name": "GRT / USDT",
       "description": "The Graph",
       "type": "price-feed",
@@ -16357,7 +16120,7 @@
       }
     },
     {
-      "id": 203,
+      "id": 200,
       "full_name": "GRT / USDC",
       "description": "The Graph",
       "type": "price-feed",
@@ -16397,9 +16160,9 @@
       }
     },
     {
-      "id": 204,
-      "full_name": "WLD / USD",
-      "description": "Worldcoin",
+      "id": 201,
+      "full_name": "SEI / USD",
+      "description": "Sei",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -16416,7 +16179,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "WLD",
+          "base": "SEI",
           "quote": "USD"
         },
         "decimals": 18,
@@ -16426,81 +16189,83 @@
           "exchanges": {
             "Binance": {
               "symbol": [
-                "WLDUSDC",
-                "WLDUSDT"
+                "SEIUSDC",
+                "SEIUSDT"
+              ]
+            },
+            "Bitfinex": {
+              "symbol": [
+                "SEIUSD"
               ]
             },
             "Bitget": {
               "symbol": [
-                "WLDUSDC_SPBL",
-                "WLDUSDT_SPBL"
+                "SEIUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "WLDUSDC",
-                "WLDUSDT"
+                "SEIUSDC",
+                "SEIUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "SEI-USD"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "WLDUSD-PERP",
-                "WLD_USD",
-                "WLD_USDT"
+                "SEIUSD-PERP",
+                "SEI_USD",
+                "SEI_USDT"
               ]
             },
             "GateIo": {
               "id": [
-                "WLD_USDC",
-                "WLD_USDT"
+                "SEI_USDC",
+                "SEI_USDT"
               ]
             },
             "Kraken": {
               "pair": [
-                "WLDUSD"
+                "SEIUSD"
               ],
               "wsname": [
-                "WLD/USD"
+                "SEI/USD"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "WLD-USDT"
+                "SEI-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "WLDUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "WLD-USD",
-                "WLD-USDC",
-                "WLD-USDT"
+                "SEIUSDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "WLD"
+                "SEI"
               ],
               "id": [
-                13502
+                23149
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "WLD/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "SEI/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 205,
-      "full_name": "WLD / USDT",
-      "description": "Worldcoin",
+      "id": 202,
+      "full_name": "SEI / USDT",
+      "description": "Sei",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -16517,7 +16282,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "WLD",
+          "base": "SEI",
           "quote": "USDT"
         },
         "decimals": 18,
@@ -16527,55 +16292,50 @@
           "exchanges": {
             "Binance": {
               "symbol": [
-                "WLDUSDT"
+                "SEIUSDT"
               ]
             },
             "Bitget": {
               "symbol": [
-                "WLDUSDT_SPBL"
+                "SEIUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "WLDUSDT"
+                "SEIUSDT"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "WLD_USDT"
+                "SEI_USDT"
               ]
             },
             "GateIo": {
               "id": [
-                "WLD_USDT"
+                "SEI_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "WLD-USDT"
+                "SEI-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "WLDUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "WLD-USDT"
+                "SEIUSDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "WLD/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "SEI/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 206,
-      "full_name": "WLD / USDC",
-      "description": "Worldcoin",
+      "id": 203,
+      "full_name": "SEI / USDC",
+      "description": "Sei",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -16592,7 +16352,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "WLD",
+          "base": "SEI",
           "quote": "USDC"
         },
         "decimals": 18,
@@ -16602,38 +16362,28 @@
           "exchanges": {
             "Binance": {
               "symbol": [
-                "WLDUSDC"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "WLDUSDC_SPBL"
+                "SEIUSDC"
               ]
             },
             "Bybit": {
               "symbol": [
-                "WLDUSDC"
+                "SEIUSDC"
               ]
             },
             "GateIo": {
               "id": [
-                "WLD_USDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "WLD-USDC"
+                "SEI_USDC"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "WLD/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "SEI/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 207,
+      "id": 204,
       "full_name": "BONK / USD",
       "description": "Bonk",
       "type": "price-feed",
@@ -16763,7 +16513,7 @@
       }
     },
     {
-      "id": 208,
+      "id": 205,
       "full_name": "BONK / USDT",
       "description": "Bonk",
       "type": "price-feed",
@@ -16848,7 +16598,7 @@
       }
     },
     {
-      "id": 209,
+      "id": 206,
       "full_name": "BONK / USDC",
       "description": "Bonk",
       "type": "price-feed",
@@ -16899,6 +16649,266 @@
         },
         "compatibility_info": {
           "chainlink": "BONK/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 207,
+      "full_name": "LDO / USD",
+      "description": "Lido DAO",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "LDO",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "LDOUSDC",
+                "LDOUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "LDOUSDT"
+              ]
+            },
+            "Bitfinex": {
+              "symbol": [
+                "LDOUSD"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "LDOUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "LDOUSDC",
+                "LDOUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "LDO-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "LDOUSD-PERP",
+                "LDO_USD",
+                "LDO_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "LDO_USDC",
+                "LDO_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "LDOUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "LDOUSD"
+              ],
+              "wsname": [
+                "LDO/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "LDO-USDC",
+                "LDO-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "LDOUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "LDO-USDC",
+                "LDO-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "LDO"
+              ],
+              "id": [
+                8000
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "LDO/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 208,
+      "full_name": "LDO / USDT",
+      "description": "Lido DAO",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "LDO",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "LDOUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "LDOUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "LDOUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "LDOUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "LDO_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "LDO_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "LDO-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "LDOUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "LDO-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "LDO/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 209,
+      "full_name": "LDO / USDC",
+      "description": "Lido DAO",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "LDO",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "LDOUSDC"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "LDOUSDC"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "LDO_USDC"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "LDO-USDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "LDO-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "LDO/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
@@ -17225,6 +17235,250 @@
     },
     {
       "id": 214,
+      "full_name": "GALA / USD",
+      "description": "Gala",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "GALA",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "GALAUSDC",
+                "GALAUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "GALAUSDT"
+              ]
+            },
+            "Bitfinex": {
+              "symbol": [
+                "GALA:USD"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "GALAUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "GALAUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "GALA-USD",
+                "GALA-USDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "GALAUSD-PERP",
+                "GALA_USD",
+                "GALA_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "GALA_USDC",
+                "GALA_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "GALAUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "GALAUSD"
+              ],
+              "wsname": [
+                "GALA/USD"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "GALAUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "GALA-USDC",
+                "GALA-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "GALA"
+              ],
+              "id": [
+                7080
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "GALA/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 215,
+      "full_name": "GALA / USDT",
+      "description": "Gala",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "GALA",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "GALAUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "GALAUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "GALAUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "GALAUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "GALA-USDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "GALA_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "GALA_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "GALAUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "GALA-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "GALA/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 216,
+      "full_name": "GALA / USDC",
+      "description": "Gala",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "GALA",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "GALAUSDC"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "GALA_USDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "GALA-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "GALA/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 217,
       "full_name": "PYUSD / USD",
       "description": "PayPal USD",
       "type": "price-feed",
@@ -17313,7 +17567,7 @@
       }
     },
     {
-      "id": 215,
+      "id": 218,
       "full_name": "PYUSD / USDT",
       "description": "PayPal USD",
       "type": "price-feed",
@@ -17378,7 +17632,7 @@
       }
     },
     {
-      "id": 216,
+      "id": 219,
       "full_name": "XTZ / BNB",
       "description": "Tezos",
       "type": "price-feed",
@@ -17418,7 +17672,7 @@
       }
     },
     {
-      "id": 217,
+      "id": 220,
       "full_name": "XTZ / USD",
       "description": "Tezos",
       "type": "price-feed",
@@ -17544,7 +17798,7 @@
       }
     },
     {
-      "id": 218,
+      "id": 221,
       "full_name": "XTZ / USDT",
       "description": "Tezos",
       "type": "price-feed",
@@ -17637,7 +17891,7 @@
       }
     },
     {
-      "id": 219,
+      "id": 222,
       "full_name": "XTZ / USDC",
       "description": "Tezos",
       "type": "price-feed",
@@ -17690,7 +17944,7 @@
       }
     },
     {
-      "id": 220,
+      "id": 223,
       "full_name": "SAND / USD",
       "description": "The Sandbox",
       "type": "price-feed",
@@ -17809,7 +18063,7 @@
       }
     },
     {
-      "id": 221,
+      "id": 224,
       "full_name": "SAND / USDT",
       "description": "The Sandbox",
       "type": "price-feed",
@@ -17894,7 +18148,7 @@
       }
     },
     {
-      "id": 222,
+      "id": 225,
       "full_name": "SAND / USDC",
       "description": "The Sandbox",
       "type": "price-feed",
@@ -17944,538 +18198,7 @@
       }
     },
     {
-      "id": 223,
-      "full_name": "JTO / USD",
-      "description": "Jito",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "JTO",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "JTOUSDC",
-                "JTOUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "JTOUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "JTOUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "JTO-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "JTOUSD-PERP",
-                "JTO_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "JTO_USDC",
-                "JTO_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "JTOUSD"
-              ],
-              "wsname": [
-                "JTO/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "JTO-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "JTOUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "JTO-USDC",
-                "JTO-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-JTO"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "JTO"
-              ],
-              "id": [
-                28541
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "JTO/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 224,
-      "full_name": "JTO / USDT",
-      "description": "Jito",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "JTO",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "JTOUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "JTOUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "JTOUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "JTO_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "JTO-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "JTOUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "JTO-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-JTO"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "JTO/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 225,
-      "full_name": "JTO / USDC",
-      "description": "Jito",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "JTO",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "JTOUSDC"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "JTO_USDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "JTO-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "JTO/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
       "id": 226,
-      "full_name": "ezETH / USD",
-      "description": "Renzo Restaked ETH",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ezETH",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "EZETH"
-              ],
-              "id": [
-                29520
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ezETH/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 227,
-      "full_name": "ENS / USD",
-      "description": "Ethereum Name Service",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ENS",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ENSUSDC",
-                "ENSUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "ENSUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ENSUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ENSUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "ENS-USD",
-                "ENS-USDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ENSUSD-PERP",
-                "ENS_USD",
-                "ENS_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ENS_USDC",
-                "ENS_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "ENSUSD"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "ENSUSD"
-              ],
-              "wsname": [
-                "ENS/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ENS-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ENSUSDC",
-                "ENSUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ENS-USD",
-                "ENS-USDC",
-                "ENS-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "ENS"
-              ],
-              "id": [
-                13855
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ENS / USD"
-        }
-      }
-    },
-    {
-      "id": 228,
-      "full_name": "ENS / USDT",
-      "description": "Ethereum Name Service",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ENS",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ENSUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "ENSUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ENSUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ENSUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "ENS-USDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ENS_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ENS_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ENS-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ENSUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ENS-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ENS / USD"
-        }
-      }
-    },
-    {
-      "id": 229,
-      "full_name": "ENS / USDC",
-      "description": "Ethereum Name Service",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ENS",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ENSUSDC"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ENS_USDC"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ENSUSDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ENS-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ENS / USD"
-        }
-      }
-    },
-    {
-      "id": 230,
       "full_name": "BERA / USD",
       "description": "Berachain",
       "type": "price-feed",
@@ -18585,7 +18308,7 @@
       }
     },
     {
-      "id": 231,
+      "id": 227,
       "full_name": "BERA / USDT",
       "description": "Berachain",
       "type": "price-feed",
@@ -18668,7 +18391,7 @@
       }
     },
     {
-      "id": 232,
+      "id": 228,
       "full_name": "BERA / USDC",
       "description": "Berachain",
       "type": "price-feed",
@@ -18716,7 +18439,239 @@
       }
     },
     {
-      "id": 233,
+      "id": 229,
+      "full_name": "JTO / USD",
+      "description": "Jito",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "JTO",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "JTOUSDC",
+                "JTOUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "JTOUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "JTOUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "JTO-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "JTOUSD-PERP",
+                "JTO_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "JTO_USDC",
+                "JTO_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "JTOUSD"
+              ],
+              "wsname": [
+                "JTO/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "JTO-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "JTOUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "JTO-USDC",
+                "JTO-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-JTO"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "JTO"
+              ],
+              "id": [
+                28541
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "JTO/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 230,
+      "full_name": "JTO / USDT",
+      "description": "Jito",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "JTO",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "JTOUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "JTOUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "JTOUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "JTO_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "JTO-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "JTOUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "JTO-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-JTO"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "JTO/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 231,
+      "full_name": "JTO / USDC",
+      "description": "Jito",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "JTO",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "JTOUSDC"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "JTO_USDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "JTO-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "JTO/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 232,
       "full_name": "FLOW / USD",
       "description": "FLOW (dapper labs)",
       "type": "price-feed",
@@ -18823,7 +18778,7 @@
       }
     },
     {
-      "id": 234,
+      "id": 233,
       "full_name": "FLOW / USDT",
       "description": "FLOW (dapper labs)",
       "type": "price-feed",
@@ -18908,7 +18863,7 @@
       }
     },
     {
-      "id": 235,
+      "id": 234,
       "full_name": "FLOW / USDC",
       "description": "FLOW (dapper labs)",
       "type": "price-feed",
@@ -18948,251 +18903,7 @@
       }
     },
     {
-      "id": 236,
-      "full_name": "GALA / USD",
-      "description": "Gala",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "GALA",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "GALAUSDC",
-                "GALAUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "GALAUSDT"
-              ]
-            },
-            "Bitfinex": {
-              "symbol": [
-                "GALA:USD"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "GALAUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "GALAUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "GALA-USD",
-                "GALA-USDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "GALAUSD-PERP",
-                "GALA_USD",
-                "GALA_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "GALA_USDC",
-                "GALA_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "GALAUSD"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "GALAUSD"
-              ],
-              "wsname": [
-                "GALA/USD"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "GALAUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "GALA-USDC",
-                "GALA-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "GALA"
-              ],
-              "id": [
-                7080
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "GALA/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 237,
-      "full_name": "GALA / USDT",
-      "description": "Gala",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "GALA",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "GALAUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "GALAUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "GALAUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "GALAUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "GALA-USDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "GALA_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "GALA_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "GALAUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "GALA-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "GALA/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 238,
-      "full_name": "GALA / USDC",
-      "description": "Gala",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "GALA",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "GALAUSDC"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "GALA_USDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "GALA-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "GALA/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 239,
+      "id": 235,
       "full_name": "FLOKI / USD",
       "description": "Floki Inu",
       "type": "price-feed",
@@ -19319,7 +19030,7 @@
       }
     },
     {
-      "id": 240,
+      "id": 236,
       "full_name": "FLOKI / USDT",
       "description": "Floki Inu",
       "type": "price-feed",
@@ -19399,7 +19110,7 @@
       }
     },
     {
-      "id": 241,
+      "id": 237,
       "full_name": "FLOKI / USDC",
       "description": "Floki Inu",
       "type": "price-feed",
@@ -19464,9 +19175,9 @@
       }
     },
     {
-      "id": 242,
-      "full_name": "PYTH / USD",
-      "description": "Pyth Network",
+      "id": 238,
+      "full_name": "ezETH / USD",
+      "description": "Renzo Restaked ETH",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -19483,97 +19194,149 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "PYTH",
+          "base": "ezETH",
           "quote": "USD"
         },
         "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "EZETH"
+              ],
+              "id": [
+                29520
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ezETH/USD-RefPrice-mainnet-production"
+        }
+      }
+    },
+    {
+      "id": 239,
+      "full_name": "ENS / USD",
+      "description": "Ethereum Name Service",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ENS",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
           "exchanges": {
             "Binance": {
               "symbol": [
-                "PYTHUSDC",
-                "PYTHUSDT"
+                "ENSUSDC",
+                "ENSUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "ENSUSDT"
               ]
             },
             "Bitget": {
               "symbol": [
-                "PYTHUSDT_SPBL"
+                "ENSUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "PYTHUSDT"
+                "ENSUSDT"
               ]
             },
             "Coinbase": {
               "id": [
-                "PYTH-USD"
+                "ENS-USD",
+                "ENS-USDT"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "PYTHUSD-PERP",
-                "PYTH_USD",
-                "PYTH_USDT"
+                "ENSUSD-PERP",
+                "ENS_USD",
+                "ENS_USDT"
               ]
             },
             "GateIo": {
               "id": [
-                "PYTH_USDT"
+                "ENS_USDC",
+                "ENS_USDT"
               ]
             },
             "Gemini": {
               "symbol": [
-                "PYTHUSD"
+                "ENSUSD"
               ]
             },
             "Kraken": {
               "pair": [
-                "PYTHUSD"
+                "ENSUSD"
               ],
               "wsname": [
-                "PYTH/USD"
+                "ENS/USD"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "PYTH-USDT"
+                "ENS-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "PYTHUSDT"
+                "ENSUSDC",
+                "ENSUSDT"
               ]
             },
             "OKX": {
               "instId": [
-                "PYTH-USDC",
-                "PYTH-USDT"
+                "ENS-USD",
+                "ENS-USDC",
+                "ENS-USDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "PYTH"
+                "ENS"
               ],
               "id": [
-                28177
+                13855
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "PYTH/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "ENS / USD"
         }
       }
     },
     {
-      "id": 243,
-      "full_name": "PYTH / USDT",
-      "description": "Pyth Network",
+      "id": 240,
+      "full_name": "ENS / USDT",
+      "description": "Ethereum Name Service",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -19590,226 +19353,75 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "PYTH",
+          "base": "ENS",
           "quote": "USDT"
         },
-        "decimals": 18,
+        "decimals": 8,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
             "Binance": {
               "symbol": [
-                "PYTHUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "PYTHUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "PYTHUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "PYTH_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "PYTH_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "PYTH-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "PYTHUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "PYTH-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "PYTH/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 244,
-      "full_name": "PYTH / USDC",
-      "description": "Pyth Network",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "PYTH",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "PYTHUSDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "PYTH-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "PYTH/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 245,
-      "full_name": "EGLD / USD",
-      "description": "MultiversX",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "EGLD",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "EGLDUSDT"
+                "ENSUSDT"
               ]
             },
             "BinanceUS": {
               "symbol": [
-                "EGLDUSDT"
-              ]
-            },
-            "Bitfinex": {
-              "symbol": [
-                "EGLD:USD"
+                "ENSUSDT"
               ]
             },
             "Bitget": {
               "symbol": [
-                "EGLDUSDT_SPBL"
+                "ENSUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "EGLDUSDT"
+                "ENSUSDT"
               ]
             },
             "Coinbase": {
               "id": [
-                "EGLD-USD"
+                "ENS-USDT"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "EGLDUSD-PERP",
-                "EGLD_USD",
-                "EGLD_USDT"
+                "ENS_USDT"
               ]
             },
             "GateIo": {
               "id": [
-                "EGLD_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "EGLDUSD"
-              ],
-              "wsname": [
-                "EGLD/USD"
+                "ENS_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "EGLD-USDT"
+                "ENS-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "EGLDUSDT"
+                "ENSUSDT"
               ]
             },
             "OKX": {
               "instId": [
-                "EGLD-USDC",
-                "EGLD-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-EGLD"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "EGLD"
-              ],
-              "id": [
-                6892
+                "ENS-USDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "EGLD/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "ENS / USD"
         }
       }
     },
     {
-      "id": 246,
-      "full_name": "EGLD / USDT",
-      "description": "MultiversX",
+      "id": 241,
+      "full_name": "ENS / USDC",
+      "description": "Ethereum Name Service",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -19826,113 +19438,43 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "EGLD",
-          "quote": "USDT"
+          "base": "ENS",
+          "quote": "USDC"
         },
-        "decimals": 18,
+        "decimals": 8,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
             "Binance": {
               "symbol": [
-                "EGLDUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "EGLDUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "EGLDUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "EGLDUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "EGLD_USDT"
+                "ENSUSDC"
               ]
             },
             "GateIo": {
               "id": [
-                "EGLD_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "EGLD-USDT"
+                "ENS_USDC"
               ]
             },
             "MEXC": {
               "symbol": [
-                "EGLDUSDT"
+                "ENSUSDC"
               ]
             },
             "OKX": {
               "instId": [
-                "EGLD-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-EGLD"
+                "ENS-USDC"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "EGLD/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "ENS / USD"
         }
       }
     },
     {
-      "id": 247,
-      "full_name": "EGLD / USDC",
-      "description": "MultiversX",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "EGLD",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "EGLD-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "EGLD/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 248,
+      "id": 242,
       "full_name": "MANA / USD",
       "description": "Decentraland",
       "type": "price-feed",
@@ -20054,7 +19596,7 @@
       }
     },
     {
-      "id": 249,
+      "id": 243,
       "full_name": "MANA / ETH",
       "description": "Decentraland",
       "type": "price-feed",
@@ -20104,7 +19646,7 @@
       }
     },
     {
-      "id": 250,
+      "id": 244,
       "full_name": "MANA / USDT",
       "description": "Decentraland",
       "type": "price-feed",
@@ -20197,7 +19739,7 @@
       }
     },
     {
-      "id": 251,
+      "id": 245,
       "full_name": "MANA / USDC",
       "description": "Decentraland",
       "type": "price-feed",
@@ -20255,713 +19797,7 @@
       }
     },
     {
-      "id": 252,
-      "full_name": "FRAX / USD",
-      "description": "FRAX",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "FRAX",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "GateIo": {
-              "id": [
-                "FRAX_USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "FRAX"
-              ],
-              "id": [
-                6952
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "FRAX / USD"
-        }
-      }
-    },
-    {
-      "id": 253,
-      "full_name": "FRAX / USDT",
-      "description": "FRAX",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "FRAX",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "GateIo": {
-              "id": [
-                "FRAX_USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "FRAX / USD"
-        }
-      }
-    },
-    {
-      "id": 254,
-      "full_name": "TUSD / USD",
-      "description": "True USD",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "TUSD",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "TUSDUSDT"
-              ]
-            },
-            "BinanceTR": {
-              "symbol": [
-                "TUSD_USDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "TUSDUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "TUSDUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "TUSDUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "TUSD_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "TUSDUSD"
-              ],
-              "wsname": [
-                "TUSD/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "TUSD-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "TUSDUSDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-TUSD"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "TUSD"
-              ],
-              "id": [
-                2563
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "TUSD / USD"
-        }
-      }
-    },
-    {
-      "id": 255,
-      "full_name": "TUSD / ETH",
-      "description": "TrueUSD",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "TUSD",
-          "quote": "ETH"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "TUSDETH"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "TUSD / ETH"
-        }
-      }
-    },
-    {
-      "id": 256,
-      "full_name": "TUSD / USDT",
-      "description": "True USD",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "TUSD",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "TUSDUSDT"
-              ]
-            },
-            "BinanceTR": {
-              "symbol": [
-                "TUSD_USDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "TUSDUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "TUSDUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "TUSDUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "TUSD_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "TUSD-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "TUSDUSDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-TUSD"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "TUSD / USD"
-        }
-      }
-    },
-    {
-      "id": 257,
-      "full_name": "RON / USD",
-      "description": "Ronin",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "RON",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "RONUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "RON_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "RONUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "RON-USDC",
-                "RON-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "RON"
-              ],
-              "id": [
-                14101
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "RON / USD"
-        }
-      }
-    },
-    {
-      "id": 258,
-      "full_name": "RON / USDT",
-      "description": "Ronin",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "RON",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "RONUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "RON_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "RONUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "RON-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "RON / USD"
-        }
-      }
-    },
-    {
-      "id": 259,
-      "full_name": "RON / USDC",
-      "description": "Ronin",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "RON",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "RON-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "RON / USD"
-        }
-      }
-    },
-    {
-      "id": 260,
-      "full_name": "AXS / USD",
-      "description": "Axie Infinity",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AXS",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "AXSUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "AXSUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "AXSUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "AXSUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "AXS-USD",
-                "AXS-USDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "AXSUSD-PERP",
-                "AXS_USD",
-                "AXS_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "AXS_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "AXSUSD"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "AXSUSD"
-              ],
-              "wsname": [
-                "AXS/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "AXS-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "AXSUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "AXS-USDC",
-                "AXS-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "AXS"
-              ],
-              "id": [
-                6783
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AXS / USD"
-        }
-      }
-    },
-    {
-      "id": 261,
-      "full_name": "AXS / USDT",
-      "description": "Axie Infinity",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AXS",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "AXSUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "AXSUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "AXSUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "AXSUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "AXS-USDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "AXS_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "AXS_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "AXS-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "AXSUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "AXS-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AXS / USD"
-        }
-      }
-    },
-    {
-      "id": 262,
-      "full_name": "AXS / USDC",
-      "description": "Axie Infinity",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AXS",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "AXS-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AXS / USD"
-        }
-      }
-    },
-    {
-      "id": 263,
+      "id": 246,
       "full_name": "CRV / USD",
       "description": "Curve DAO",
       "type": "price-feed",
@@ -21080,7 +19916,7 @@
       }
     },
     {
-      "id": 264,
+      "id": 247,
       "full_name": "CRV / ETH",
       "description": "Curve DAO",
       "type": "price-feed",
@@ -21130,7 +19966,7 @@
       }
     },
     {
-      "id": 265,
+      "id": 248,
       "full_name": "CRV / USDT",
       "description": "Curve DAO",
       "type": "price-feed",
@@ -21210,7 +20046,7 @@
       }
     },
     {
-      "id": 266,
+      "id": 249,
       "full_name": "CRV / USDC",
       "description": "Curve DAO",
       "type": "price-feed",
@@ -21260,7 +20096,1097 @@
       }
     },
     {
-      "id": 267,
+      "id": 250,
+      "full_name": "PYTH / USD",
+      "description": "Pyth Network",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "PYTH",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "PYTHUSDC",
+                "PYTHUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "PYTHUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "PYTHUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "PYTH-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "PYTHUSD-PERP",
+                "PYTH_USD",
+                "PYTH_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "PYTH_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "PYTHUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "PYTHUSD"
+              ],
+              "wsname": [
+                "PYTH/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "PYTH-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "PYTHUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "PYTH-USDC",
+                "PYTH-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "PYTH"
+              ],
+              "id": [
+                28177
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "PYTH/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 251,
+      "full_name": "PYTH / USDT",
+      "description": "Pyth Network",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "PYTH",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "PYTHUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "PYTHUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "PYTHUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "PYTH_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "PYTH_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "PYTH-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "PYTHUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "PYTH-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "PYTH/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 252,
+      "full_name": "PYTH / USDC",
+      "description": "Pyth Network",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "PYTH",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "PYTHUSDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "PYTH-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "PYTH/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 253,
+      "full_name": "EGLD / USD",
+      "description": "MultiversX",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "EGLD",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "EGLDUSDC",
+                "EGLDUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "EGLDUSDT"
+              ]
+            },
+            "Bitfinex": {
+              "symbol": [
+                "EGLD:USD"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "EGLDUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "EGLDUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "EGLD-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "EGLDUSD-PERP",
+                "EGLD_USD",
+                "EGLD_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "EGLD_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "EGLDUSD"
+              ],
+              "wsname": [
+                "EGLD/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "EGLD-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "EGLDUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "EGLD-USDC",
+                "EGLD-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-EGLD"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "EGLD"
+              ],
+              "id": [
+                6892
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "EGLD/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 254,
+      "full_name": "EGLD / USDT",
+      "description": "MultiversX",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "EGLD",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "EGLDUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "EGLDUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "EGLDUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "EGLDUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "EGLD_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "EGLD_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "EGLD-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "EGLDUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "EGLD-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-EGLD"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "EGLD/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 255,
+      "full_name": "EGLD / USDC",
+      "description": "MultiversX",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "EGLD",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "EGLDUSDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "EGLD-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "EGLD/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 256,
+      "full_name": "RON / USD",
+      "description": "Ronin",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "RON",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "RONUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "RON_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "RONUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "RON-USDC",
+                "RON-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "RON"
+              ],
+              "id": [
+                14101
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "RON / USD"
+        }
+      }
+    },
+    {
+      "id": 257,
+      "full_name": "RON / USDT",
+      "description": "Ronin",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "RON",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "RONUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "RON_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "RONUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "RON-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "RON / USD"
+        }
+      }
+    },
+    {
+      "id": 258,
+      "full_name": "RON / USDC",
+      "description": "Ronin",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "RON",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "RON-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "RON / USD"
+        }
+      }
+    },
+    {
+      "id": 259,
+      "full_name": "AXS / USD",
+      "description": "Axie Infinity",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AXS",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "AXSUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "AXSUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "AXSUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "AXSUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "AXS-USD",
+                "AXS-USDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "AXSUSD-PERP",
+                "AXS_USD",
+                "AXS_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "AXS_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "AXSUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "AXSUSD"
+              ],
+              "wsname": [
+                "AXS/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "AXS-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "AXSUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "AXS-USDC",
+                "AXS-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "AXS"
+              ],
+              "id": [
+                6783
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AXS / USD"
+        }
+      }
+    },
+    {
+      "id": 260,
+      "full_name": "AXS / USDT",
+      "description": "Axie Infinity",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AXS",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "AXSUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "AXSUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "AXSUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "AXSUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "AXS-USDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "AXS_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "AXS_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "AXS-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "AXSUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "AXS-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AXS / USD"
+        }
+      }
+    },
+    {
+      "id": 261,
+      "full_name": "AXS / USDC",
+      "description": "Axie Infinity",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AXS",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "AXS-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AXS / USD"
+        }
+      }
+    },
+    {
+      "id": 262,
+      "full_name": "TUSD / USD",
+      "description": "True USD",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "TUSD",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "TUSDUSDT"
+              ]
+            },
+            "BinanceTR": {
+              "symbol": [
+                "TUSD_USDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "TUSDUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "TUSDUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "TUSDUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "TUSD_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "TUSDUSD"
+              ],
+              "wsname": [
+                "TUSD/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "TUSD-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "TUSDUSDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-TUSD"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "TUSD"
+              ],
+              "id": [
+                2563
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "TUSD / USD"
+        }
+      }
+    },
+    {
+      "id": 263,
+      "full_name": "TUSD / ETH",
+      "description": "TrueUSD",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "TUSD",
+          "quote": "ETH"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "TUSDETH"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "TUSD / ETH"
+        }
+      }
+    },
+    {
+      "id": 264,
+      "full_name": "TUSD / USDT",
+      "description": "True USD",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "TUSD",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "TUSDUSDT"
+              ]
+            },
+            "BinanceTR": {
+              "symbol": [
+                "TUSD_USDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "TUSDUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "TUSDUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "TUSDUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "TUSD_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "TUSD-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "TUSDUSDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-TUSD"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "TUSD / USD"
+        }
+      }
+    },
+    {
+      "id": 265,
       "full_name": "ZEC / USD",
       "description": "ZCash",
       "type": "price-feed",
@@ -21350,7 +21276,7 @@
       }
     },
     {
-      "id": 268,
+      "id": 266,
       "full_name": "ZEC / USDT",
       "description": "ZCash",
       "type": "price-feed",
@@ -21405,7 +21331,7 @@
       }
     },
     {
-      "id": 269,
+      "id": 267,
       "full_name": "ZEC / USDC",
       "description": "ZCash",
       "type": "price-feed",
@@ -21450,7 +21376,7 @@
       }
     },
     {
-      "id": 270,
+      "id": 268,
       "full_name": "KAVA / USD",
       "description": "Kava",
       "type": "price-feed",
@@ -21555,7 +21481,7 @@
       }
     },
     {
-      "id": 271,
+      "id": 269,
       "full_name": "KAVA / USDT",
       "description": "Kava",
       "type": "price-feed",
@@ -21630,7 +21556,371 @@
       }
     },
     {
+      "id": 270,
+      "full_name": "DYDX / USD",
+      "description": "dYdX",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "DYDX",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "DYDXUSDC",
+                "DYDXUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "DYDXUSDC_SPBL",
+                "DYDXUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "DYDXUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "DYDXUSD-PERP",
+                "DYDX_USD",
+                "DYDX_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "DYDX_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "DYDXUSD"
+              ],
+              "wsname": [
+                "DYDX/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "DYDX-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "DYDXUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "DYDX-USDC",
+                "DYDX-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "DYDX"
+              ],
+              "id": [
+                28324
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "DYDX/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 271,
+      "full_name": "DYDX / USDT",
+      "description": "dYdX",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "DYDX",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "DYDXUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "DYDXUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "DYDXUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "DYDX_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "DYDX_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "DYDX-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "DYDXUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "DYDX-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "DYDX/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
       "id": 272,
+      "full_name": "DYDX / USDC",
+      "description": "dYdX",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "DYDX",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "DYDXUSDC"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "DYDXUSDC_SPBL"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "DYDX-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "DYDX/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 273,
+      "full_name": "XCN / USD",
+      "description": "Chain",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "XCN",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "XCNUSDT_SPBL"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "XCN-USD",
+                "XCN-USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "XCN_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "XCNUSD"
+              ],
+              "wsname": [
+                "XCN/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "XCN-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "XCNUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "XCN",
+                "XCN"
+              ],
+              "id": [
+                18679,
+                501
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "XCN / USD"
+        }
+      }
+    },
+    {
+      "id": 274,
+      "full_name": "XCN / USDT",
+      "description": "Chain",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "XCN",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "XCNUSDT_SPBL"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "XCN-USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "XCN_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "XCN-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "XCNUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "XCN / USD"
+        }
+      }
+    },
+    {
+      "id": 275,
       "full_name": "WIF / USD",
       "description": "dogwifhat",
       "type": "price-feed",
@@ -21759,7 +22049,7 @@
       }
     },
     {
-      "id": 273,
+      "id": 276,
       "full_name": "WIF / USDT",
       "description": "dogwifhat",
       "type": "price-feed",
@@ -21839,7 +22129,7 @@
       }
     },
     {
-      "id": 274,
+      "id": 277,
       "full_name": "WIF / USDC",
       "description": "dogwifhat",
       "type": "price-feed",
@@ -21894,826 +22184,7 @@
       }
     },
     {
-      "id": 275,
-      "full_name": "AERO / USD",
-      "description": "Aerodrome Finance",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AERO",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "AEROUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "AEROUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "AERO-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "AERO_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "AERO_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "AEROUSD"
-              ],
-              "wsname": [
-                "AERO/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "AERO-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "AEROUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "AERO",
-                "AERO"
-              ],
-              "id": [
-                17706,
-                29270
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AERO / USD"
-        }
-      }
-    },
-    {
-      "id": 276,
-      "full_name": "AERO / USDT",
-      "description": "Aerodrome Finance",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AERO",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "AEROUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "AEROUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "AERO_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "AERO-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "AEROUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AERO / USD"
-        }
-      }
-    },
-    {
-      "id": 277,
-      "full_name": "CAKE / USD",
-      "description": "PancakeSwap",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "CAKE",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "CAKEUSDC",
-                "CAKEUSDT"
-              ]
-            },
-            "BinanceTR": {
-              "symbol": [
-                "CAKE_USDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "CAKEUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "CAKEUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "CAKE_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "CAKE-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "CAKEUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "CAKE"
-              ],
-              "id": [
-                7186
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "CAKE / USD"
-        }
-      }
-    },
-    {
       "id": 278,
-      "full_name": "CAKE / BNB",
-      "description": "PancakeSwap",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "CAKE",
-          "quote": "BNB"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "CAKEBNB"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "CAKE / BNB"
-        }
-      }
-    },
-    {
-      "id": 279,
-      "full_name": "CAKE / USDT",
-      "description": "PancakeSwap",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "CAKE",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "CAKEUSDT"
-              ]
-            },
-            "BinanceTR": {
-              "symbol": [
-                "CAKE_USDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "CAKEUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "CAKEUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "CAKE_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "CAKE-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "CAKEUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "CAKE / USD"
-        }
-      }
-    },
-    {
-      "id": 280,
-      "full_name": "CAKE / USDC",
-      "description": "PancakeSwap",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "CAKE",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "CAKEUSDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "CAKE / USD"
-        }
-      }
-    },
-    {
-      "id": 281,
-      "full_name": "DYDX / USD",
-      "description": "dYdX",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "DYDX",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "DYDXUSDC",
-                "DYDXUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "DYDXUSDC_SPBL",
-                "DYDXUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "DYDXUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "DYDXUSD-PERP",
-                "DYDX_USD",
-                "DYDX_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "DYDX_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "DYDXUSD"
-              ],
-              "wsname": [
-                "DYDX/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "DYDX-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "DYDXUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "DYDX-USDC",
-                "DYDX-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "DYDX"
-              ],
-              "id": [
-                28324
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "DYDX/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 282,
-      "full_name": "DYDX / USDT",
-      "description": "dYdX",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "DYDX",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "DYDXUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "DYDXUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "DYDXUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "DYDX_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "DYDX_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "DYDX-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "DYDXUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "DYDX-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "DYDX/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 283,
-      "full_name": "DYDX / USDC",
-      "description": "dYdX",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "DYDX",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "DYDXUSDC"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "DYDXUSDC_SPBL"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "DYDX-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "DYDX/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 284,
-      "full_name": "RUNE / USD",
-      "description": "THORChain",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "RUNE",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "RUNEUSDC",
-                "RUNEUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "RUNEUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "RUNEUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "RUNEUSD-PERP",
-                "RUNE_USD",
-                "RUNE_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "RUNE_USDC",
-                "RUNE_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "RUNEUSD"
-              ],
-              "wsname": [
-                "RUNE/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "RUNE-USDC",
-                "RUNE-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "RUNEUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "RUNE",
-                "RUNE"
-              ],
-              "id": [
-                4157,
-                9905
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "RUNE / USD"
-        }
-      }
-    },
-    {
-      "id": 285,
-      "full_name": "RUNE / USDT",
-      "description": "THORChain",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "RUNE",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "RUNEUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "RUNEUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "RUNEUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "RUNE_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "RUNE_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "RUNE-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "RUNEUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "RUNE / USD"
-        }
-      }
-    },
-    {
-      "id": 286,
-      "full_name": "RUNE / USDC",
-      "description": "THORChain",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "RUNE",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "RUNEUSDC"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "RUNE_USDC"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "RUNE-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "RUNE / USD"
-        }
-      }
-    },
-    {
-      "id": 287,
       "full_name": "STRK / USD",
       "description": "Starknet",
       "type": "price-feed",
@@ -22824,7 +22295,7 @@
       }
     },
     {
-      "id": 288,
+      "id": 279,
       "full_name": "STRK / USDT",
       "description": "Starknet",
       "type": "price-feed",
@@ -22899,7 +22370,7 @@
       }
     },
     {
-      "id": 289,
+      "id": 280,
       "full_name": "STRK / USDC",
       "description": "Starknet",
       "type": "price-feed",
@@ -22954,7 +22425,238 @@
       }
     },
     {
-      "id": 290,
+      "id": 281,
+      "full_name": "CAKE / USD",
+      "description": "PancakeSwap",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "CAKE",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "CAKEUSDC",
+                "CAKEUSDT"
+              ]
+            },
+            "BinanceTR": {
+              "symbol": [
+                "CAKE_USDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "CAKEUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "CAKEUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "CAKE_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "CAKE-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "CAKEUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "CAKE"
+              ],
+              "id": [
+                7186
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "CAKE / USD"
+        }
+      }
+    },
+    {
+      "id": 282,
+      "full_name": "CAKE / BNB",
+      "description": "PancakeSwap",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "CAKE",
+          "quote": "BNB"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "CAKEBNB"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "CAKE / BNB"
+        }
+      }
+    },
+    {
+      "id": 283,
+      "full_name": "CAKE / USDT",
+      "description": "PancakeSwap",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "CAKE",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "CAKEUSDT"
+              ]
+            },
+            "BinanceTR": {
+              "symbol": [
+                "CAKE_USDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "CAKEUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "CAKEUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "CAKE_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "CAKE-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "CAKEUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "CAKE / USD"
+        }
+      }
+    },
+    {
+      "id": 284,
+      "full_name": "CAKE / USDC",
+      "description": "PancakeSwap",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "CAKE",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "CAKEUSDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "CAKE / USD"
+        }
+      }
+    },
+    {
+      "id": 285,
       "full_name": "MATIC / USD",
       "description": "Polygon (MATIC)",
       "type": "price-feed",
@@ -23038,7 +22740,7 @@
       }
     },
     {
-      "id": 291,
+      "id": 286,
       "full_name": "MATIC / USDT",
       "description": "Polygon (MATIC)",
       "type": "price-feed",
@@ -23096,7 +22798,7 @@
       }
     },
     {
-      "id": 292,
+      "id": 287,
       "full_name": "MATIC / USDC",
       "description": "Polygon (MATIC)",
       "type": "price-feed",
@@ -23144,9 +22846,9 @@
       }
     },
     {
-      "id": 293,
-      "full_name": "AR / USD",
-      "description": "Arweave",
+      "id": 288,
+      "full_name": "AERO / USD",
+      "description": "Aerodrome Finance",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -23163,81 +22865,80 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "AR",
+          "base": "AERO",
           "quote": "USD"
         },
-        "decimals": 18,
+        "decimals": 8,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ARUSDC",
-                "ARUSDT"
-              ]
-            },
             "Bitget": {
               "symbol": [
-                "ARUSDC_SPBL",
-                "ARUSDT_SPBL"
+                "AEROUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "ARUSDT"
+                "AEROUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "AERO-USD"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "ARUSD-PERP",
-                "AR_USD",
-                "AR_USDT"
+                "AERO_USD"
               ]
             },
             "GateIo": {
               "id": [
-                "AR_USDC",
-                "AR_USDT"
+                "AERO_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "AEROUSD"
+              ],
+              "wsname": [
+                "AERO/USD"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "AR-USDT"
+                "AERO-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "ARUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "AR-USDC",
-                "AR-USDT"
+                "AEROUSDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "AR"
+                "AERO",
+                "AERO"
               ],
               "id": [
-                5632
+                17706,
+                29270
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "AR/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "AERO / USD"
         }
       }
     },
     {
-      "id": 294,
-      "full_name": "AR / USDT",
-      "description": "Arweave",
+      "id": 289,
+      "full_name": "AERO / USDT",
+      "description": "Aerodrome Finance",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -23254,118 +22955,48 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "AR",
+          "base": "AERO",
           "quote": "USDT"
         },
-        "decimals": 18,
+        "decimals": 8,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ARUSDT"
-              ]
-            },
             "Bitget": {
               "symbol": [
-                "ARUSDT_SPBL"
+                "AEROUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "ARUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "AR_USDT"
+                "AEROUSDT"
               ]
             },
             "GateIo": {
               "id": [
-                "AR_USDT"
+                "AERO_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "AR-USDT"
+                "AERO-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "ARUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "AR-USDT"
+                "AEROUSDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "AR/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "AERO / USD"
         }
       }
     },
     {
-      "id": 295,
-      "full_name": "AR / USDC",
-      "description": "Arweave",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AR",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ARUSDC"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ARUSDC_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "AR_USDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "AR-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AR/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 296,
+      "id": 290,
       "full_name": "CHZ / USD",
       "description": "Chiliz",
       "type": "price-feed",
@@ -23484,7 +23115,7 @@
       }
     },
     {
-      "id": 297,
+      "id": 291,
       "full_name": "CHZ / USDT",
       "description": "Chiliz",
       "type": "price-feed",
@@ -23569,7 +23200,7 @@
       }
     },
     {
-      "id": 298,
+      "id": 292,
       "full_name": "CHZ / USDC",
       "description": "Chiliz",
       "type": "price-feed",
@@ -23619,7 +23250,706 @@
       }
     },
     {
+      "id": 293,
+      "full_name": "FRAX / USD",
+      "description": "FRAX",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "FRAX",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "GateIo": {
+              "id": [
+                "FRAX_USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "FRAX"
+              ],
+              "id": [
+                6952
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "FRAX / USD"
+        }
+      }
+    },
+    {
+      "id": 294,
+      "full_name": "FRAX / USDT",
+      "description": "FRAX",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "FRAX",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "GateIo": {
+              "id": [
+                "FRAX_USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "FRAX / USD"
+        }
+      }
+    },
+    {
+      "id": 295,
+      "full_name": "CORE / USD",
+      "description": "",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "CORE",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "",
+        "market_hours": null,
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "COREUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "COREUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "CORE_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "COREUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "CORE-USDC",
+                "CORE-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "CORE",
+                "CORE"
+              ],
+              "id": [
+                23254,
+                7242
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "CORE / USD"
+        }
+      }
+    },
+    {
+      "id": 296,
+      "full_name": "CORE / USDT",
+      "description": "",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "CORE",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "",
+        "market_hours": null,
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "COREUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "COREUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "CORE_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "COREUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "CORE-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "CORE / USD"
+        }
+      }
+    },
+    {
+      "id": 297,
+      "full_name": "CORE / USDC",
+      "description": "",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "CORE",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "",
+        "market_hours": null,
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "CORE-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "CORE / USD"
+        }
+      }
+    },
+    {
+      "id": 298,
+      "full_name": "RUNE / USD",
+      "description": "THORChain",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "RUNE",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "RUNEUSDC",
+                "RUNEUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "RUNEUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "RUNEUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "RUNEUSD-PERP",
+                "RUNE_USD",
+                "RUNE_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "RUNE_USDC",
+                "RUNE_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "RUNEUSD"
+              ],
+              "wsname": [
+                "RUNE/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "RUNE-USDC",
+                "RUNE-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "RUNEUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "RUNE",
+                "RUNE"
+              ],
+              "id": [
+                4157,
+                9905
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "RUNE / USD"
+        }
+      }
+    },
+    {
       "id": 299,
+      "full_name": "RUNE / USDT",
+      "description": "THORChain",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "RUNE",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "RUNEUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "RUNEUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "RUNEUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "RUNE_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "RUNE_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "RUNE-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "RUNEUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "RUNE / USD"
+        }
+      }
+    },
+    {
+      "id": 300,
+      "full_name": "RUNE / USDC",
+      "description": "THORChain",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "RUNE",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "RUNEUSDC"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "RUNE_USDC"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "RUNE-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "RUNE / USD"
+        }
+      }
+    },
+    {
+      "id": 301,
+      "full_name": "AR / USD",
+      "description": "Arweave",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AR",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ARUSDC",
+                "ARUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ARUSDC_SPBL",
+                "ARUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ARUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ARUSD-PERP",
+                "AR_USD",
+                "AR_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "AR_USDC",
+                "AR_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "AR-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ARUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "AR-USDC",
+                "AR-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "AR"
+              ],
+              "id": [
+                5632
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AR/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 302,
+      "full_name": "AR / USDT",
+      "description": "Arweave",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AR",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ARUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ARUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ARUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "AR_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "AR_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "AR-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ARUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "AR-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AR/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 303,
+      "full_name": "AR / USDC",
+      "description": "Arweave",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AR",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ARUSDC"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ARUSDC_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "AR_USDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "AR-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AR/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 304,
       "full_name": "CFX / USD",
       "description": "Conflux",
       "type": "price-feed",
@@ -23702,7 +24032,7 @@
       }
     },
     {
-      "id": 300,
+      "id": 305,
       "full_name": "CFX / USDT",
       "description": "Conflux",
       "type": "price-feed",
@@ -23767,7 +24097,7 @@
       }
     },
     {
-      "id": 301,
+      "id": 306,
       "full_name": "CFX / USDC",
       "description": "Conflux",
       "type": "price-feed",
@@ -23813,368 +24143,6 @@
         },
         "compatibility_info": {
           "chainlink": "CFX / USD"
-        }
-      }
-    },
-    {
-      "id": 302,
-      "full_name": "VIRTUAL / USD",
-      "description": "Virtuals Protocol",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "VIRTUAL",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "VIRTUALUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "VIRTUALUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "VIRTUALUSD-PERP",
-                "VIRTUAL_USD",
-                "VIRTUAL_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "VIRTUAL_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "VIRTUALUSD",
-                "VIRTUALUSDC",
-                "VIRTUALUSDT"
-              ],
-              "wsname": [
-                "VIRTUAL/USD",
-                "VIRTUAL/USDC",
-                "VIRTUAL/USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "VIRTUAL-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "VIRTUALUSDC",
-                "VIRTUALUSDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-VIRTUAL"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "VIRTUAL"
-              ],
-              "id": [
-                29420
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "VIRTUAL/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 303,
-      "full_name": "VIRTUAL / USDT",
-      "description": "Virtuals Protocol",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "VIRTUAL",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "VIRTUALUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "VIRTUALUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "VIRTUAL_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "VIRTUAL_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "VIRTUALUSDT"
-              ],
-              "wsname": [
-                "VIRTUAL/USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "VIRTUAL-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "VIRTUALUSDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-VIRTUAL"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "VIRTUAL/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 304,
-      "full_name": "VIRTUAL / USDC",
-      "description": "Virtuals Protocol",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "VIRTUAL",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Kraken": {
-              "pair": [
-                "VIRTUALUSDC"
-              ],
-              "wsname": [
-                "VIRTUAL/USDC"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "VIRTUALUSDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "VIRTUAL/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 305,
-      "full_name": "XCN / USD",
-      "description": "Chain",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "XCN",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "XCNUSDT_SPBL"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "XCN-USD",
-                "XCN-USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "XCN_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "XCNUSD"
-              ],
-              "wsname": [
-                "XCN/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "XCN-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "XCNUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "XCN",
-                "XCN"
-              ],
-              "id": [
-                18679,
-                501
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "XCN / USD"
-        }
-      }
-    },
-    {
-      "id": 306,
-      "full_name": "XCN / USDT",
-      "description": "Chain",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "XCN",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "XCNUSDT_SPBL"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "XCN-USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "XCN_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "XCN-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "XCNUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "XCN / USD"
         }
       }
     },
@@ -24406,550 +24374,6 @@
     },
     {
       "id": 311,
-      "full_name": "CORE / USD",
-      "description": "",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "CORE",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "",
-        "market_hours": null,
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "COREUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "COREUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "CORE_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "COREUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "CORE-USDC",
-                "CORE-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "CORE",
-                "CORE"
-              ],
-              "id": [
-                23254,
-                7242
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "CORE / USD"
-        }
-      }
-    },
-    {
-      "id": 312,
-      "full_name": "CORE / USDT",
-      "description": "",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "CORE",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "",
-        "market_hours": null,
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "COREUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "COREUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "CORE_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "COREUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "CORE-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "CORE / USD"
-        }
-      }
-    },
-    {
-      "id": 313,
-      "full_name": "CORE / USDC",
-      "description": "",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "CORE",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "",
-        "market_hours": null,
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "CORE-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "CORE / USD"
-        }
-      }
-    },
-    {
-      "id": 314,
-      "full_name": "COMP / USD",
-      "description": "Compound",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "COMP",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "COMPUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "COMPUSDT"
-              ]
-            },
-            "Bitfinex": {
-              "symbol": [
-                "COMP:USD"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "COMPUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "COMPUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "COMP-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "COMPUSD-PERP",
-                "COMP_USD",
-                "COMP_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "COMP_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "COMPUSD"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "COMPUSD"
-              ],
-              "wsname": [
-                "COMP/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "COMP-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "COMPUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "COMP-USD",
-                "COMP-USDC",
-                "COMP-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "COMP"
-              ],
-              "id": [
-                5692
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "COMP / USD"
-        }
-      }
-    },
-    {
-      "id": 315,
-      "full_name": "COMP / USDT",
-      "description": "Compound",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "COMP",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "COMPUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "COMPUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "COMPUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "COMPUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "COMP_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "COMP_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "COMP-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "COMPUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "COMP-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "COMP / USD"
-        }
-      }
-    },
-    {
-      "id": 316,
-      "full_name": "COMP / USDC",
-      "description": "Compound",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "COMP",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "COMP-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "COMP / USD"
-        }
-      }
-    },
-    {
-      "id": 317,
-      "full_name": "SPX / USD",
-      "description": "SPX6900",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SPX",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bybit": {
-              "symbol": [
-                "SPXUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "SPXUSD-PERP",
-                "SPX_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "SPX_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "SPXUSD"
-              ],
-              "wsname": [
-                "SPX/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "SPX-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "SPXUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "SPX"
-              ],
-              "id": [
-                28081
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SPX/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 318,
-      "full_name": "SPX / USDT",
-      "description": "SPX6900",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SPX",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bybit": {
-              "symbol": [
-                "SPXUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "SPX_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "SPX-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "SPXUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SPX/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 319,
       "full_name": "APE / USD",
       "description": "ApeCoin",
       "type": "price-feed",
@@ -25078,7 +24502,7 @@
       }
     },
     {
-      "id": 320,
+      "id": 312,
       "full_name": "APE / ETH",
       "description": "APECoin",
       "type": "price-feed",
@@ -25118,7 +24542,7 @@
       }
     },
     {
-      "id": 321,
+      "id": 313,
       "full_name": "APE / USDT",
       "description": "ApeCoin",
       "type": "price-feed",
@@ -25211,7 +24635,7 @@
       }
     },
     {
-      "id": 322,
+      "id": 314,
       "full_name": "APE / USDC",
       "description": "ApeCoin",
       "type": "price-feed",
@@ -25279,7 +24703,228 @@
       }
     },
     {
-      "id": 323,
+      "id": 315,
+      "full_name": "VIRTUAL / USD",
+      "description": "Virtuals Protocol",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "VIRTUAL",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "VIRTUALUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "VIRTUALUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "VIRTUALUSD-PERP",
+                "VIRTUAL_USD",
+                "VIRTUAL_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "VIRTUAL_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "VIRTUALUSD",
+                "VIRTUALUSDC",
+                "VIRTUALUSDT"
+              ],
+              "wsname": [
+                "VIRTUAL/USD",
+                "VIRTUAL/USDC",
+                "VIRTUAL/USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "VIRTUAL-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "VIRTUALUSDC",
+                "VIRTUALUSDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-VIRTUAL"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "VIRTUAL"
+              ],
+              "id": [
+                29420
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "VIRTUAL/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 316,
+      "full_name": "VIRTUAL / USDT",
+      "description": "Virtuals Protocol",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "VIRTUAL",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "VIRTUALUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "VIRTUALUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "VIRTUAL_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "VIRTUAL_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "VIRTUALUSDT"
+              ],
+              "wsname": [
+                "VIRTUAL/USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "VIRTUAL-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "VIRTUALUSDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-VIRTUAL"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "VIRTUAL/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 317,
+      "full_name": "VIRTUAL / USDC",
+      "description": "Virtuals Protocol",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "VIRTUAL",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Kraken": {
+              "pair": [
+                "VIRTUALUSDC"
+              ],
+              "wsname": [
+                "VIRTUAL/USDC"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "VIRTUALUSDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "VIRTUAL/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 318,
       "full_name": "PENGU / USD",
       "description": "Pudgy Penguins",
       "type": "price-feed",
@@ -25377,11 +25022,9 @@
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "PENGU",
                 "PENGU"
               ],
               "id": [
-                31654,
                 34466
               ]
             }
@@ -25393,7 +25036,7 @@
       }
     },
     {
-      "id": 324,
+      "id": 319,
       "full_name": "PENGU / USDT",
       "description": "Pudgy Penguins",
       "type": "price-feed",
@@ -25481,7 +25124,7 @@
       }
     },
     {
-      "id": 325,
+      "id": 320,
       "full_name": "PENGU / USDC",
       "description": "Pudgy Penguins",
       "type": "price-feed",
@@ -25530,6 +25173,372 @@
         },
         "compatibility_info": {
           "chainlink": "PENGU/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 321,
+      "full_name": "COMP / USD",
+      "description": "Compound",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "COMP",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "COMPUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "COMPUSDT"
+              ]
+            },
+            "Bitfinex": {
+              "symbol": [
+                "COMP:USD"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "COMPUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "COMPUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "COMP-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "COMPUSD-PERP",
+                "COMP_USD",
+                "COMP_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "COMP_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "COMPUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "COMPUSD"
+              ],
+              "wsname": [
+                "COMP/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "COMP-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "COMPUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "COMP-USD",
+                "COMP-USDC",
+                "COMP-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "COMP"
+              ],
+              "id": [
+                5692
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "COMP / USD"
+        }
+      }
+    },
+    {
+      "id": 322,
+      "full_name": "COMP / USDT",
+      "description": "Compound",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "COMP",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "COMPUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "COMPUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "COMPUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "COMPUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "COMP_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "COMP_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "COMP-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "COMPUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "COMP-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "COMP / USD"
+        }
+      }
+    },
+    {
+      "id": 323,
+      "full_name": "COMP / USDC",
+      "description": "Compound",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "COMP",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "COMP-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "COMP / USD"
+        }
+      }
+    },
+    {
+      "id": 324,
+      "full_name": "AXL / USD",
+      "description": "Axelar",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AXL",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "AXLUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "AXLUSDT"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "AXLUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "AXL-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "AXLUSD-PERP",
+                "AXL_USD",
+                "AXL_USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "AXL",
+                "AXL"
+              ],
+              "id": [
+                15853,
+                17799
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AXL / USD"
+        }
+      }
+    },
+    {
+      "id": 325,
+      "full_name": "AXL / USDT",
+      "description": "Axelar",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AXL",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "AXLUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "AXLUSDT"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "AXLUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "AXL_USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AXL / USD"
         }
       }
     },
@@ -25758,8 +25767,8 @@
     },
     {
       "id": 329,
-      "full_name": "AXL / USD",
-      "description": "Axelar",
+      "full_name": "SPX / USD",
+      "description": "SPX6900",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -25776,64 +25785,69 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "AXL",
+          "base": "SPX",
           "quote": "USD"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "AXLUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "AXLUSDT"
-              ]
-            },
             "Bybit": {
               "symbol": [
-                "AXLUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "AXL-USD"
+                "SPXUSDT"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "AXLUSD-PERP",
-                "AXL_USD",
-                "AXL_USDT"
+                "SPXUSD-PERP",
+                "SPX_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "SPX_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "SPXUSD"
+              ],
+              "wsname": [
+                "SPX/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "SPX-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "SPXUSDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "AXL",
-                "AXL"
+                "SPX"
               ],
               "id": [
-                15853,
-                17799
+                28081
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "AXL / USD"
+          "chainlink": "SPX/USD-RefPrice-mainnet-production"
         }
       }
     },
     {
       "id": 330,
-      "full_name": "AXL / USDT",
-      "description": "Axelar",
+      "full_name": "SPX / USDT",
+      "description": "SPX6900",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -25850,38 +25864,38 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "AXL",
+          "base": "SPX",
           "quote": "USDT"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "AXLUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "AXLUSDT"
-              ]
-            },
             "Bybit": {
               "symbol": [
-                "AXLUSDT"
+                "SPXUSDT"
               ]
             },
-            "CryptoCom": {
-              "instrument_name": [
-                "AXL_USDT"
+            "GateIo": {
+              "id": [
+                "SPX_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "SPX-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "SPXUSDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "AXL / USD"
+          "chainlink": "SPX/USD-RefPrice-mainnet-production"
         }
       }
     },
@@ -26031,279 +26045,6 @@
     },
     {
       "id": 333,
-      "full_name": "BRETT / USD",
-      "description": "Brett",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "BRETT",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "BRETTUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "BRETTUSDC",
-                "BRETTUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "BRETT_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "BRETT-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-BRETT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "BRETT",
-                "BRETT",
-                "BRETT",
-                "BRETT",
-                "BRETT",
-                "BRETT",
-                "BRETT"
-              ],
-              "id": [
-                28891,
-                29743,
-                30665,
-                31343,
-                31755,
-                31992,
-                33422
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "BRETT/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 334,
-      "full_name": "BRETT / USDT",
-      "description": "Brett",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "BRETT",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "BRETTUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "BRETTUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "BRETT_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "BRETT-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-BRETT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "BRETT/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 335,
-      "full_name": "BRETT / USDC",
-      "description": "Brett",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "BRETT",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bybit": {
-              "symbol": [
-                "BRETTUSDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "BRETT/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 336,
-      "full_name": "deUSD / USD",
-      "description": "",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "deUSD",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "",
-        "market_hours": "",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "DEUSDUSDT_SPBL"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "DEUSD"
-              ],
-              "id": [
-                31024
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "deUSD / USD"
-        }
-      }
-    },
-    {
-      "id": 337,
-      "full_name": "deUSD / USDT",
-      "description": "",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "deUSD",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "",
-        "market_hours": "",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "DEUSDUSDT_SPBL"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "deUSD / USD"
-        }
-      }
-    },
-    {
-      "id": 338,
       "full_name": "MORPHO / USD",
       "description": "Morpho",
       "type": "price-feed",
@@ -26398,7 +26139,7 @@
       }
     },
     {
-      "id": 339,
+      "id": 334,
       "full_name": "MORPHO / USDT",
       "description": "Morpho",
       "type": "price-feed",
@@ -26463,7 +26204,7 @@
       }
     },
     {
-      "id": 340,
+      "id": 335,
       "full_name": "MORPHO / USDC",
       "description": "Morpho",
       "type": "price-feed",
@@ -26503,7 +26244,7 @@
       }
     },
     {
-      "id": 341,
+      "id": 336,
       "full_name": "RSR / USD",
       "description": "Reserve Rights",
       "type": "price-feed",
@@ -26594,7 +26335,7 @@
       }
     },
     {
-      "id": 342,
+      "id": 337,
       "full_name": "RSR / USDT",
       "description": "Reserve Rights",
       "type": "price-feed",
@@ -26664,7 +26405,7 @@
       }
     },
     {
-      "id": 343,
+      "id": 338,
       "full_name": "RSR / USDC",
       "description": "Reserve Rights",
       "type": "price-feed",
@@ -26709,9 +26450,9 @@
       }
     },
     {
-      "id": 344,
-      "full_name": "1INCH / USD",
-      "description": "1inch",
+      "id": 339,
+      "full_name": "BRETT / USD",
+      "description": "Brett",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -26728,96 +26469,73 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "1INCH",
+          "base": "BRETT",
           "quote": "USD"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "1INCHUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "1INCHUSDT"
-              ]
-            },
             "Bitget": {
               "symbol": [
-                "1INCHUSDT_SPBL"
+                "BRETTUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "1INCHUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "1INCH-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "1INCHUSD-PERP",
-                "1INCH_USD",
-                "1INCH_USDT"
+                "BRETTUSDC",
+                "BRETTUSDT"
               ]
             },
             "GateIo": {
               "id": [
-                "1INCH_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "1INCHUSD"
-              ],
-              "wsname": [
-                "1INCH/USD"
+                "BRETT_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "1INCH-USDT"
+                "BRETT-USDT"
               ]
             },
-            "MEXC": {
-              "symbol": [
-                "1INCHUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "1INCH-USDC",
-                "1INCH-USDT"
+            "Upbit": {
+              "market": [
+                "USDT-BRETT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "1INCH"
+                "BRETT",
+                "BRETT",
+                "BRETT",
+                "BRETT",
+                "BRETT",
+                "BRETT",
+                "BRETT"
               ],
               "id": [
-                8104
+                28891,
+                29743,
+                30665,
+                31343,
+                31755,
+                31992,
+                33422
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "1INCH / USD"
+          "chainlink": "BRETT/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 345,
-      "full_name": "1INCH / USDT",
-      "description": "1inch",
+      "id": 340,
+      "full_name": "BRETT / USDT",
+      "description": "Brett",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -26834,70 +26552,50 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "1INCH",
+          "base": "BRETT",
           "quote": "USDT"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "1INCHUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "1INCHUSDT"
-              ]
-            },
             "Bitget": {
               "symbol": [
-                "1INCHUSDT_SPBL"
+                "BRETTUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "1INCHUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "1INCH_USDT"
+                "BRETTUSDT"
               ]
             },
             "GateIo": {
               "id": [
-                "1INCH_USDT"
+                "BRETT_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "1INCH-USDT"
+                "BRETT-USDT"
               ]
             },
-            "MEXC": {
-              "symbol": [
-                "1INCHUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "1INCH-USDT"
+            "Upbit": {
+              "market": [
+                "USDT-BRETT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "1INCH / USD"
+          "chainlink": "BRETT/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 346,
-      "full_name": "1INCH / USDC",
-      "description": "1inch",
+      "id": 341,
+      "full_name": "BRETT / USDC",
+      "description": "Brett",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -26914,28 +26612,28 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "1INCH",
+          "base": "BRETT",
           "quote": "USDC"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "OKX": {
-              "instId": [
-                "1INCH-USDC"
+            "Bybit": {
+              "symbol": [
+                "BRETTUSDC"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "1INCH / USD"
+          "chainlink": "BRETT/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 347,
+      "id": 342,
       "full_name": "BEAM / USD",
       "description": "Beam",
       "type": "price-feed",
@@ -27020,7 +26718,7 @@
       }
     },
     {
-      "id": 348,
+      "id": 343,
       "full_name": "BEAM / USDT",
       "description": "Beam",
       "type": "price-feed",
@@ -27085,7 +26783,97 @@
       }
     },
     {
-      "id": 349,
+      "id": 344,
+      "full_name": "deUSD / USD",
+      "description": "",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "deUSD",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "",
+        "market_hours": "",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "DEUSDUSDT_SPBL"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "DEUSD"
+              ],
+              "id": [
+                31024
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "deUSD / USD"
+        }
+      }
+    },
+    {
+      "id": 345,
+      "full_name": "deUSD / USDT",
+      "description": "",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "deUSD",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "",
+        "market_hours": "",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "DEUSDUSDT_SPBL"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "deUSD / USD"
+        }
+      }
+    },
+    {
+      "id": 346,
       "full_name": "SNX / USD",
       "description": "Synthetix Network",
       "type": "price-feed",
@@ -27191,7 +26979,7 @@
       }
     },
     {
-      "id": 350,
+      "id": 347,
       "full_name": "SNX / ETH",
       "description": "Synthetix Network",
       "type": "price-feed",
@@ -27241,7 +27029,7 @@
       }
     },
     {
-      "id": 351,
+      "id": 348,
       "full_name": "SNX / USDT",
       "description": "Synthetix Network",
       "type": "price-feed",
@@ -27321,7 +27109,7 @@
       }
     },
     {
-      "id": 352,
+      "id": 349,
       "full_name": "SNX / USDC",
       "description": "Synthetix Network",
       "type": "price-feed",
@@ -27361,9 +27149,9 @@
       }
     },
     {
-      "id": 353,
-      "full_name": "EIGEN / USD",
-      "description": "Eigenlayer",
+      "id": 350,
+      "full_name": "FARTCOIN / USD",
+      "description": "Fartcoin",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -27380,7 +27168,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "EIGEN",
+          "base": "FARTCOIN",
           "quote": "USD"
         },
         "decimals": 18,
@@ -27388,93 +27176,68 @@
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "EIGENUSDC",
-                "EIGENUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "EIGENUSDT"
-              ]
-            },
-            "Bitfinex": {
-              "symbol": [
-                "EIGEN:USD"
-              ]
-            },
             "Bitget": {
               "symbol": [
-                "EIGENUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "EIGENUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "EIGEN-USD"
+                "FARTCOINUSDT_SPBL"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "EIGENUSD-PERP",
-                "EIGEN_USD"
+                "FARTCOINUSD-PERP",
+                "FARTCOIN_USD"
               ]
             },
             "GateIo": {
               "id": [
-                "EIGEN_USDT"
+                "FARTCOIN_USDT"
               ]
             },
             "Kraken": {
               "pair": [
-                "EIGENUSD"
+                "FARTCOINUSD",
+                "FARTCOINUSDC",
+                "FARTCOINUSDT"
               ],
               "wsname": [
-                "EIGEN/USD"
+                "FARTCOIN/USD",
+                "FARTCOIN/USDC",
+                "FARTCOIN/USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "EIGEN-USDT"
+                "FARTCOIN-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "EIGENUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "EIGEN-USDC",
-                "EIGEN-USDT"
+                "FARTCOINUSDC",
+                "FARTCOINUSDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "EIGEN"
+                "FARTCOIN",
+                "FARTCOIN"
               ],
               "id": [
-                30494
+                33597,
+                34814
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "EIGEN/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "FARTCOIN/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 354,
-      "full_name": "EIGEN / USDT",
-      "description": "Eigenlayer",
+      "id": 351,
+      "full_name": "FARTCOIN / USDT",
+      "description": "Fartcoin",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -27491,7 +27254,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "EIGEN",
+          "base": "FARTCOIN",
           "quote": "USDT"
         },
         "decimals": 18,
@@ -27499,57 +27262,45 @@
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "EIGENUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "EIGENUSDT"
-              ]
-            },
             "Bitget": {
               "symbol": [
-                "EIGENUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "EIGENUSDT"
+                "FARTCOINUSDT_SPBL"
               ]
             },
             "GateIo": {
               "id": [
-                "EIGEN_USDT"
+                "FARTCOIN_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "FARTCOINUSDT"
+              ],
+              "wsname": [
+                "FARTCOIN/USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "EIGEN-USDT"
+                "FARTCOIN-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "EIGENUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "EIGEN-USDT"
+                "FARTCOINUSDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "EIGEN/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "FARTCOIN/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 355,
-      "full_name": "EIGEN / USDC",
-      "description": "Eigenlayer",
+      "id": 352,
+      "full_name": "FARTCOIN / USDC",
+      "description": "Fartcoin",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -27566,7 +27317,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "EIGEN",
+          "base": "FARTCOIN",
           "quote": "USDC"
         },
         "decimals": 18,
@@ -27574,20 +27325,249 @@
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "EIGENUSDC"
+            "Kraken": {
+              "pair": [
+                "FARTCOINUSDC"
+              ],
+              "wsname": [
+                "FARTCOIN/USDC"
               ]
             },
-            "OKX": {
-              "instId": [
-                "EIGEN-USDC"
+            "MEXC": {
+              "symbol": [
+                "FARTCOINUSDC"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "EIGEN/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "FARTCOIN/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 353,
+      "full_name": "1INCH / USD",
+      "description": "1inch",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "1INCH",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "1INCHUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "1INCHUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "1INCHUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "1INCHUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "1INCH-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "1INCHUSD-PERP",
+                "1INCH_USD",
+                "1INCH_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "1INCH_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "1INCHUSD"
+              ],
+              "wsname": [
+                "1INCH/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "1INCH-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "1INCHUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "1INCH-USDC",
+                "1INCH-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "1INCH"
+              ],
+              "id": [
+                8104
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "1INCH / USD"
+        }
+      }
+    },
+    {
+      "id": 354,
+      "full_name": "1INCH / USDT",
+      "description": "1inch",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "1INCH",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "1INCHUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "1INCHUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "1INCHUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "1INCHUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "1INCH_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "1INCH_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "1INCH-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "1INCHUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "1INCH-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "1INCH / USD"
+        }
+      }
+    },
+    {
+      "id": 355,
+      "full_name": "1INCH / USDC",
+      "description": "1inch",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "1INCH",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "1INCH-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "1INCH / USD"
         }
       }
     },
@@ -27726,8 +27706,8 @@
     },
     {
       "id": 358,
-      "full_name": "KSM / USD",
-      "description": "Kusama",
+      "full_name": "EIGEN / USD",
+      "description": "Eigenlayer",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -27744,97 +27724,101 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "KSM",
+          "base": "EIGEN",
           "quote": "USD"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
             "Binance": {
               "symbol": [
-                "KSMUSDT"
+                "EIGENUSDC",
+                "EIGENUSDT"
               ]
             },
             "BinanceUS": {
               "symbol": [
-                "KSMUSDT"
+                "EIGENUSDT"
+              ]
+            },
+            "Bitfinex": {
+              "symbol": [
+                "EIGEN:USD"
               ]
             },
             "Bitget": {
               "symbol": [
-                "KSMUSDT_SPBL"
+                "EIGENUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "KSMUSDT"
+                "EIGENUSDT"
               ]
             },
             "Coinbase": {
               "id": [
-                "KSM-USD",
-                "KSM-USDT"
+                "EIGEN-USD"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "KSMUSD-PERP",
-                "KSM_USD",
-                "KSM_USDT"
+                "EIGENUSD-PERP",
+                "EIGEN_USD"
               ]
             },
             "GateIo": {
               "id": [
-                "KSM_USDT"
+                "EIGEN_USDT"
               ]
             },
             "Kraken": {
               "pair": [
-                "KSMUSD"
+                "EIGENUSD"
               ],
               "wsname": [
-                "KSM/USD"
+                "EIGEN/USD"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "KSM-USDT"
+                "EIGEN-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "KSMUSDT"
+                "EIGENUSDT"
               ]
             },
             "OKX": {
               "instId": [
-                "KSM-USDC",
-                "KSM-USDT"
+                "EIGEN-USDC",
+                "EIGEN-USDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "KSM"
+                "EIGEN"
               ],
               "id": [
-                5034
+                30494
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "KSM / USD"
+          "chainlink": "EIGEN/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
       "id": 359,
-      "full_name": "KSM / USDT",
-      "description": "Kusama",
+      "full_name": "EIGEN / USDT",
+      "description": "Eigenlayer",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -27851,75 +27835,65 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "KSM",
+          "base": "EIGEN",
           "quote": "USDT"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
             "Binance": {
               "symbol": [
-                "KSMUSDT"
+                "EIGENUSDT"
               ]
             },
             "BinanceUS": {
               "symbol": [
-                "KSMUSDT"
+                "EIGENUSDT"
               ]
             },
             "Bitget": {
               "symbol": [
-                "KSMUSDT_SPBL"
+                "EIGENUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "KSMUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "KSM-USDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "KSM_USDT"
+                "EIGENUSDT"
               ]
             },
             "GateIo": {
               "id": [
-                "KSM_USDT"
+                "EIGEN_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "KSM-USDT"
+                "EIGEN-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "KSMUSDT"
+                "EIGENUSDT"
               ]
             },
             "OKX": {
               "instId": [
-                "KSM-USDT"
+                "EIGEN-USDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "KSM / USD"
+          "chainlink": "EIGEN/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
       "id": 360,
-      "full_name": "KSM / USDC",
-      "description": "Kusama",
+      "full_name": "EIGEN / USDC",
+      "description": "Eigenlayer",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -27936,23 +27910,28 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "KSM",
+          "base": "EIGEN",
           "quote": "USDC"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
+            "Binance": {
+              "symbol": [
+                "EIGENUSDC"
+              ]
+            },
             "OKX": {
               "instId": [
-                "KSM-USDC"
+                "EIGEN-USDC"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "KSM / USD"
+          "chainlink": "EIGEN/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
@@ -28186,6 +28165,238 @@
     },
     {
       "id": 364,
+      "full_name": "KSM / USD",
+      "description": "Kusama",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "KSM",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "KSMUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "KSMUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "KSMUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "KSMUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "KSM-USD",
+                "KSM-USDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "KSMUSD-PERP",
+                "KSM_USD",
+                "KSM_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "KSM_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "KSMUSD"
+              ],
+              "wsname": [
+                "KSM/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "KSM-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "KSMUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "KSM-USDC",
+                "KSM-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "KSM"
+              ],
+              "id": [
+                5034
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "KSM / USD"
+        }
+      }
+    },
+    {
+      "id": 365,
+      "full_name": "KSM / USDT",
+      "description": "Kusama",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "KSM",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "KSMUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "KSMUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "KSMUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "KSMUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "KSM-USDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "KSM_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "KSM_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "KSM-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "KSMUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "KSM-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "KSM / USD"
+        }
+      }
+    },
+    {
+      "id": 366,
+      "full_name": "KSM / USDC",
+      "description": "Kusama",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "KSM",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "KSM-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "KSM / USD"
+        }
+      }
+    },
+    {
+      "id": 367,
       "full_name": "SATS / USD",
       "description": "SATS (Ordinals)",
       "type": "price-feed",
@@ -28263,7 +28474,7 @@
       }
     },
     {
-      "id": 365,
+      "id": 368,
       "full_name": "SATS / USDT",
       "description": "SATS (Ordinals)",
       "type": "price-feed",
@@ -28328,7 +28539,7 @@
       }
     },
     {
-      "id": 366,
+      "id": 369,
       "full_name": "SATS / USDC",
       "description": "SATS (Ordinals)",
       "type": "price-feed",
@@ -28368,9 +28579,9 @@
       }
     },
     {
-      "id": 367,
-      "full_name": "FARTCOIN / USD",
-      "description": "Fartcoin",
+      "id": 370,
+      "full_name": "ASTR / USD",
+      "description": "Astar",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -28387,7 +28598,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "FARTCOIN",
+          "base": "ASTR",
           "quote": "USD"
         },
         "decimals": 18,
@@ -28395,68 +28606,83 @@
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ASTRUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "ASTRUSDT"
+              ]
+            },
             "Bitget": {
               "symbol": [
-                "FARTCOINUSDT_SPBL"
+                "ASTRUSDT_SPBL"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "FARTCOINUSD-PERP",
-                "FARTCOIN_USD"
+                "ASTRUSD-PERP",
+                "ASTR_USD",
+                "ASTR_USDT"
               ]
             },
             "GateIo": {
               "id": [
-                "FARTCOIN_USDT"
+                "ASTR_USDT"
               ]
             },
             "Kraken": {
               "pair": [
-                "FARTCOINUSD",
-                "FARTCOINUSDC",
-                "FARTCOINUSDT"
+                "ASTRUSD"
               ],
               "wsname": [
-                "FARTCOIN/USD",
-                "FARTCOIN/USDC",
-                "FARTCOIN/USDT"
+                "ASTR/USD"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "FARTCOIN-USDT"
+                "ASTR-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "FARTCOINUSDC",
-                "FARTCOINUSDT"
+                "ASTRUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ASTR-USDC",
+                "ASTR-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-ASTR"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "FARTCOIN",
-                "FARTCOIN"
+                "ASTR"
               ],
               "id": [
-                33597,
-                34814
+                12885
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "FARTCOIN/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "ASTR/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 368,
-      "full_name": "FARTCOIN / USDT",
-      "description": "Fartcoin",
+      "id": 371,
+      "full_name": "ASTR / USDT",
+      "description": "Astar",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -28473,7 +28699,442 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "FARTCOIN",
+          "base": "ASTR",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ASTRUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "ASTRUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ASTRUSDT_SPBL"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ASTR_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ASTR_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ASTR-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ASTRUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ASTR-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-ASTR"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ASTR/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 372,
+      "full_name": "ASTR / USDC",
+      "description": "Astar",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ASTR",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "ASTR-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ASTR/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 373,
+      "full_name": "ZIL / USD",
+      "description": "Zilliqa",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ZIL",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ZILUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "ZILUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ZILUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ZILUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ZIL_USD",
+                "ZIL_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ZIL_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ZIL-USDC",
+                "ZIL-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ZILUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ZIL-USDC",
+                "ZIL-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "ZIL"
+              ],
+              "id": [
+                2469
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ZIL / USD"
+        }
+      }
+    },
+    {
+      "id": 374,
+      "full_name": "ZIL / USDT",
+      "description": "Zilliqa",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ZIL",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ZILUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "ZILUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ZILUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ZILUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ZIL_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ZIL_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ZIL-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ZILUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ZIL-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ZIL / USD"
+        }
+      }
+    },
+    {
+      "id": 375,
+      "full_name": "ZIL / USDC",
+      "description": "Zilliqa",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ZIL",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "KuCoin": {
+              "symbol": [
+                "ZIL-USDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ZIL-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ZIL / USD"
+        }
+      }
+    },
+    {
+      "id": 376,
+      "full_name": "ATH / USD",
+      "description": "Aethir",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ATH",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitfinex": {
+              "symbol": [
+                "ATHUSD"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ATHUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ATHUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ATH_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ATH_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "ATHUSD"
+              ],
+              "wsname": [
+                "ATH/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ATH-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ATHUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ATH-USD",
+                "ATH-USDC",
+                "ATH-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "ATH",
+                "ATH"
+              ],
+              "id": [
+                30083,
+                34278
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ATH/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 377,
+      "full_name": "ATH / USDT",
+      "description": "Aethir",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ATH",
           "quote": "USDT"
         },
         "decimals": 18,
@@ -28483,43 +29144,45 @@
           "exchanges": {
             "Bitget": {
               "symbol": [
-                "FARTCOINUSDT_SPBL"
+                "ATHUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ATHUSDT"
               ]
             },
             "GateIo": {
               "id": [
-                "FARTCOIN_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "FARTCOINUSDT"
-              ],
-              "wsname": [
-                "FARTCOIN/USDT"
+                "ATH_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "FARTCOIN-USDT"
+                "ATH-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "FARTCOINUSDT"
+                "ATHUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ATH-USDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "FARTCOIN/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "ATH/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 369,
-      "full_name": "FARTCOIN / USDC",
-      "description": "Fartcoin",
+      "id": 378,
+      "full_name": "ATH / USDC",
+      "description": "Aethir",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -28536,7 +29199,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "FARTCOIN",
+          "base": "ATH",
           "quote": "USDC"
         },
         "decimals": 18,
@@ -28544,28 +29207,20 @@
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Kraken": {
-              "pair": [
-                "FARTCOINUSDC"
-              ],
-              "wsname": [
-                "FARTCOIN/USDC"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "FARTCOINUSDC"
+            "OKX": {
+              "instId": [
+                "ATH-USDC"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "FARTCOIN/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "ATH/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 370,
+      "id": 379,
       "full_name": "BLUR / USD",
       "description": "Blur",
       "type": "price-feed",
@@ -28672,7 +29327,7 @@
       }
     },
     {
-      "id": 371,
+      "id": 380,
       "full_name": "BLUR / USDT",
       "description": "Blur",
       "type": "price-feed",
@@ -28747,7 +29402,7 @@
       }
     },
     {
-      "id": 372,
+      "id": 381,
       "full_name": "BLUR / USDC",
       "description": "Blur",
       "type": "price-feed",
@@ -28797,9 +29452,9 @@
       }
     },
     {
-      "id": 373,
-      "full_name": "ASTR / USD",
-      "description": "Astar",
+      "id": 382,
+      "full_name": "NOT / USD",
+      "description": "Notcoin",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -28816,7 +29471,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "ASTR",
+          "base": "NOT",
           "quote": "USD"
         },
         "decimals": 18,
@@ -28826,81 +29481,84 @@
           "exchanges": {
             "Binance": {
               "symbol": [
-                "ASTRUSDT"
+                "NOTUSDC",
+                "NOTUSDT"
               ]
             },
-            "BinanceUS": {
+            "Bitfinex": {
               "symbol": [
-                "ASTRUSDT"
+                "NOTUSD"
               ]
             },
             "Bitget": {
               "symbol": [
-                "ASTRUSDT_SPBL"
+                "NOTUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "NOTUSDC",
+                "NOTUSDT"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "ASTRUSD-PERP",
-                "ASTR_USD",
-                "ASTR_USDT"
+                "NOTUSD-PERP",
+                "NOT_USD",
+                "NOT_USDT"
               ]
             },
             "GateIo": {
               "id": [
-                "ASTR_USDT"
+                "NOT_USDC",
+                "NOT_USDT"
               ]
             },
             "Kraken": {
               "pair": [
-                "ASTRUSD"
+                "NOTUSD"
               ],
               "wsname": [
-                "ASTR/USD"
+                "NOT/USD"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "ASTR-USDT"
+                "NOT-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "ASTRUSDT"
+                "NOTUSDT"
               ]
             },
             "OKX": {
               "instId": [
-                "ASTR-USDC",
-                "ASTR-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-ASTR"
+                "NOT-USDC",
+                "NOT-USDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "ASTR"
+                "NOT"
               ],
               "id": [
-                12885
+                28850
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "ASTR/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "NOT/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 374,
-      "full_name": "ASTR / USDT",
-      "description": "Astar",
+      "id": 383,
+      "full_name": "NOT / USDT",
+      "description": "Notcoin",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -28917,7 +29575,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "ASTR",
+          "base": "NOT",
           "quote": "USDT"
         },
         "decimals": 18,
@@ -28927,60 +29585,55 @@
           "exchanges": {
             "Binance": {
               "symbol": [
-                "ASTRUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "ASTRUSDT"
+                "NOTUSDT"
               ]
             },
             "Bitget": {
               "symbol": [
-                "ASTRUSDT_SPBL"
+                "NOTUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "NOTUSDT"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "ASTR_USDT"
+                "NOT_USDT"
               ]
             },
             "GateIo": {
               "id": [
-                "ASTR_USDT"
+                "NOT_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "ASTR-USDT"
+                "NOT-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "ASTRUSDT"
+                "NOTUSDT"
               ]
             },
             "OKX": {
               "instId": [
-                "ASTR-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-ASTR"
+                "NOT-USDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "ASTR/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "NOT/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 375,
-      "full_name": "ASTR / USDC",
-      "description": "Astar",
+      "id": 384,
+      "full_name": "NOT / USDC",
+      "description": "Notcoin",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -28997,7 +29650,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "ASTR",
+          "base": "NOT",
           "quote": "USDC"
         },
         "decimals": 18,
@@ -29005,238 +29658,35 @@
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "OKX": {
-              "instId": [
-                "ASTR-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ASTR/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 376,
-      "full_name": "ZIL / USD",
-      "description": "Zilliqa",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ZIL",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
             "Binance": {
               "symbol": [
-                "ZILUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "ZILUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ZILUSDT_SPBL"
+                "NOTUSDC"
               ]
             },
             "Bybit": {
               "symbol": [
-                "ZILUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ZIL_USD",
-                "ZIL_USDT"
+                "NOTUSDC"
               ]
             },
             "GateIo": {
               "id": [
-                "ZIL_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ZIL-USDC",
-                "ZIL-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ZILUSDT"
+                "NOT_USDC"
               ]
             },
             "OKX": {
               "instId": [
-                "ZIL-USDC",
-                "ZIL-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "ZIL"
-              ],
-              "id": [
-                2469
+                "NOT-USDC"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "ZIL / USD"
+          "chainlink": "NOT/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 377,
-      "full_name": "ZIL / USDT",
-      "description": "Zilliqa",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ZIL",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ZILUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "ZILUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ZILUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ZILUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ZIL_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ZIL_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ZIL-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ZILUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ZIL-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ZIL / USD"
-        }
-      }
-    },
-    {
-      "id": 378,
-      "full_name": "ZIL / USDC",
-      "description": "Zilliqa",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ZIL",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "KuCoin": {
-              "symbol": [
-                "ZIL-USDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ZIL-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ZIL / USD"
-        }
-      }
-    },
-    {
-      "id": 379,
+      "id": 385,
       "full_name": "USDD / USD",
       "description": "USDD",
       "type": "price-feed",
@@ -29297,7 +29747,7 @@
       }
     },
     {
-      "id": 380,
+      "id": 386,
       "full_name": "USDD / USDT",
       "description": "USDD",
       "type": "price-feed",
@@ -29347,7 +29797,7 @@
       }
     },
     {
-      "id": 381,
+      "id": 387,
       "full_name": "USDD / USDC",
       "description": "USDD",
       "type": "price-feed",
@@ -29387,7 +29837,7 @@
       }
     },
     {
-      "id": 382,
+      "id": 388,
       "full_name": "BAT / USD",
       "description": "Basic Attention Token",
       "type": "price-feed",
@@ -29505,7 +29955,7 @@
       }
     },
     {
-      "id": 383,
+      "id": 389,
       "full_name": "BAT / ETH",
       "description": "Basic Attention Token",
       "type": "price-feed",
@@ -29550,7 +30000,7 @@
       }
     },
     {
-      "id": 384,
+      "id": 390,
       "full_name": "BAT / USDT",
       "description": "Basic Attention Token",
       "type": "price-feed",
@@ -29635,7 +30085,7 @@
       }
     },
     {
-      "id": 385,
+      "id": 391,
       "full_name": "BAT / USDC",
       "description": "Basic Attention Token",
       "type": "price-feed",
@@ -29685,7 +30135,7 @@
       }
     },
     {
-      "id": 386,
+      "id": 392,
       "full_name": "MASK / USD",
       "description": "Mask Network",
       "type": "price-feed",
@@ -29797,7 +30247,7 @@
       }
     },
     {
-      "id": 387,
+      "id": 393,
       "full_name": "MASK / USDT",
       "description": "Mask Network",
       "type": "price-feed",
@@ -29882,7 +30332,7 @@
       }
     },
     {
-      "id": 388,
+      "id": 394,
       "full_name": "MASK / USDC",
       "description": "Mask Network",
       "type": "price-feed",
@@ -29922,416 +30372,9 @@
       }
     },
     {
-      "id": 389,
-      "full_name": "ATH / USD",
-      "description": "Aethir",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ATH",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitfinex": {
-              "symbol": [
-                "ATHUSD"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ATHUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ATHUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ATH_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ATH_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "ATHUSD"
-              ],
-              "wsname": [
-                "ATH/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ATH-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ATHUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ATH-USD",
-                "ATH-USDC",
-                "ATH-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "ATH",
-                "ATH"
-              ],
-              "id": [
-                30083,
-                34278
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ATH/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 390,
-      "full_name": "ATH / USDT",
-      "description": "Aethir",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ATH",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "ATHUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ATHUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ATH_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ATH-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ATHUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ATH-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ATH/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 391,
-      "full_name": "ATH / USDC",
-      "description": "Aethir",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ATH",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "ATH-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ATH/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 392,
-      "full_name": "AI16Z / USD",
-      "description": "ai16z",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AI16Z",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "AI16ZUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "AI16ZUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "AI16ZUSD-PERP",
-                "AI16Z_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "AI16Z_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "AI16ZUSD",
-                "AI16ZUSDC",
-                "AI16ZUSDT"
-              ],
-              "wsname": [
-                "AI16Z/USD",
-                "AI16Z/USDC",
-                "AI16Z/USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "AI16Z-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "AI16ZUSDC",
-                "AI16ZUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "AI16Z"
-              ],
-              "id": [
-                34026
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AI16Z/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 393,
-      "full_name": "AI16Z / USDT",
-      "description": "ai16z",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AI16Z",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "AI16ZUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "AI16ZUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "AI16Z_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "AI16ZUSDT"
-              ],
-              "wsname": [
-                "AI16Z/USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "AI16Z-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "AI16ZUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AI16Z/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 394,
-      "full_name": "AI16Z / USDC",
-      "description": "ai16z",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AI16Z",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Kraken": {
-              "pair": [
-                "AI16ZUSDC"
-              ],
-              "wsname": [
-                "AI16Z/USDC"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "AI16ZUSDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AI16Z/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
       "id": 395,
-      "full_name": "WEMIX / USD",
-      "description": "WEMIX",
+      "full_name": "ID / USD",
+      "description": "SPACE ID",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -30348,65 +30391,73 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "WEMIX",
+          "base": "ID",
           "quote": "USD"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
+            "Binance": {
+              "symbol": [
+                "IDUSDT"
+              ]
+            },
             "Bitget": {
               "symbol": [
-                "WEMIXUSDT_SPBL"
+                "IDUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "WEMIXUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "WEMIX_USD"
+                "IDUSDT"
               ]
             },
             "GateIo": {
               "id": [
-                "WEMIX_USDT"
+                "ID_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "WEMIX-USDT"
+                "ID-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "WEMIXUSDT"
+                "IDUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ID-USDC",
+                "ID-USDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "WEMIX"
+                "ID",
+                "ID"
               ],
               "id": [
-                7548
+                21846,
+                8495
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "WEMIX / USD"
+          "chainlink": "ID/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
       "id": 396,
-      "full_name": "WEMIX / USDT",
-      "description": "WEMIX",
+      "full_name": "ID / USDT",
+      "description": "SPACE ID",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -30423,48 +30474,98 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "WEMIX",
+          "base": "ID",
           "quote": "USDT"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
+            "Binance": {
+              "symbol": [
+                "IDUSDT"
+              ]
+            },
             "Bitget": {
               "symbol": [
-                "WEMIXUSDT_SPBL"
+                "IDUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "WEMIXUSDT"
+                "IDUSDT"
               ]
             },
             "GateIo": {
               "id": [
-                "WEMIX_USDT"
+                "ID_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "WEMIX-USDT"
+                "ID-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "WEMIXUSDT"
+                "IDUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ID-USDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "WEMIX / USD"
+          "chainlink": "ID/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
       "id": 397,
+      "full_name": "ID / USDC",
+      "description": "SPACE ID",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ID",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "ID-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ID/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 398,
       "full_name": "ZRX / USD",
       "description": "0x",
       "type": "price-feed",
@@ -30584,7 +30685,7 @@
       }
     },
     {
-      "id": 398,
+      "id": 399,
       "full_name": "ZRX / ETH",
       "description": "0x",
       "type": "price-feed",
@@ -30624,7 +30725,7 @@
       }
     },
     {
-      "id": 399,
+      "id": 400,
       "full_name": "ZRX / USDT",
       "description": "0x",
       "type": "price-feed",
@@ -30704,7 +30805,7 @@
       }
     },
     {
-      "id": 400,
+      "id": 401,
       "full_name": "ZRX / USDC",
       "description": "0x",
       "type": "price-feed",
@@ -30744,440 +30845,7 @@
       }
     },
     {
-      "id": 401,
-      "full_name": "NOT / USD",
-      "description": "Notcoin",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "NOT",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "NOTUSDC",
-                "NOTUSDT"
-              ]
-            },
-            "Bitfinex": {
-              "symbol": [
-                "NOTUSD"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "NOTUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "NOTUSDC",
-                "NOTUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "NOTUSD-PERP",
-                "NOT_USD",
-                "NOT_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "NOT_USDC",
-                "NOT_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "NOTUSD"
-              ],
-              "wsname": [
-                "NOT/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "NOT-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "NOTUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "NOT-USDC",
-                "NOT-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "NOT"
-              ],
-              "id": [
-                28850
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "NOT/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
       "id": 402,
-      "full_name": "NOT / USDT",
-      "description": "Notcoin",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "NOT",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "NOTUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "NOTUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "NOTUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "NOT_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "NOT_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "NOT-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "NOTUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "NOT-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "NOT/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 403,
-      "full_name": "NOT / USDC",
-      "description": "Notcoin",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "NOT",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "NOTUSDC"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "NOTUSDC"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "NOT_USDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "NOT-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "NOT/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 404,
-      "full_name": "CVX / USD",
-      "description": "Convex Finance",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "CVX",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "CVXUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "CVXUSDT_SPBL"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "CVX-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "CVX_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "CVX_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "CVXUSD"
-              ],
-              "wsname": [
-                "CVX/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "CVX-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "CVXUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "CVX-USDC",
-                "CVX-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "CVX"
-              ],
-              "id": [
-                9903
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "CVX / USD"
-        }
-      }
-    },
-    {
-      "id": 405,
-      "full_name": "CVX / USDT",
-      "description": "Convex Finance",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "CVX",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "CVXUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "CVXUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "CVX_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "CVX-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "CVXUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "CVX-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "CVX / USD"
-        }
-      }
-    },
-    {
-      "id": 406,
-      "full_name": "CVX / USDC",
-      "description": "Convex Finance",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "CVX",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "CVX-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "CVX / USD"
-        }
-      }
-    },
-    {
-      "id": 407,
       "full_name": "ZRO / USD",
       "description": "LayerZero",
       "type": "price-feed",
@@ -31290,7 +30958,7 @@
       }
     },
     {
-      "id": 408,
+      "id": 403,
       "full_name": "ZRO / USDT",
       "description": "LayerZero",
       "type": "price-feed",
@@ -31370,7 +31038,7 @@
       }
     },
     {
-      "id": 409,
+      "id": 404,
       "full_name": "ZRO / USDC",
       "description": "LayerZero",
       "type": "price-feed",
@@ -31420,7 +31088,7 @@
       }
     },
     {
-      "id": 410,
+      "id": 405,
       "full_name": "HOT / USD",
       "description": "Holo",
       "type": "price-feed",
@@ -31500,7 +31168,7 @@
       }
     },
     {
-      "id": 411,
+      "id": 406,
       "full_name": "HOT / USDT",
       "description": "Holo",
       "type": "price-feed",
@@ -31561,6 +31229,356 @@
         },
         "compatibility_info": {
           "chainlink": "HOT/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 407,
+      "full_name": "WEMIX / USD",
+      "description": "WEMIX",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "WEMIX",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "WEMIXUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "WEMIXUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "WEMIX_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "WEMIX_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "WEMIX-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "WEMIXUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "WEMIX"
+              ],
+              "id": [
+                7548
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "WEMIX / USD"
+        }
+      }
+    },
+    {
+      "id": 408,
+      "full_name": "WEMIX / USDT",
+      "description": "WEMIX",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "WEMIX",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "WEMIXUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "WEMIXUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "WEMIX_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "WEMIX-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "WEMIXUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "WEMIX / USD"
+        }
+      }
+    },
+    {
+      "id": 409,
+      "full_name": "ORDI / USD",
+      "description": "ORDI",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ORDI",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ORDIUSDC",
+                "ORDIUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ORDIUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ORDIUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ORDIUSD-PERP",
+                "ORDI_USD",
+                "ORDI_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ORDI_USDC",
+                "ORDI_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ORDI-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ORDIUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ORDI-USDC",
+                "ORDI-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "ORDI"
+              ],
+              "id": [
+                25028
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ORDI/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 410,
+      "full_name": "ORDI / USDT",
+      "description": "ORDI",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ORDI",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ORDIUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ORDIUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ORDIUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ORDI_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ORDI_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ORDI-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ORDIUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ORDI-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ORDI/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 411,
+      "full_name": "ORDI / USDC",
+      "description": "ORDI",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ORDI",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ORDIUSDC"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ORDI_USDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ORDI-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ORDI/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
@@ -31777,8 +31795,8 @@
     },
     {
       "id": 415,
-      "full_name": "ID / USD",
-      "description": "SPACE ID",
+      "full_name": "AI16Z / USD",
+      "description": "ai16z",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -31795,7 +31813,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "ID",
+          "base": "AI16Z",
           "quote": "USD"
         },
         "decimals": 18,
@@ -31803,65 +31821,71 @@
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "IDUSDT"
-              ]
-            },
             "Bitget": {
               "symbol": [
-                "IDUSDT_SPBL"
+                "AI16ZUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "IDUSDT"
+                "AI16ZUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "AI16ZUSD-PERP",
+                "AI16Z_USD"
               ]
             },
             "GateIo": {
               "id": [
-                "ID_USDT"
+                "AI16Z_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "AI16ZUSD",
+                "AI16ZUSDC",
+                "AI16ZUSDT"
+              ],
+              "wsname": [
+                "AI16Z/USD",
+                "AI16Z/USDC",
+                "AI16Z/USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "ID-USDT"
+                "AI16Z-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "IDUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ID-USDC",
-                "ID-USDT"
+                "AI16ZUSDC",
+                "AI16ZUSDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "ID",
-                "ID"
+                "AI16Z"
               ],
               "id": [
-                21846,
-                8495
+                34026
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "ID/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "AI16Z/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
       "id": 416,
-      "full_name": "ID / USDT",
-      "description": "SPACE ID",
+      "full_name": "AI16Z / USDT",
+      "description": "ai16z",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -31878,7 +31902,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "ID",
+          "base": "AI16Z",
           "quote": "USDT"
         },
         "decimals": 18,
@@ -31886,52 +31910,50 @@
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "IDUSDT"
-              ]
-            },
             "Bitget": {
               "symbol": [
-                "IDUSDT_SPBL"
+                "AI16ZUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "IDUSDT"
+                "AI16ZUSDT"
               ]
             },
             "GateIo": {
               "id": [
-                "ID_USDT"
+                "AI16Z_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "AI16ZUSDT"
+              ],
+              "wsname": [
+                "AI16Z/USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "ID-USDT"
+                "AI16Z-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "IDUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ID-USDT"
+                "AI16ZUSDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "ID/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "AI16Z/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
       "id": 417,
-      "full_name": "ID / USDC",
-      "description": "SPACE ID",
+      "full_name": "AI16Z / USDC",
+      "description": "ai16z",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -31948,7 +31970,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "ID",
+          "base": "AI16Z",
           "quote": "USDC"
         },
         "decimals": 18,
@@ -31956,22 +31978,30 @@
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "OKX": {
-              "instId": [
-                "ID-USDC"
+            "Kraken": {
+              "pair": [
+                "AI16ZUSDC"
+              ],
+              "wsname": [
+                "AI16Z/USDC"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "AI16ZUSDC"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "ID/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "AI16Z/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
       "id": 418,
-      "full_name": "DGB / USD",
-      "description": "Digibyte",
+      "full_name": "CVX / USD",
+      "description": "Convex Finance",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -31988,7 +32018,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "DGB",
+          "base": "CVX",
           "quote": "USD"
         },
         "decimals": 8,
@@ -31998,66 +32028,74 @@
           "exchanges": {
             "Binance": {
               "symbol": [
-                "DGBUSDT"
+                "CVXUSDT"
               ]
             },
-            "BinanceUS": {
+            "Bitget": {
               "symbol": [
-                "DGBUSDT"
+                "CVXUSDT_SPBL"
               ]
             },
-            "Bybit": {
-              "symbol": [
-                "DGBUSDT"
+            "Coinbase": {
+              "id": [
+                "CVX-USD"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "DGB_USD"
+                "CVX_USD"
               ]
             },
             "GateIo": {
               "id": [
-                "DGB_USDT"
+                "CVX_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "CVXUSD"
+              ],
+              "wsname": [
+                "CVX/USD"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "DGB-USDT"
+                "CVX-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "CVXUSDT"
               ]
             },
             "OKX": {
               "instId": [
-                "DGB-USDC",
-                "DGB-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-DGB"
+                "CVX-USDC",
+                "CVX-USDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "DGB"
+                "CVX"
               ],
               "id": [
-                109
+                9903
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "DGB / USD"
+          "chainlink": "CVX / USD"
         }
       }
     },
     {
       "id": 419,
-      "full_name": "DGB / USDT",
-      "description": "Digibyte",
+      "full_name": "CVX / USDT",
+      "description": "Convex Finance",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -32074,7 +32112,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "DGB",
+          "base": "CVX",
           "quote": "USDT"
         },
         "decimals": 8,
@@ -32084,50 +32122,45 @@
           "exchanges": {
             "Binance": {
               "symbol": [
-                "DGBUSDT"
+                "CVXUSDT"
               ]
             },
-            "BinanceUS": {
+            "Bitget": {
               "symbol": [
-                "DGBUSDT"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "DGBUSDT"
+                "CVXUSDT_SPBL"
               ]
             },
             "GateIo": {
               "id": [
-                "DGB_USDT"
+                "CVX_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "DGB-USDT"
+                "CVX-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "CVXUSDT"
               ]
             },
             "OKX": {
               "instId": [
-                "DGB-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-DGB"
+                "CVX-USDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "DGB / USD"
+          "chainlink": "CVX / USD"
         }
       }
     },
     {
       "id": 420,
-      "full_name": "DGB / USDC",
-      "description": "Digibyte",
+      "full_name": "CVX / USDC",
+      "description": "Convex Finance",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -32144,7 +32177,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "DGB",
+          "base": "CVX",
           "quote": "USDC"
         },
         "decimals": 8,
@@ -32154,18 +32187,177 @@
           "exchanges": {
             "OKX": {
               "instId": [
-                "DGB-USDC"
+                "CVX-USDC"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "DGB / USD"
+          "chainlink": "CVX / USD"
         }
       }
     },
     {
       "id": 421,
+      "full_name": "MOG / USD",
+      "description": "Mog Coin",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "MOG",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "MOGUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "MOGUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "MOG-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "MOGUSD-PERP",
+                "MOG_USD",
+                "MOG_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "MOG_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "MOGUSD"
+              ],
+              "wsname": [
+                "MOG/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "MOG-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "MOGUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "MOG",
+                "MOG",
+                "MOG"
+              ],
+              "id": [
+                27659,
+                33033,
+                34170
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "MOG/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 422,
+      "full_name": "MOG / USDT",
+      "description": "Mog Coin",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "MOG",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "MOGUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "MOGUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "MOG_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "MOG_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "MOG-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "MOGUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "MOG/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 423,
       "full_name": "ANKR / USD",
       "description": "Ankr",
       "type": "price-feed",
@@ -32271,7 +32463,7 @@
       }
     },
     {
-      "id": 422,
+      "id": 424,
       "full_name": "ANKR / USDT",
       "description": "Ankr",
       "type": "price-feed",
@@ -32346,7 +32538,7 @@
       }
     },
     {
-      "id": 423,
+      "id": 425,
       "full_name": "ANKR / USDC",
       "description": "Ankr",
       "type": "price-feed",
@@ -32386,445 +32578,7 @@
       }
     },
     {
-      "id": 424,
-      "full_name": "ORDI / USD",
-      "description": "ORDI",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ORDI",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ORDIUSDC",
-                "ORDIUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ORDIUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ORDIUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ORDIUSD-PERP",
-                "ORDI_USD",
-                "ORDI_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ORDI_USDC",
-                "ORDI_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ORDI-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ORDIUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ORDI-USDC",
-                "ORDI-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "ORDI"
-              ],
-              "id": [
-                25028
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ORDI/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 425,
-      "full_name": "ORDI / USDT",
-      "description": "ORDI",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ORDI",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ORDIUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ORDIUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ORDIUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ORDI_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ORDI_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ORDI-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ORDIUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ORDI-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ORDI/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
       "id": 426,
-      "full_name": "ORDI / USDC",
-      "description": "ORDI",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ORDI",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ORDIUSDC"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ORDI_USDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ORDI-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ORDI/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 427,
-      "full_name": "ONE / USD",
-      "description": "Harmony",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ONE",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ONEUSDC",
-                "ONEUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "ONEUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ONEUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ONEUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ONEUSD-PERP",
-                "ONE_USD",
-                "ONE_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ONE_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ONE-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ONEUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ONE-USDC",
-                "ONE-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "ONE",
-                "ONE",
-                "ONE"
-              ],
-              "id": [
-                2324,
-                24085,
-                3945
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ONE / USD"
-        }
-      }
-    },
-    {
-      "id": 428,
-      "full_name": "ONE / USDT",
-      "description": "Harmony",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ONE",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ONEUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "ONEUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "ONEUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ONEUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ONE_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ONE_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ONE-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ONEUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ONE-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ONE / USD"
-        }
-      }
-    },
-    {
-      "id": 429,
-      "full_name": "ONE / USDC",
-      "description": "Harmony",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ONE",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ONEUSDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ONE-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ONE / USD"
-        }
-      }
-    },
-    {
-      "id": 430,
       "full_name": "YFI / USD",
       "description": "Yearn Finance",
       "type": "price-feed",
@@ -32939,7 +32693,7 @@
       }
     },
     {
-      "id": 431,
+      "id": 427,
       "full_name": "YFI / BNB",
       "description": "Yearn Finance",
       "type": "price-feed",
@@ -32979,7 +32733,7 @@
       }
     },
     {
-      "id": 432,
+      "id": 428,
       "full_name": "YFI / ETH",
       "description": "Yearn Finance",
       "type": "price-feed",
@@ -33019,7 +32773,7 @@
       }
     },
     {
-      "id": 433,
+      "id": 429,
       "full_name": "YFI / USDT",
       "description": "Yearn Finance",
       "type": "price-feed",
@@ -33094,7 +32848,7 @@
       }
     },
     {
-      "id": 434,
+      "id": 430,
       "full_name": "YFI / USDC",
       "description": "Yearn Finance",
       "type": "price-feed",
@@ -33134,528 +32888,7 @@
       }
     },
     {
-      "id": 435,
-      "full_name": "POPCAT / USD",
-      "description": "POPCAT",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "POPCAT",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bybit": {
-              "symbol": [
-                "POPCATUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "POPCAT-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "POPCATUSD-PERP",
-                "POPCAT_USD",
-                "POPCAT_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "POPCAT_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "POPCATUSD"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "POPCATUSD"
-              ],
-              "wsname": [
-                "POPCAT/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "POPCAT-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "POPCATUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "POPCAT",
-                "POPCAT"
-              ],
-              "id": [
-                28782,
-                33470
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "POPCAT/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 436,
-      "full_name": "POPCAT / USDT",
-      "description": "POPCAT",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "POPCAT",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bybit": {
-              "symbol": [
-                "POPCATUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "POPCAT_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "POPCAT_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "POPCAT-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "POPCATUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "POPCAT/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 437,
-      "full_name": "MOG / USD",
-      "description": "Mog Coin",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "MOG",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "MOGUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "MOGUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "MOG-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "MOGUSD-PERP",
-                "MOG_USD",
-                "MOG_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "MOG_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "MOGUSD"
-              ],
-              "wsname": [
-                "MOG/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "MOG-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "MOGUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "MOG",
-                "MOG",
-                "MOG"
-              ],
-              "id": [
-                27659,
-                33033,
-                34170
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "MOG/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 438,
-      "full_name": "MOG / USDT",
-      "description": "Mog Coin",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "MOG",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "MOGUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "MOGUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "MOG_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "MOG_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "MOG-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "MOGUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "MOG/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 439,
-      "full_name": "MEW / USD",
-      "description": "cat in a dogs world",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "MEW",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitfinex": {
-              "symbol": [
-                "MEWUSD"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "MEWUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "MEWUSDC",
-                "MEWUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "MEW_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "MEWUSD"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "MEWUSD"
-              ],
-              "wsname": [
-                "MEW/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "MEW-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "MEWUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "MEW-USD",
-                "MEW-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-MEW"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "MEW"
-              ],
-              "id": [
-                30126
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "MEW/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 440,
-      "full_name": "MEW / USDT",
-      "description": "cat in a dogs world",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "MEW",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "MEWUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "MEWUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "MEW_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "MEW-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "MEWUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "MEW-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-MEW"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "MEW/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 441,
-      "full_name": "MEW / USDC",
-      "description": "cat in a dogs world",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "MEW",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bybit": {
-              "symbol": [
-                "MEWUSDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "MEW/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 442,
+      "id": 431,
       "full_name": "ENJ / USD",
       "description": "Enjin Coin",
       "type": "price-feed",
@@ -33762,7 +32995,7 @@
       }
     },
     {
-      "id": 443,
+      "id": 432,
       "full_name": "ENJ / ETH",
       "description": "Enjin Coin",
       "type": "price-feed",
@@ -33807,7 +33040,7 @@
       }
     },
     {
-      "id": 444,
+      "id": 433,
       "full_name": "ENJ / USDT",
       "description": "Enjin Coin",
       "type": "price-feed",
@@ -33892,7 +33125,7 @@
       }
     },
     {
-      "id": 445,
+      "id": 434,
       "full_name": "ENJ / USDC",
       "description": "Enjin Coin",
       "type": "price-feed",
@@ -33932,463 +33165,7 @@
       }
     },
     {
-      "id": 446,
-      "full_name": "WOO / USD",
-      "description": "Woo Network",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "WOO",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "WOOUSDT"
-              ]
-            },
-            "Bitfinex": {
-              "symbol": [
-                "WOOUSD"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "WOOUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "WOOUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "WOOUSD-PERP",
-                "WOO_USD",
-                "WOO_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "WOO_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "WOOUSD"
-              ],
-              "wsname": [
-                "WOO/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "WOO-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "WOOUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "WOO-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "WOO"
-              ],
-              "id": [
-                7501
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "WOO / USD"
-        }
-      }
-    },
-    {
-      "id": 447,
-      "full_name": "WOO / USDT",
-      "description": "Woo Network",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "WOO",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "WOOUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "WOOUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "WOOUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "WOO_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "WOO_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "WOO-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "WOOUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "WOO-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "WOO / USD"
-        }
-      }
-    },
-    {
-      "id": 448,
-      "full_name": "SUSHI / USD",
-      "description": "Sushi",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SUSHI",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "SUSHIUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "SUSHIUSDT"
-              ]
-            },
-            "Bitfinex": {
-              "symbol": [
-                "SUSHI:USD"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "SUSHIUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "SUSHIUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "SUSHI-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "SUSHIUSD-PERP",
-                "SUSHI_USD",
-                "SUSHI_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "SUSHI_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "SUSHIUSD"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "SUSHIUSD"
-              ],
-              "wsname": [
-                "SUSHI/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "SUSHI-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "SUSHIUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "SUSHI-USDC",
-                "SUSHI-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "SUSHI"
-              ],
-              "id": [
-                6758
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SUSHI / USD"
-        }
-      }
-    },
-    {
-      "id": 449,
-      "full_name": "SUSHI / ETH",
-      "description": "Sushi",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SUSHI",
-          "quote": "ETH"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Coinbase": {
-              "id": [
-                "SUSHI-ETH"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "SUSHIETH"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SUSHI / ETH"
-        }
-      }
-    },
-    {
-      "id": 450,
-      "full_name": "SUSHI / USDT",
-      "description": "Sushi",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SUSHI",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "SUSHIUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "SUSHIUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "SUSHIUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "SUSHIUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "SUSHI_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "SUSHI_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "SUSHI-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "SUSHIUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "SUSHI-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SUSHI / USD"
-        }
-      }
-    },
-    {
-      "id": 451,
-      "full_name": "SUSHI / USDC",
-      "description": "Sushi",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SUSHI",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "SUSHI-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SUSHI / USD"
-        }
-      }
-    },
-    {
-      "id": 452,
+      "id": 435,
       "full_name": "PNUT / USD",
       "description": "Peanut the Squirrel",
       "type": "price-feed",
@@ -34506,7 +33283,7 @@
       }
     },
     {
-      "id": 453,
+      "id": 436,
       "full_name": "PNUT / USDT",
       "description": "Peanut the Squirrel",
       "type": "price-feed",
@@ -34586,7 +33363,7 @@
       }
     },
     {
-      "id": 454,
+      "id": 437,
       "full_name": "PNUT / USDC",
       "description": "Peanut the Squirrel",
       "type": "price-feed",
@@ -34631,7 +33408,883 @@
       }
     },
     {
-      "id": 455,
+      "id": 438,
+      "full_name": "ONE / USD",
+      "description": "Harmony",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ONE",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ONEUSDC",
+                "ONEUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "ONEUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ONEUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ONEUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ONEUSD-PERP",
+                "ONE_USD",
+                "ONE_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ONE_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ONE-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ONEUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ONE-USDC",
+                "ONE-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "ONE",
+                "ONE",
+                "ONE"
+              ],
+              "id": [
+                2324,
+                24085,
+                3945
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ONE / USD"
+        }
+      }
+    },
+    {
+      "id": 439,
+      "full_name": "ONE / USDT",
+      "description": "Harmony",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ONE",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ONEUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "ONEUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "ONEUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ONEUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ONE_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ONE_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ONE-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ONEUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ONE-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ONE / USD"
+        }
+      }
+    },
+    {
+      "id": 440,
+      "full_name": "ONE / USDC",
+      "description": "Harmony",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ONE",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ONEUSDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ONE-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ONE / USD"
+        }
+      }
+    },
+    {
+      "id": 441,
+      "full_name": "MEW / USD",
+      "description": "cat in a dogs world",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "MEW",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitfinex": {
+              "symbol": [
+                "MEWUSD"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "MEWUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "MEWUSDC",
+                "MEWUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "MEW_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "MEWUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "MEWUSD"
+              ],
+              "wsname": [
+                "MEW/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "MEW-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "MEWUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "MEW-USD",
+                "MEW-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-MEW"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "MEW"
+              ],
+              "id": [
+                30126
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "MEW/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 442,
+      "full_name": "MEW / USDT",
+      "description": "cat in a dogs world",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "MEW",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "MEWUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "MEWUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "MEW_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "MEW-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "MEWUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "MEW-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-MEW"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "MEW/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 443,
+      "full_name": "MEW / USDC",
+      "description": "cat in a dogs world",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "MEW",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bybit": {
+              "symbol": [
+                "MEWUSDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "MEW/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 444,
+      "full_name": "SUSHI / USD",
+      "description": "Sushi",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "SUSHI",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "SUSHIUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "SUSHIUSDT"
+              ]
+            },
+            "Bitfinex": {
+              "symbol": [
+                "SUSHI:USD"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "SUSHIUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "SUSHIUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "SUSHI-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "SUSHIUSD-PERP",
+                "SUSHI_USD",
+                "SUSHI_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "SUSHI_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "SUSHIUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "SUSHIUSD"
+              ],
+              "wsname": [
+                "SUSHI/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "SUSHI-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "SUSHIUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "SUSHI-USDC",
+                "SUSHI-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "SUSHI"
+              ],
+              "id": [
+                6758
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "SUSHI / USD"
+        }
+      }
+    },
+    {
+      "id": 445,
+      "full_name": "SUSHI / ETH",
+      "description": "Sushi",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "SUSHI",
+          "quote": "ETH"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Coinbase": {
+              "id": [
+                "SUSHI-ETH"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "SUSHIETH"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "SUSHI / ETH"
+        }
+      }
+    },
+    {
+      "id": 446,
+      "full_name": "SUSHI / USDT",
+      "description": "Sushi",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "SUSHI",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "SUSHIUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "SUSHIUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "SUSHIUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "SUSHIUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "SUSHI_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "SUSHI_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "SUSHI-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "SUSHIUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "SUSHI-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "SUSHI / USD"
+        }
+      }
+    },
+    {
+      "id": 447,
+      "full_name": "SUSHI / USDC",
+      "description": "Sushi",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "SUSHI",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "SUSHI-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "SUSHI / USD"
+        }
+      }
+    },
+    {
+      "id": 448,
+      "full_name": "IOTX / USD",
+      "description": "IoTeX",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "IOTX",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "IOTXUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "IOTXUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "IOTXUSDT_SPBL"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "IOTX-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "IOTXUSD-PERP",
+                "IOTX_USD",
+                "IOTX_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "IOTX_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "IOTXUSD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "IOTX-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "IOTXUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "IOTX"
+              ],
+              "id": [
+                2777
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "IOTX / USD"
+        }
+      }
+    },
+    {
+      "id": 449,
+      "full_name": "IOTX / USDT",
+      "description": "IoTeX",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "IOTX",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "IOTXUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "IOTXUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "IOTXUSDT_SPBL"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "IOTX_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "IOTX_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "IOTX-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "IOTXUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "IOTX / USD"
+        }
+      }
+    },
+    {
+      "id": 450,
       "full_name": "ETHFI / USD",
       "description": "Ether.fi",
       "type": "price-feed",
@@ -34734,7 +34387,7 @@
       }
     },
     {
-      "id": 456,
+      "id": 451,
       "full_name": "ETHFI / USDT",
       "description": "Ether.fi",
       "type": "price-feed",
@@ -34804,7 +34457,7 @@
       }
     },
     {
-      "id": 457,
+      "id": 452,
       "full_name": "ETHFI / USDC",
       "description": "Ether.fi",
       "type": "price-feed",
@@ -34854,7 +34507,334 @@
       }
     },
     {
-      "id": 458,
+      "id": 453,
+      "full_name": "WOO / USD",
+      "description": "Woo Network",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "WOO",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "WOOUSDT"
+              ]
+            },
+            "Bitfinex": {
+              "symbol": [
+                "WOOUSD"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "WOOUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "WOOUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "WOOUSD-PERP",
+                "WOO_USD",
+                "WOO_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "WOO_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "WOOUSD"
+              ],
+              "wsname": [
+                "WOO/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "WOO-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "WOOUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "WOO-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "WOO"
+              ],
+              "id": [
+                7501
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "WOO / USD"
+        }
+      }
+    },
+    {
+      "id": 454,
+      "full_name": "WOO / USDT",
+      "description": "Woo Network",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "WOO",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "WOOUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "WOOUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "WOOUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "WOO_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "WOO_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "WOO-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "WOOUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "WOO-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "WOO / USD"
+        }
+      }
+    },
+    {
+      "id": 455,
+      "full_name": "POPCAT / USD",
+      "description": "POPCAT",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "POPCAT",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bybit": {
+              "symbol": [
+                "POPCATUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "POPCAT-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "POPCATUSD-PERP",
+                "POPCAT_USD",
+                "POPCAT_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "POPCAT_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "POPCATUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "POPCATUSD"
+              ],
+              "wsname": [
+                "POPCAT/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "POPCAT-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "POPCATUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "POPCAT",
+                "POPCAT"
+              ],
+              "id": [
+                28782,
+                33470
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "POPCAT/USD-RefPrice-mainnet-production"
+        }
+      }
+    },
+    {
+      "id": 456,
+      "full_name": "POPCAT / USDT",
+      "description": "POPCAT",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "POPCAT",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bybit": {
+              "symbol": [
+                "POPCATUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "POPCAT_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "POPCAT_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "POPCAT-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "POPCATUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "POPCAT/USD-RefPrice-mainnet-production"
+        }
+      }
+    },
+    {
+      "id": 457,
       "full_name": "TURBO / USD",
       "description": "Turbo",
       "type": "price-feed",
@@ -34961,7 +34941,7 @@
       }
     },
     {
-      "id": 459,
+      "id": 458,
       "full_name": "TURBO / USDT",
       "description": "Turbo",
       "type": "price-feed",
@@ -35031,7 +35011,7 @@
       }
     },
     {
-      "id": 460,
+      "id": 459,
       "full_name": "TURBO / USDC",
       "description": "Turbo",
       "type": "price-feed",
@@ -35081,9 +35061,9 @@
       }
     },
     {
-      "id": 461,
-      "full_name": "IOTX / USD",
-      "description": "IoTeX",
+      "id": 460,
+      "full_name": "DGB / USD",
+      "description": "Digibyte",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -35100,7 +35080,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "IOTX",
+          "base": "DGB",
           "quote": "USD"
         },
         "decimals": 8,
@@ -35110,72 +35090,136 @@
           "exchanges": {
             "Binance": {
               "symbol": [
-                "IOTXUSDT"
+                "DGBUSDT"
               ]
             },
             "BinanceUS": {
               "symbol": [
-                "IOTXUSDT"
+                "DGBUSDT"
               ]
             },
-            "Bitget": {
+            "Bybit": {
               "symbol": [
-                "IOTXUSDT_SPBL"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "IOTX-USD"
+                "DGBUSDT"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "IOTXUSD-PERP",
-                "IOTX_USD",
-                "IOTX_USDT"
+                "DGB_USD"
               ]
             },
             "GateIo": {
               "id": [
-                "IOTX_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "IOTXUSD"
+                "DGB_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "IOTX-USDT"
+                "DGB-USDT"
               ]
             },
-            "MEXC": {
-              "symbol": [
-                "IOTXUSDT"
+            "OKX": {
+              "instId": [
+                "DGB-USDC",
+                "DGB-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-DGB"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "IOTX"
+                "DGB"
               ],
               "id": [
-                2777
+                109
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "IOTX / USD"
+          "chainlink": "DGB / USD"
+        }
+      }
+    },
+    {
+      "id": 461,
+      "full_name": "DGB / USDT",
+      "description": "Digibyte",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "DGB",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "DGBUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "DGBUSDT"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "DGBUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "DGB_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "DGB-USDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "DGB-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-DGB"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "DGB / USD"
         }
       }
     },
     {
       "id": 462,
-      "full_name": "IOTX / USDT",
-      "description": "IoTeX",
+      "full_name": "DGB / USDC",
+      "description": "Digibyte",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -35192,227 +35236,28 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "IOTX",
-          "quote": "USDT"
+          "base": "DGB",
+          "quote": "USDC"
         },
         "decimals": 8,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "IOTXUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "IOTXUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "IOTXUSDT_SPBL"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "IOTX_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "IOTX_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "IOTX-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "IOTXUSDT"
+            "OKX": {
+              "instId": [
+                "DGB-USDC"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "IOTX / USD"
+          "chainlink": "DGB / USD"
         }
       }
     },
     {
       "id": 463,
-      "full_name": "GMX / USD",
-      "description": "GMX",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "GMX",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "GMXUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "GMXUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "GMXUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "GMX_USD",
-                "GMX_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "GMX_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "GMXUSD"
-              ],
-              "wsname": [
-                "GMX/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "GMX-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "GMXUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "GMX-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "GMX"
-              ],
-              "id": [
-                11857
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "GMX / USD"
-        }
-      }
-    },
-    {
-      "id": 464,
-      "full_name": "GMX / USDT",
-      "description": "GMX",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "GMX",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "GMXUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "GMXUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "GMXUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "GMX_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "GMX_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "GMX-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "GMXUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "GMX-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "GMX / USD"
-        }
-      }
-    },
-    {
-      "id": 465,
       "full_name": "LRC / ETH",
       "description": "Loopring",
       "type": "price-feed",
@@ -35457,7 +35302,7 @@
       }
     },
     {
-      "id": 466,
+      "id": 464,
       "full_name": "HMSTR / USD",
       "description": "Hamster Kombat",
       "type": "price-feed",
@@ -35551,7 +35396,7 @@
       }
     },
     {
-      "id": 467,
+      "id": 465,
       "full_name": "HMSTR / USDT",
       "description": "Hamster Kombat",
       "type": "price-feed",
@@ -35621,7 +35466,7 @@
       }
     },
     {
-      "id": 468,
+      "id": 466,
       "full_name": "HMSTR / USDC",
       "description": "Hamster Kombat",
       "type": "price-feed",
@@ -35671,9 +35516,9 @@
       }
     },
     {
-      "id": 469,
-      "full_name": "RLUSD / USD",
-      "description": "Ripple USD",
+      "id": 467,
+      "full_name": "GMX / USD",
+      "description": "GMX",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -35690,50 +35535,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "RLUSD",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "RLUSD"
-              ],
-              "id": [
-                34387
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "RLUSD / USD"
-        }
-      }
-    },
-    {
-      "id": 470,
-      "full_name": "ONT / USD",
-      "description": "Ontology",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ONT",
+          "base": "GMX",
           "quote": "USD"
         },
         "decimals": 8,
@@ -35743,68 +35545,74 @@
           "exchanges": {
             "Binance": {
               "symbol": [
-                "ONTUSDC",
-                "ONTUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "ONTUSDT"
+                "GMXUSDT"
               ]
             },
             "Bitget": {
               "symbol": [
-                "ONTUSDT_SPBL"
+                "GMXUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "GMXUSDT"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "ONT_USD"
+                "GMX_USD",
+                "GMX_USDT"
               ]
             },
             "GateIo": {
               "id": [
-                "ONT_USDC",
-                "ONT_USDT"
+                "GMX_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "GMXUSD"
+              ],
+              "wsname": [
+                "GMX/USD"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "ONT-USDT"
+                "GMX-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "ONTUSDT"
+                "GMXUSDT"
               ]
             },
             "OKX": {
               "instId": [
-                "ONT-USDC",
-                "ONT-USDT"
+                "GMX-USDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "ONT"
+                "GMX"
               ],
               "id": [
-                2566
+                11857
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "ONT / USD"
+          "chainlink": "GMX / USD"
         }
       }
     },
     {
-      "id": 471,
-      "full_name": "ONT / USDT",
-      "description": "Ontology",
+      "id": 468,
+      "full_name": "GMX / USDT",
+      "description": "GMX",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -35821,7 +35629,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "ONT",
+          "base": "GMX",
           "quote": "USDT"
         },
         "decimals": 8,
@@ -35831,98 +35639,53 @@
           "exchanges": {
             "Binance": {
               "symbol": [
-                "ONTUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "ONTUSDT"
+                "GMXUSDT"
               ]
             },
             "Bitget": {
               "symbol": [
-                "ONTUSDT_SPBL"
+                "GMXUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "GMXUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "GMX_USDT"
               ]
             },
             "GateIo": {
               "id": [
-                "ONT_USDT"
+                "GMX_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "ONT-USDT"
+                "GMX-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "ONTUSDT"
+                "GMXUSDT"
               ]
             },
             "OKX": {
               "instId": [
-                "ONT-USDT"
+                "GMX-USDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "ONT / USD"
+          "chainlink": "GMX / USD"
         }
       }
     },
     {
-      "id": 472,
-      "full_name": "ONT / USDC",
-      "description": "Ontology",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ONT",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ONTUSDC"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ONT_USDC"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ONT-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ONT / USD"
-        }
-      }
-    },
-    {
-      "id": 473,
+      "id": 469,
       "full_name": "EURC / USD",
       "description": "Circle EUR",
       "type": "price-feed",
@@ -35980,7 +35743,7 @@
       }
     },
     {
-      "id": 474,
+      "id": 470,
       "full_name": "EURC / USDC",
       "description": "Circle EUR",
       "type": "price-feed",
@@ -36021,6 +35784,272 @@
         },
         "compatibility_info": {
           "chainlink": "EURC / USD"
+        }
+      }
+    },
+    {
+      "id": 471,
+      "full_name": "RLUSD / USD",
+      "description": "Ripple USD",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "RLUSD",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "RLUSD"
+              ],
+              "id": [
+                34387
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "RLUSD / USD"
+        }
+      }
+    },
+    {
+      "id": 472,
+      "full_name": "GMT / USD",
+      "description": "STEPN",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "GMT",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "GMTUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "GMTUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "GMTUSDC",
+                "GMTUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "GMT-USD",
+                "GMT-USDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "GMTUSD-PERP",
+                "GMT_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "GMT_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "GMTUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "GMTUSD"
+              ],
+              "wsname": [
+                "GMT/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "GMT-USDC",
+                "GMT-USDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "GMT-USDC",
+                "GMT-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "GMT"
+              ],
+              "id": [
+                18069
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "GMT / USD"
+        }
+      }
+    },
+    {
+      "id": 473,
+      "full_name": "GMT / USDT",
+      "description": "STEPN",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "GMT",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "GMTUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "GMTUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "GMTUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "GMT-USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "GMT_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "GMT-USDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "GMT-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "GMT / USD"
+        }
+      }
+    },
+    {
+      "id": 474,
+      "full_name": "GMT / USDC",
+      "description": "STEPN",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "GMT",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bybit": {
+              "symbol": [
+                "GMTUSDC"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "GMT-USDC"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "GMT-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "GMT / USD"
         }
       }
     },
@@ -36190,8 +36219,8 @@
     },
     {
       "id": 477,
-      "full_name": "GMT / USD",
-      "description": "STEPN",
+      "full_name": "ONT / USD",
+      "description": "Ontology",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -36208,7 +36237,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "GMT",
+          "base": "ONT",
           "quote": "USD"
         },
         "decimals": 8,
@@ -36218,83 +36247,68 @@
           "exchanges": {
             "Binance": {
               "symbol": [
-                "GMTUSDT"
+                "ONTUSDC",
+                "ONTUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "ONTUSDT"
               ]
             },
             "Bitget": {
               "symbol": [
-                "GMTUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "GMTUSDC",
-                "GMTUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "GMT-USD",
-                "GMT-USDT"
+                "ONTUSDT_SPBL"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "GMTUSD-PERP",
-                "GMT_USD"
+                "ONT_USD"
               ]
             },
             "GateIo": {
               "id": [
-                "GMT_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "GMTUSD"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "GMTUSD"
-              ],
-              "wsname": [
-                "GMT/USD"
+                "ONT_USDC",
+                "ONT_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "GMT-USDC",
-                "GMT-USDT"
+                "ONT-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ONTUSDT"
               ]
             },
             "OKX": {
               "instId": [
-                "GMT-USDC",
-                "GMT-USDT"
+                "ONT-USDC",
+                "ONT-USDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "GMT"
+                "ONT"
               ],
               "id": [
-                18069
+                2566
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "GMT / USD"
+          "chainlink": "ONT / USD"
         }
       }
     },
     {
       "id": 478,
-      "full_name": "GMT / USDT",
-      "description": "STEPN",
+      "full_name": "ONT / USDT",
+      "description": "Ontology",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -36311,7 +36325,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "GMT",
+          "base": "ONT",
           "quote": "USDT"
         },
         "decimals": 8,
@@ -36321,50 +36335,50 @@
           "exchanges": {
             "Binance": {
               "symbol": [
-                "GMTUSDT"
+                "ONTUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "ONTUSDT"
               ]
             },
             "Bitget": {
               "symbol": [
-                "GMTUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "GMTUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "GMT-USDT"
+                "ONTUSDT_SPBL"
               ]
             },
             "GateIo": {
               "id": [
-                "GMT_USDT"
+                "ONT_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "GMT-USDT"
+                "ONT-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ONTUSDT"
               ]
             },
             "OKX": {
               "instId": [
-                "GMT-USDT"
+                "ONT-USDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "GMT / USD"
+          "chainlink": "ONT / USD"
         }
       }
     },
     {
       "id": 479,
-      "full_name": "GMT / USDC",
-      "description": "STEPN",
+      "full_name": "ONT / USDC",
+      "description": "Ontology",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -36381,7 +36395,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "GMT",
+          "base": "ONT",
           "quote": "USDC"
         },
         "decimals": 8,
@@ -36389,30 +36403,170 @@
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Bybit": {
+            "Binance": {
               "symbol": [
-                "GMTUSDC"
+                "ONTUSDC"
               ]
             },
-            "KuCoin": {
-              "symbol": [
-                "GMT-USDC"
+            "GateIo": {
+              "id": [
+                "ONT_USDC"
               ]
             },
             "OKX": {
               "instId": [
-                "GMT-USDC"
+                "ONT-USDC"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "GMT / USD"
+          "chainlink": "ONT / USD"
         }
       }
     },
     {
       "id": 480,
+      "full_name": "SXP / USD",
+      "description": "Swipe",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "SXP",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "SXPUSDT"
+              ]
+            },
+            "BinanceTR": {
+              "symbol": [
+                "SXP_USDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "SXPUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "SXP_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "SXP-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "SXPUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "SXP"
+              ],
+              "id": [
+                4279
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "SXP / USD"
+        }
+      }
+    },
+    {
+      "id": 481,
+      "full_name": "SXP / USDT",
+      "description": "Swipe",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "SXP",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "SXPUSDT"
+              ]
+            },
+            "BinanceTR": {
+              "symbol": [
+                "SXP_USDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "SXPUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "SXP_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "SXP-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "SXPUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "SXP / USD"
+        }
+      }
+    },
+    {
+      "id": 482,
       "full_name": "POLYX / USD",
       "description": "Polymesh",
       "type": "price-feed",
@@ -36488,7 +36642,7 @@
       }
     },
     {
-      "id": 481,
+      "id": 483,
       "full_name": "POLYX / USDT",
       "description": "Polymesh",
       "type": "price-feed",
@@ -36548,7 +36702,7 @@
       }
     },
     {
-      "id": 482,
+      "id": 484,
       "full_name": "BAND / BNB",
       "description": "Band Protocol",
       "type": "price-feed",
@@ -36588,7 +36742,7 @@
       }
     },
     {
-      "id": 483,
+      "id": 485,
       "full_name": "BAND / USD",
       "description": "Band Protocol",
       "type": "price-feed",
@@ -36684,7 +36838,7 @@
       }
     },
     {
-      "id": 484,
+      "id": 486,
       "full_name": "BAND / USDT",
       "description": "Band Protocol",
       "type": "price-feed",
@@ -36754,7 +36908,7 @@
       }
     },
     {
-      "id": 485,
+      "id": 487,
       "full_name": "BAND / USDC",
       "description": "Band Protocol",
       "type": "price-feed",
@@ -36794,524 +36948,7 @@
       }
     },
     {
-      "id": 486,
-      "full_name": "IO / USD",
-      "description": "io.net",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "IO",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "IOUSDC",
-                "IOUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "IOUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "IOUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "IO-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "IOUSD-PERP",
-                "IO_USD",
-                "IO_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "IO_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "IO-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "IOUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "IO"
-              ],
-              "id": [
-                29835
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "IO/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 487,
-      "full_name": "IO / USDT",
-      "description": "io.net",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "IO",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "IOUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "IOUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "IOUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "IO_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "IO_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "IO-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "IOUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "IO/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
       "id": 488,
-      "full_name": "IO / USDC",
-      "description": "io.net",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "IO",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "IOUSDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "IO/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 489,
-      "full_name": "SXP / USD",
-      "description": "Swipe",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SXP",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "SXPUSDT"
-              ]
-            },
-            "BinanceTR": {
-              "symbol": [
-                "SXP_USDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "SXPUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "SXP_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "SXP-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "SXPUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "SXP"
-              ],
-              "id": [
-                4279
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SXP / USD"
-        }
-      }
-    },
-    {
-      "id": 490,
-      "full_name": "SXP / USDT",
-      "description": "Swipe",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SXP",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "SXPUSDT"
-              ]
-            },
-            "BinanceTR": {
-              "symbol": [
-                "SXP_USDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "SXPUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "SXP_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "SXP-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "SXPUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SXP / USD"
-        }
-      }
-    },
-    {
-      "id": 491,
-      "full_name": "USUAL / USD",
-      "description": "Usual",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "USUAL",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "USUALUSDC",
-                "USUALUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "USUALUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "USUAL_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "USUALUSD"
-              ],
-              "wsname": [
-                "USUAL/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "USUAL-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "USUALUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "USUAL"
-              ],
-              "id": [
-                33979
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "USUAL/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 492,
-      "full_name": "USUAL / USDT",
-      "description": "Usual",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "USUAL",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "USUALUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "USUALUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "USUAL_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "USUAL-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "USUALUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "USUAL/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 493,
-      "full_name": "USUAL / USDC",
-      "description": "Usual",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "USUAL",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "USUALUSDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "USUAL/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 494,
       "full_name": "ARKM / USD",
       "description": "Arkham",
       "type": "price-feed",
@@ -37418,7 +37055,7 @@
       }
     },
     {
-      "id": 495,
+      "id": 489,
       "full_name": "ARKM / USDT",
       "description": "Arkham",
       "type": "price-feed",
@@ -37493,7 +37130,7 @@
       }
     },
     {
-      "id": 496,
+      "id": 490,
       "full_name": "ARKM / USDC",
       "description": "Arkham",
       "type": "price-feed",
@@ -37539,6 +37176,425 @@
         },
         "compatibility_info": {
           "chainlink": "ARKM/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 491,
+      "full_name": "IO / USD",
+      "description": "io.net",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "IO",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "IOUSDC",
+                "IOUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "IOUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "IOUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "IO-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "IOUSD-PERP",
+                "IO_USD",
+                "IO_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "IO_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "IO-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "IOUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "IO"
+              ],
+              "id": [
+                29835
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "IO/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 492,
+      "full_name": "IO / USDT",
+      "description": "io.net",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "IO",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "IOUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "IOUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "IOUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "IO_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "IO_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "IO-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "IOUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "IO/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 493,
+      "full_name": "IO / USDC",
+      "description": "io.net",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "IO",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "IOUSDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "IO/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 494,
+      "full_name": "STORJ / USD",
+      "description": "Storj",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "STORJ",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "STORJUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "STORJUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "STORJUSDT_SPBL"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "STORJ-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "STORJUSD-PERP",
+                "STORJ_USD",
+                "STORJ_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "STORJ_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "STORJUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "STORJUSD"
+              ],
+              "wsname": [
+                "STORJ/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "STORJ-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "STORJUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "STORJ-USDC",
+                "STORJ-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "STORJ"
+              ],
+              "id": [
+                1772
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "STORJ / USD"
+        }
+      }
+    },
+    {
+      "id": 495,
+      "full_name": "STORJ / USDT",
+      "description": "Storj",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "STORJ",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "STORJUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "STORJUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "STORJUSDT_SPBL"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "STORJ_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "STORJ_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "STORJ-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "STORJUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "STORJ-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "STORJ / USD"
+        }
+      }
+    },
+    {
+      "id": 496,
+      "full_name": "STORJ / USDC",
+      "description": "Storj",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "STORJ",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "STORJ-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "STORJ / USD"
         }
       }
     },
@@ -37753,8 +37809,8 @@
     },
     {
       "id": 500,
-      "full_name": "STORJ / USD",
-      "description": "Storj",
+      "full_name": "USUAL / USD",
+      "description": "Usual",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -37771,96 +37827,69 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "STORJ",
+          "base": "USUAL",
           "quote": "USD"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
             "Binance": {
               "symbol": [
-                "STORJUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "STORJUSDT"
+                "USUALUSDC",
+                "USUALUSDT"
               ]
             },
             "Bitget": {
               "symbol": [
-                "STORJUSDT_SPBL"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "STORJ-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "STORJUSD-PERP",
-                "STORJ_USD",
-                "STORJ_USDT"
+                "USUALUSDT_SPBL"
               ]
             },
             "GateIo": {
               "id": [
-                "STORJ_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "STORJUSD"
+                "USUAL_USDT"
               ]
             },
             "Kraken": {
               "pair": [
-                "STORJUSD"
+                "USUALUSD"
               ],
               "wsname": [
-                "STORJ/USD"
+                "USUAL/USD"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "STORJ-USDT"
+                "USUAL-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "STORJUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "STORJ-USDC",
-                "STORJ-USDT"
+                "USUALUSDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "STORJ"
+                "USUAL"
               ],
               "id": [
-                1772
+                33979
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "STORJ / USD"
+          "chainlink": "USUAL/USD-RefPrice-mainnet-production"
         }
       }
     },
     {
       "id": 501,
-      "full_name": "STORJ / USDT",
-      "description": "Storj",
+      "full_name": "USUAL / USDT",
+      "description": "Usual",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -37877,65 +37906,50 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "STORJ",
+          "base": "USUAL",
           "quote": "USDT"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
             "Binance": {
               "symbol": [
-                "STORJUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "STORJUSDT"
+                "USUALUSDT"
               ]
             },
             "Bitget": {
               "symbol": [
-                "STORJUSDT_SPBL"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "STORJ_USDT"
+                "USUALUSDT_SPBL"
               ]
             },
             "GateIo": {
               "id": [
-                "STORJ_USDT"
+                "USUAL_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "STORJ-USDT"
+                "USUAL-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "STORJUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "STORJ-USDT"
+                "USUALUSDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "STORJ / USD"
+          "chainlink": "USUAL/USD-RefPrice-mainnet-production"
         }
       }
     },
     {
       "id": 502,
-      "full_name": "STORJ / USDC",
-      "description": "Storj",
+      "full_name": "USUAL / USDC",
+      "description": "Usual",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -37952,28 +37966,232 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "STORJ",
+          "base": "USUAL",
           "quote": "USDC"
         },
-        "decimals": 8,
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "USUALUSDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "USUAL/USD-RefPrice-mainnet-production"
+        }
+      }
+    },
+    {
+      "id": 503,
+      "full_name": "AEVO / USD",
+      "description": "Aevo",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AEVO",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "AEVOUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "AEVOUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "AEVOUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "AEVO_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "AEVO_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "AEVOUSD"
+              ],
+              "wsname": [
+                "AEVO/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "AEVO-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "AEVOUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "AEVO-USDC",
+                "AEVO-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "AEVO"
+              ],
+              "id": [
+                29676
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AEVO/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 504,
+      "full_name": "AEVO / USDT",
+      "description": "Aevo",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AEVO",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "AEVOUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "AEVOUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "AEVOUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "AEVO_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "AEVO-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "AEVOUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "AEVO-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AEVO/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 505,
+      "full_name": "AEVO / USDC",
+      "description": "Aevo",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AEVO",
+          "quote": "USDC"
+        },
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
             "OKX": {
               "instId": [
-                "STORJ-USDC"
+                "AEVO-USDC"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "STORJ / USD"
+          "chainlink": "AEVO/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 503,
+      "id": 506,
       "full_name": "METIS / USD",
       "description": "Metis",
       "type": "price-feed",
@@ -38062,7 +38280,7 @@
       }
     },
     {
-      "id": 504,
+      "id": 507,
       "full_name": "METIS / USDT",
       "description": "Metis",
       "type": "price-feed",
@@ -38137,7 +38355,7 @@
       }
     },
     {
-      "id": 505,
+      "id": 508,
       "full_name": "METIS / USDC",
       "description": "Metis",
       "type": "price-feed",
@@ -38177,7 +38395,7 @@
       }
     },
     {
-      "id": 506,
+      "id": 509,
       "full_name": "NEIRO / USD",
       "description": "Neiro",
       "type": "price-feed",
@@ -38288,7 +38506,7 @@
       }
     },
     {
-      "id": 507,
+      "id": 510,
       "full_name": "NEIRO / USDT",
       "description": "Neiro",
       "type": "price-feed",
@@ -38363,7 +38581,7 @@
       }
     },
     {
-      "id": 508,
+      "id": 511,
       "full_name": "NEIRO / USDC",
       "description": "Neiro",
       "type": "price-feed",
@@ -38408,341 +38626,7 @@
       }
     },
     {
-      "id": 509,
-      "full_name": "AEVO / USD",
-      "description": "Aevo",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AEVO",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "AEVOUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "AEVOUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "AEVOUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "AEVO_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "AEVO_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "AEVOUSD"
-              ],
-              "wsname": [
-                "AEVO/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "AEVO-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "AEVOUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "AEVO-USDC",
-                "AEVO-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "AEVO"
-              ],
-              "id": [
-                29676
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AEVO/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 510,
-      "full_name": "AEVO / USDT",
-      "description": "Aevo",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AEVO",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "AEVOUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "AEVOUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "AEVOUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "AEVO_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "AEVO-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "AEVOUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "AEVO-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AEVO/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 511,
-      "full_name": "AEVO / USDC",
-      "description": "Aevo",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AEVO",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "AEVO-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AEVO/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
       "id": 512,
-      "full_name": "AVAIL / USD",
-      "description": "Avail",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AVAIL",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "AVAILUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "AVAILUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "AVAIL_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "AVAIL-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "AVAILUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "AVAIL"
-              ],
-              "id": [
-                32376
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AVAIL / USD"
-        }
-      }
-    },
-    {
-      "id": 513,
-      "full_name": "AVAIL / USDT",
-      "description": "Avail",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AVAIL",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "AVAILUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "AVAILUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "AVAIL_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "AVAIL-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "AVAILUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AVAIL / USD"
-        }
-      }
-    },
-    {
-      "id": 514,
       "full_name": "MEME / USD",
       "description": "Memecoin",
       "type": "price-feed",
@@ -38839,7 +38723,7 @@
       }
     },
     {
-      "id": 515,
+      "id": 513,
       "full_name": "MEME / USDT",
       "description": "Memecoin",
       "type": "price-feed",
@@ -38904,7 +38788,7 @@
       }
     },
     {
-      "id": 516,
+      "id": 514,
       "full_name": "MEME / USDC",
       "description": "Memecoin",
       "type": "price-feed",
@@ -38944,7 +38828,7 @@
       }
     },
     {
-      "id": 517,
+      "id": 515,
       "full_name": "UMA / USD",
       "description": "UMA",
       "type": "price-feed",
@@ -39048,7 +38932,7 @@
       }
     },
     {
-      "id": 518,
+      "id": 516,
       "full_name": "UMA / USDT",
       "description": "UMA",
       "type": "price-feed",
@@ -39118,7 +39002,7 @@
       }
     },
     {
-      "id": 519,
+      "id": 517,
       "full_name": "UMA / USDC",
       "description": "UMA",
       "type": "price-feed",
@@ -39158,9 +39042,9 @@
       }
     },
     {
-      "id": 520,
-      "full_name": "AIXBT / USD",
-      "description": "aixbt by Virtuals",
+      "id": 518,
+      "full_name": "AVAIL / USD",
+      "description": "Avail",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -39177,87 +39061,60 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "AIXBT",
+          "base": "AVAIL",
           "quote": "USD"
         },
-        "decimals": 18,
+        "decimals": 8,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "AIXBTUSDC",
-                "AIXBTUSDT"
-              ]
-            },
             "Bitget": {
               "symbol": [
-                "AIXBTUSDT_SPBL"
+                "AVAILUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "AIXBTUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "AIXBTUSD-PERP",
-                "AIXBT_USD"
+                "AVAILUSDT"
               ]
             },
             "GateIo": {
               "id": [
-                "AIXBT_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "AIXBTUSD"
-              ],
-              "wsname": [
-                "AIXBT/USD"
+                "AVAIL_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "AIXBT-USDT"
+                "AVAIL-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "AIXBTUSDC",
-                "AIXBTUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "AIXBT-USD",
-                "AIXBT-USDT"
+                "AVAILUSDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "AIXBT"
+                "AVAIL"
               ],
               "id": [
-                34103
+                32376
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "AIXBT/USD-RefPrice-mainnet-production"
+          "chainlink": "AVAIL / USD"
         }
       }
     },
     {
-      "id": 521,
-      "full_name": "AIXBT / USDT",
-      "description": "aixbt by Virtuals",
+      "id": 519,
+      "full_name": "AVAIL / USDT",
+      "description": "Avail",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -39274,103 +39131,48 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "AIXBT",
+          "base": "AVAIL",
           "quote": "USDT"
         },
-        "decimals": 18,
+        "decimals": 8,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "AIXBTUSDT"
-              ]
-            },
             "Bitget": {
               "symbol": [
-                "AIXBTUSDT_SPBL"
+                "AVAILUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "AIXBTUSDT"
+                "AVAILUSDT"
               ]
             },
             "GateIo": {
               "id": [
-                "AIXBT_USDT"
+                "AVAIL_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "AIXBT-USDT"
+                "AVAIL-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "AIXBTUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "AIXBT-USDT"
+                "AVAILUSDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "AIXBT/USD-RefPrice-mainnet-production"
+          "chainlink": "AVAIL / USD"
         }
       }
     },
     {
-      "id": 522,
-      "full_name": "AIXBT / USDC",
-      "description": "aixbt by Virtuals",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AIXBT",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "AIXBTUSDC"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "AIXBTUSDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AIXBT/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 523,
+      "id": 520,
       "full_name": "MANTA / USD",
       "description": "Manta Network",
       "type": "price-feed",
@@ -39447,7 +39249,7 @@
       }
     },
     {
-      "id": 524,
+      "id": 521,
       "full_name": "MANTA / USDT",
       "description": "Manta Network",
       "type": "price-feed",
@@ -39512,7 +39314,7 @@
       }
     },
     {
-      "id": 525,
+      "id": 522,
       "full_name": "MANTA / USDC",
       "description": "Manta Network",
       "type": "price-feed",
@@ -39557,9 +39359,9 @@
       }
     },
     {
-      "id": 526,
-      "full_name": "BAL / USD",
-      "description": "Balancer",
+      "id": 523,
+      "full_name": "ALT / USD",
+      "description": "Altlayer",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -39576,90 +39378,74 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "BAL",
+          "base": "ALT",
           "quote": "USD"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
             "Binance": {
               "symbol": [
-                "BALUSDT"
+                "ALTUSDC",
+                "ALTUSDT"
               ]
             },
-            "BinanceUS": {
+            "Bybit": {
               "symbol": [
-                "BALUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "BALUSDT_SPBL"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "BAL-USD"
+                "ALTUSDT"
               ]
             },
             "CryptoCom": {
               "instrument_name": [
-                "BALUSD-PERP",
-                "BAL_USD"
+                "ALT_USD"
               ]
             },
             "GateIo": {
               "id": [
-                "BAL_USDT"
+                "ALT_USDC",
+                "ALT_USDT"
               ]
             },
             "Kraken": {
               "pair": [
-                "BALUSD"
+                "ALTUSD"
               ],
               "wsname": [
-                "BAL/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "BAL-USDT"
+                "ALT/USD"
               ]
             },
             "MEXC": {
               "symbol": [
-                "BALUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "BAL-USDC",
-                "BAL-USDT"
+                "ALTUSDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "BAL"
+                "ALT",
+                "ALT",
+                "ALT"
               ],
               "id": [
-                5728
+                10897,
+                22065,
+                29073
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "BAL / USD"
+          "chainlink": "ALT/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 527,
-      "full_name": "BAL / USDT",
-      "description": "Balancer",
+      "id": 524,
+      "full_name": "ALT / USDT",
+      "description": "Altlayer",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -39676,60 +39462,45 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "BAL",
+          "base": "ALT",
           "quote": "USDT"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
             "Binance": {
               "symbol": [
-                "BALUSDT"
+                "ALTUSDT"
               ]
             },
-            "BinanceUS": {
+            "Bybit": {
               "symbol": [
-                "BALUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "BALUSDT_SPBL"
+                "ALTUSDT"
               ]
             },
             "GateIo": {
               "id": [
-                "BAL_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "BAL-USDT"
+                "ALT_USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "BALUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "BAL-USDT"
+                "ALTUSDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "BAL / USD"
+          "chainlink": "ALT/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 528,
-      "full_name": "BAL / USDC",
-      "description": "Balancer",
+      "id": 525,
+      "full_name": "ALT / USDC",
+      "description": "Altlayer",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -39746,28 +39517,33 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "BAL",
+          "base": "ALT",
           "quote": "USDC"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "OKX": {
-              "instId": [
-                "BAL-USDC"
+            "Binance": {
+              "symbol": [
+                "ALTUSDC"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ALT_USDC"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "BAL / USD"
+          "chainlink": "ALT/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 529,
+      "id": 526,
       "full_name": "SPELL / USD",
       "description": "Spell Token",
       "type": "price-feed",
@@ -39867,7 +39643,7 @@
       }
     },
     {
-      "id": 530,
+      "id": 527,
       "full_name": "SPELL / USDT",
       "description": "Spell Token",
       "type": "price-feed",
@@ -39942,517 +39718,7 @@
       }
     },
     {
-      "id": 531,
-      "full_name": "ALT / USD",
-      "description": "Altlayer",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ALT",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ALTUSDC",
-                "ALTUSDT"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ALTUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ALT_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ALT_USDC",
-                "ALT_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "ALTUSD"
-              ],
-              "wsname": [
-                "ALT/USD"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ALTUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "ALT",
-                "ALT",
-                "ALT"
-              ],
-              "id": [
-                10897,
-                22065,
-                29073
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ALT/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 532,
-      "full_name": "ALT / USDT",
-      "description": "Altlayer",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ALT",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ALTUSDT"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ALTUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ALT_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ALTUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ALT/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 533,
-      "full_name": "ALT / USDC",
-      "description": "Altlayer",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ALT",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ALTUSDC"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ALT_USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ALT/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 534,
-      "full_name": "XVS / BNB",
-      "description": "Venus",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "XVS",
-          "quote": "BNB"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "XVSBNB"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "XVS / BNB"
-        }
-      }
-    },
-    {
-      "id": 535,
-      "full_name": "XVS / USD",
-      "description": "Venus",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "XVS",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "XVSUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "XVS_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "XVSUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "XVS"
-              ],
-              "id": [
-                7288
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "XVS / USD"
-        }
-      }
-    },
-    {
-      "id": 536,
-      "full_name": "XVS / USDT",
-      "description": "Venus",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "XVS",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "XVSUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "XVS_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "XVSUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "XVS / USD"
-        }
-      }
-    },
-    {
-      "id": 537,
-      "full_name": "IQ / USD",
-      "description": "IQ",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "IQ",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "IQUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "IQUSDT_SPBL"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "IQ_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "IQ_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "IQUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "IQ-USDC",
-                "IQ-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "IQ"
-              ],
-              "id": [
-                2930
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "IQ/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 538,
-      "full_name": "IQ / USDT",
-      "description": "IQ",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "IQ",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "IQUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "IQUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "IQ_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "IQUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "IQ-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "IQ/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 539,
-      "full_name": "IQ / USDC",
-      "description": "IQ",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "IQ",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "IQ-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "IQ/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 540,
+      "id": 528,
       "full_name": "BOME / USD",
       "description": "BOOK OF MEME",
       "type": "price-feed",
@@ -40551,7 +39817,7 @@
       }
     },
     {
-      "id": 541,
+      "id": 529,
       "full_name": "BOME / USDT",
       "description": "BOOK OF MEME",
       "type": "price-feed",
@@ -40626,7 +39892,7 @@
       }
     },
     {
-      "id": 542,
+      "id": 530,
       "full_name": "BOME / USDC",
       "description": "BOOK OF MEME",
       "type": "price-feed",
@@ -40671,7 +39937,395 @@
       }
     },
     {
-      "id": 543,
+      "id": 531,
+      "full_name": "IQ / USD",
+      "description": "IQ",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "IQ",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "IQUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "IQUSDT_SPBL"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "IQ_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "IQ_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "IQUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "IQ-USDC",
+                "IQ-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "IQ"
+              ],
+              "id": [
+                2930
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "IQ/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 532,
+      "full_name": "IQ / USDT",
+      "description": "IQ",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "IQ",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "IQUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "IQUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "IQ_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "IQUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "IQ-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "IQ/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 533,
+      "full_name": "IQ / USDC",
+      "description": "IQ",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "IQ",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "IQ-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "IQ/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 534,
+      "full_name": "AIXBT / USD",
+      "description": "aixbt by Virtuals",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AIXBT",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "AIXBTUSDC",
+                "AIXBTUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "AIXBTUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "AIXBTUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "AIXBTUSD-PERP",
+                "AIXBT_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "AIXBT_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "AIXBTUSD"
+              ],
+              "wsname": [
+                "AIXBT/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "AIXBT-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "AIXBTUSDC",
+                "AIXBTUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "AIXBT-USD",
+                "AIXBT-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "AIXBT"
+              ],
+              "id": [
+                34103
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AIXBT/USD-RefPrice-mainnet-production"
+        }
+      }
+    },
+    {
+      "id": 535,
+      "full_name": "AIXBT / USDT",
+      "description": "aixbt by Virtuals",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AIXBT",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "AIXBTUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "AIXBTUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "AIXBTUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "AIXBT_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "AIXBT-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "AIXBTUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "AIXBT-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AIXBT/USD-RefPrice-mainnet-production"
+        }
+      }
+    },
+    {
+      "id": 536,
+      "full_name": "AIXBT / USDC",
+      "description": "aixbt by Virtuals",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AIXBT",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "AIXBTUSDC"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "AIXBTUSDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AIXBT/USD-RefPrice-mainnet-production"
+        }
+      }
+    },
+    {
+      "id": 537,
       "full_name": "VELO / USD",
       "description": "Velo",
       "type": "price-feed",
@@ -40759,7 +40413,7 @@
       }
     },
     {
-      "id": 544,
+      "id": 538,
       "full_name": "VELO / USDT",
       "description": "Velo",
       "type": "price-feed",
@@ -40824,7 +40478,7 @@
       }
     },
     {
-      "id": 545,
+      "id": 539,
       "full_name": "VELO / USDC",
       "description": "Velo",
       "type": "price-feed",
@@ -40864,9 +40518,9 @@
       }
     },
     {
-      "id": 546,
-      "full_name": "HSK / USD",
-      "description": "HashKey Platform Token",
+      "id": 540,
+      "full_name": "BAL / USD",
+      "description": "Balancer",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -40883,7 +40537,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "HSK",
+          "base": "BAL",
           "quote": "USD"
         },
         "decimals": 8,
@@ -40891,42 +40545,82 @@
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
+            "Binance": {
+              "symbol": [
+                "BALUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "BALUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "BALUSDT_SPBL"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "BAL-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "BALUSD-PERP",
+                "BAL_USD"
+              ]
+            },
             "GateIo": {
               "id": [
-                "HSK_USDT"
+                "BAL_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "BALUSD"
+              ],
+              "wsname": [
+                "BAL/USD"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "HSK-USDT"
+                "BAL-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "HSKUSDT"
+                "BALUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "BAL-USDC",
+                "BAL-USDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "HSK"
+                "BAL"
               ],
               "id": [
-                33849
+                5728
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "HSK / USD"
+          "chainlink": "BAL / USD"
         }
       }
     },
     {
-      "id": 547,
-      "full_name": "HSK / USDT",
-      "description": "HashKey Platform Token",
+      "id": 541,
+      "full_name": "BAL / USDT",
+      "description": "Balancer",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -40943,7 +40637,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "HSK",
+          "base": "BAL",
           "quote": "USDT"
         },
         "decimals": 8,
@@ -40951,25 +40645,387 @@
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
+            "Binance": {
+              "symbol": [
+                "BALUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "BALUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "BALUSDT_SPBL"
+              ]
+            },
             "GateIo": {
               "id": [
-                "HSK_USDT"
+                "BAL_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "HSK-USDT"
+                "BAL-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "HSKUSDT"
+                "BALUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "BAL-USDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "HSK / USD"
+          "chainlink": "BAL / USD"
+        }
+      }
+    },
+    {
+      "id": 542,
+      "full_name": "BAL / USDC",
+      "description": "Balancer",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "BAL",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "BAL-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "BAL / USD"
+        }
+      }
+    },
+    {
+      "id": 543,
+      "full_name": "XVS / BNB",
+      "description": "Venus",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "XVS",
+          "quote": "BNB"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "XVSBNB"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "XVS / BNB"
+        }
+      }
+    },
+    {
+      "id": 544,
+      "full_name": "XVS / USD",
+      "description": "Venus",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "XVS",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "XVSUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "XVS_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "XVSUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "XVS"
+              ],
+              "id": [
+                7288
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "XVS / USD"
+        }
+      }
+    },
+    {
+      "id": 545,
+      "full_name": "XVS / USDT",
+      "description": "Venus",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "XVS",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "XVSUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "XVS_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "XVSUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "XVS / USD"
+        }
+      }
+    },
+    {
+      "id": 546,
+      "full_name": "CHR / USD",
+      "description": "Chromaway",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "CHR",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "CHRUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "CHRUSDT_SPBL"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "CHRUSD-PERP",
+                "CHR_USD",
+                "CHR_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "CHR_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "CHRUSD"
+              ],
+              "wsname": [
+                "CHR/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "CHR-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "CHRUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "CHR",
+                "CHR"
+              ],
+              "id": [
+                24158,
+                3978
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "CHR / USD"
+        }
+      }
+    },
+    {
+      "id": 547,
+      "full_name": "CHR / USDT",
+      "description": "Chromaway",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "CHR",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "CHRUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "CHRUSDT_SPBL"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "CHR_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "CHR_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "CHR-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "CHRUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "CHR / USD"
         }
       }
     },
@@ -41110,6 +41166,164 @@
     },
     {
       "id": 550,
+      "full_name": "BLAST / USD",
+      "description": "Blast",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "BLAST",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitfinex": {
+              "symbol": [
+                "BLAST:USD"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "BLASTUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "BLASTUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "BLAST-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "BLASTUSD-PERP",
+                "BLAST_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "BLAST_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "BLAST-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "BLASTUSDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-BLAST"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "BLAST",
+                "BLAST"
+              ],
+              "id": [
+                28480,
+                9967
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "BLAST/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 551,
+      "full_name": "BLAST / USDT",
+      "description": "Blast",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "BLAST",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "BLASTUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "BLASTUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "BLAST_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "BLAST-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "BLASTUSDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-BLAST"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "BLAST/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 552,
       "full_name": "BIGTIME / USD",
       "description": "Big Time",
       "type": "price-feed",
@@ -41205,7 +41419,7 @@
       }
     },
     {
-      "id": 551,
+      "id": 553,
       "full_name": "BIGTIME / USDT",
       "description": "Big Time",
       "type": "price-feed",
@@ -41275,7 +41489,7 @@
       }
     },
     {
-      "id": 552,
+      "id": 554,
       "full_name": "BIGTIME / USDC",
       "description": "Big Time",
       "type": "price-feed",
@@ -41315,317 +41529,7 @@
       }
     },
     {
-      "id": 553,
-      "full_name": "CHR / USD",
-      "description": "Chromaway",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "CHR",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "CHRUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "CHRUSDT_SPBL"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "CHRUSD-PERP",
-                "CHR_USD",
-                "CHR_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "CHR_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "CHRUSD"
-              ],
-              "wsname": [
-                "CHR/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "CHR-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "CHRUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "CHR",
-                "CHR"
-              ],
-              "id": [
-                24158,
-                3978
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "CHR / USD"
-        }
-      }
-    },
-    {
-      "id": 554,
-      "full_name": "CHR / USDT",
-      "description": "Chromaway",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "CHR",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "CHRUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "CHRUSDT_SPBL"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "CHR_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "CHR_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "CHR-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "CHRUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "CHR / USD"
-        }
-      }
-    },
-    {
       "id": 555,
-      "full_name": "BLAST / USD",
-      "description": "Blast",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "BLAST",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitfinex": {
-              "symbol": [
-                "BLAST:USD"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "BLASTUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "BLASTUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "BLAST-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "BLASTUSD-PERP",
-                "BLAST_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "BLAST_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "BLAST-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "BLASTUSDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-BLAST"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "BLAST",
-                "BLAST"
-              ],
-              "id": [
-                28480,
-                9967
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "BLAST/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 556,
-      "full_name": "BLAST / USDT",
-      "description": "Blast",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "BLAST",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "BLASTUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "BLASTUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "BLAST_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "BLAST-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "BLASTUSDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-BLAST"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "BLAST/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 557,
       "full_name": "ILV / USD",
       "description": "Illuvium",
       "type": "price-feed",
@@ -41717,7 +41621,7 @@
       }
     },
     {
-      "id": 558,
+      "id": 556,
       "full_name": "ILV / USDT",
       "description": "Illuvium",
       "type": "price-feed",
@@ -41792,7 +41696,7 @@
       }
     },
     {
-      "id": 559,
+      "id": 557,
       "full_name": "USDP / USD",
       "description": "Pax Dollar",
       "type": "price-feed",
@@ -41859,7 +41763,7 @@
       }
     },
     {
-      "id": 560,
+      "id": 558,
       "full_name": "USDP / USDT",
       "description": "Pax Dollar",
       "type": "price-feed",
@@ -41914,52 +41818,7 @@
       }
     },
     {
-      "id": 561,
-      "full_name": "USDX / USD",
-      "description": "",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "USDX",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "",
-        "market_hours": "",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "USDX",
-                "USDX"
-              ],
-              "id": [
-                34060,
-                6651
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "USDX / USD"
-        }
-      }
-    },
-    {
-      "id": 562,
+      "id": 559,
       "full_name": "PEOPLE / USD",
       "description": "ConstitutionDAO",
       "type": "price-feed",
@@ -42044,7 +41903,7 @@
       }
     },
     {
-      "id": 563,
+      "id": 560,
       "full_name": "PEOPLE / USDT",
       "description": "ConstitutionDAO",
       "type": "price-feed",
@@ -42114,7 +41973,7 @@
       }
     },
     {
-      "id": 564,
+      "id": 561,
       "full_name": "PEOPLE / USDC",
       "description": "ConstitutionDAO",
       "type": "price-feed",
@@ -42164,423 +42023,8 @@
       }
     },
     {
-      "id": 565,
-      "full_name": "SCR / USD",
-      "description": "Scroll",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SCR",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "SCRUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "SCRUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "SCRUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "SCR_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "SCR-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "SCRUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "SCR-USDC",
-                "SCR-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-SCR"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "SCR",
-                "SCR"
-              ],
-              "id": [
-                26998,
-                3094
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SCR/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 566,
-      "full_name": "SCR / USDT",
-      "description": "Scroll",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SCR",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "SCRUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "SCRUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "SCRUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "SCR_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "SCR-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "SCRUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "SCR-USDT"
-              ]
-            },
-            "Upbit": {
-              "market": [
-                "USDT-SCR"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SCR/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 567,
-      "full_name": "SCR / USDC",
-      "description": "Scroll",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SCR",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "SCR-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SCR/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 568,
-      "full_name": "SLP / USD",
-      "description": "Smooth Love Potion",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SLP",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "SLPUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "SLPUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "SLPUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "SLPUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "SLP_USD",
-                "SLP_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "SLP_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "SLP-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "SLPUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "SLP-USDC",
-                "SLP-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "SLP"
-              ],
-              "id": [
-                5824
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SLP / USD"
-        }
-      }
-    },
-    {
-      "id": 569,
-      "full_name": "SLP / USDT",
-      "description": "Smooth Love Potion",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SLP",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "SLPUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "SLPUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "SLPUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "SLPUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "SLP_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "SLP_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "SLP-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "SLPUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "SLP-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SLP / USD"
-        }
-      }
-    },
-    {
-      "id": 570,
-      "full_name": "SLP / USDC",
-      "description": "Smooth Love Potion",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "SLP",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "SLP-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "SLP / USD"
-        }
-      }
-    },
-    {
-      "id": 571,
-      "full_name": "USDtb / USD",
+      "id": 562,
+      "full_name": "USDX / USD",
       "description": "",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
@@ -42598,78 +42042,33 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "USDtb",
+          "base": "USDX",
           "quote": "USD"
         },
         "decimals": 8,
         "category": "",
-        "market_hours": null,
+        "market_hours": "",
         "arguments": {
-          "exchanges": {
-            "Bybit": {
-              "symbol": [
-                "USDTBUSDT"
-              ]
-            }
-          },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "USDTb"
+                "USDX",
+                "USDX"
               ],
               "id": [
-                34691
+                34060,
+                6651
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "USDtb / USD"
+          "chainlink": "USDX / USD"
         }
       }
     },
     {
-      "id": 572,
-      "full_name": "USDtb / USDT",
-      "description": "",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "USDtb",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "",
-        "market_hours": null,
-        "arguments": {
-          "exchanges": {
-            "Bybit": {
-              "symbol": [
-                "USDTBUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "USDtb / USD"
-        }
-      }
-    },
-    {
-      "id": 573,
+      "id": 563,
       "full_name": "TRB / USD",
       "description": "Tellor Tributes",
       "type": "price-feed",
@@ -42754,7 +42153,7 @@
       }
     },
     {
-      "id": 574,
+      "id": 564,
       "full_name": "TRB / USDT",
       "description": "Tellor Tributes",
       "type": "price-feed",
@@ -42819,7 +42218,7 @@
       }
     },
     {
-      "id": 575,
+      "id": 565,
       "full_name": "TRB / USDC",
       "description": "Tellor Tributes",
       "type": "price-feed",
@@ -42869,7 +42268,207 @@
       }
     },
     {
-      "id": 576,
+      "id": 566,
+      "full_name": "PIXEL / USD",
+      "description": "Pixels",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "PIXEL",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "PIXELUSDC",
+                "PIXELUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "PIXELUSDT_SPBL"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "PIXELUSD-PERP",
+                "PIXEL_USD",
+                "PIXEL_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "PIXEL_USDC",
+                "PIXEL_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "PIXEL-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "PIXELUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "PIXEL-USD",
+                "PIXEL-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "PIXEL"
+              ],
+              "id": [
+                29335
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "PIXEL/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 567,
+      "full_name": "PIXEL / USDT",
+      "description": "Pixels",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "PIXEL",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "PIXELUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "PIXELUSDT_SPBL"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "PIXEL_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "PIXEL_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "PIXEL-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "PIXELUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "PIXEL-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "PIXEL/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 568,
+      "full_name": "PIXEL / USDC",
+      "description": "Pixels",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "PIXEL",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "PIXELUSDC"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "PIXEL_USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "PIXEL/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 569,
       "full_name": "XAI / USD",
       "description": "Xai",
       "type": "price-feed",
@@ -42961,7 +42560,7 @@
       }
     },
     {
-      "id": 577,
+      "id": 570,
       "full_name": "XAI / USDT",
       "description": "Xai",
       "type": "price-feed",
@@ -43026,6 +42625,418 @@
       }
     },
     {
+      "id": 571,
+      "full_name": "SLP / USD",
+      "description": "Smooth Love Potion",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "SLP",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "SLPUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "SLPUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "SLPUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "SLPUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "SLP_USD",
+                "SLP_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "SLP_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "SLP-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "SLPUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "SLP-USDC",
+                "SLP-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "SLP"
+              ],
+              "id": [
+                5824
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "SLP / USD"
+        }
+      }
+    },
+    {
+      "id": 572,
+      "full_name": "SLP / USDT",
+      "description": "Smooth Love Potion",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "SLP",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "SLPUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "SLPUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "SLPUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "SLPUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "SLP_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "SLP_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "SLP-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "SLPUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "SLP-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "SLP / USD"
+        }
+      }
+    },
+    {
+      "id": 573,
+      "full_name": "SLP / USDC",
+      "description": "Smooth Love Potion",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "SLP",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "SLP-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "SLP / USD"
+        }
+      }
+    },
+    {
+      "id": 574,
+      "full_name": "USDtb / USD",
+      "description": "",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "USDtb",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "",
+        "market_hours": null,
+        "arguments": {
+          "exchanges": {
+            "Bybit": {
+              "symbol": [
+                "USDTBUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "USDTb"
+              ],
+              "id": [
+                34691
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "USDtb / USD"
+        }
+      }
+    },
+    {
+      "id": 575,
+      "full_name": "USDtb / USDT",
+      "description": "",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "USDtb",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "",
+        "market_hours": null,
+        "arguments": {
+          "exchanges": {
+            "Bybit": {
+              "symbol": [
+                "USDTBUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "USDtb / USD"
+        }
+      }
+    },
+    {
+      "id": 576,
+      "full_name": "HSK / USD",
+      "description": "HashKey Platform Token",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "HSK",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "GateIo": {
+              "id": [
+                "HSK_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "HSK-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "HSKUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "HSK"
+              ],
+              "id": [
+                33849
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "HSK / USD"
+        }
+      }
+    },
+    {
+      "id": 577,
+      "full_name": "HSK / USDT",
+      "description": "HashKey Platform Token",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "HSK",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "GateIo": {
+              "id": [
+                "HSK_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "HSK-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "HSKUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "HSK / USD"
+        }
+      }
+    },
+    {
       "id": 578,
       "full_name": "JOE / USD",
       "description": "Trader Joe",
@@ -43081,6 +43092,7 @@
             },
             "OKX": {
               "instId": [
+                "JOE-USD",
                 "JOE-USDC",
                 "JOE-USDT"
               ]
@@ -43208,6 +43220,209 @@
     },
     {
       "id": 581,
+      "full_name": "SCR / USD",
+      "description": "Scroll",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "SCR",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "SCRUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "SCRUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "SCRUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "SCR_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "SCR-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "SCRUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "SCR-USDC",
+                "SCR-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-SCR"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "SCR",
+                "SCR"
+              ],
+              "id": [
+                26998,
+                3094
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "SCR/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 582,
+      "full_name": "SCR / USDT",
+      "description": "Scroll",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "SCR",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "SCRUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "SCRUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "SCRUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "SCR_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "SCR-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "SCRUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "SCR-USDT"
+              ]
+            },
+            "Upbit": {
+              "market": [
+                "USDT-SCR"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "SCR/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 583,
+      "full_name": "SCR / USDC",
+      "description": "Scroll",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "SCR",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "SCR-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "SCR/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 584,
       "full_name": "DOGS / USD",
       "description": "DOGS",
       "type": "price-feed",
@@ -43317,7 +43532,7 @@
       }
     },
     {
-      "id": 582,
+      "id": 585,
       "full_name": "DOGS / USDT",
       "description": "DOGS",
       "type": "price-feed",
@@ -43392,7 +43607,7 @@
       }
     },
     {
-      "id": 583,
+      "id": 586,
       "full_name": "DOGS / USDC",
       "description": "DOGS",
       "type": "price-feed",
@@ -43442,7 +43657,7 @@
       }
     },
     {
-      "id": 584,
+      "id": 587,
       "full_name": "EDU / USD",
       "description": "Open Campus",
       "type": "price-feed",
@@ -43507,7 +43722,7 @@
       }
     },
     {
-      "id": 585,
+      "id": 588,
       "full_name": "EDU / USDT",
       "description": "Open Campus",
       "type": "price-feed",
@@ -43562,7 +43777,283 @@
       }
     },
     {
-      "id": 586,
+      "id": 589,
+      "full_name": "ANON / USD",
+      "description": "",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ANON",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "",
+        "market_hours": "",
+        "arguments": {
+          "exchanges": {
+            "GateIo": {
+              "id": [
+                "ANON_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "ANONUSD"
+              ],
+              "wsname": [
+                "ANON/USD"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ANONUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "ANON",
+                "ANON",
+                "ANON"
+              ],
+              "id": [
+                30846,
+                31734,
+                35092
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ANON / USD"
+        }
+      }
+    },
+    {
+      "id": 590,
+      "full_name": "ANON / USDT",
+      "description": "",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ANON",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "",
+        "market_hours": "",
+        "arguments": {
+          "exchanges": {
+            "GateIo": {
+              "id": [
+                "ANON_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ANONUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ANON / USD"
+        }
+      }
+    },
+    {
+      "id": 591,
+      "full_name": "C98 / USD",
+      "description": "C98",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "C98",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "C98USDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "C98USDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "C98USDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "C98-USD",
+                "C98-USDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "C98_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "C98_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "C98USD"
+              ],
+              "wsname": [
+                "C98/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "C98-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "C98USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "C98"
+              ],
+              "id": [
+                10903
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "C98 / USD"
+        }
+      }
+    },
+    {
+      "id": 592,
+      "full_name": "C98 / USDT",
+      "description": "C98",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "C98",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "C98USDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "C98USDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "C98USDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "C98-USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "C98_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "C98-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "C98USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "C98 / USD"
+        }
+      }
+    },
+    {
+      "id": 593,
       "full_name": "KNC / USD",
       "description": "Kyber Network Crystal v2",
       "type": "price-feed",
@@ -43661,7 +44152,7 @@
       }
     },
     {
-      "id": 587,
+      "id": 594,
       "full_name": "KNC / ETH",
       "description": "Kyber Network Crystal",
       "type": "price-feed",
@@ -43706,7 +44197,7 @@
       }
     },
     {
-      "id": 588,
+      "id": 595,
       "full_name": "KNC / USDT",
       "description": "Kyber Network Crystal v2",
       "type": "price-feed",
@@ -43776,7 +44267,7 @@
       }
     },
     {
-      "id": 589,
+      "id": 596,
       "full_name": "KNC / USDC",
       "description": "Kyber Network Crystal v2",
       "type": "price-feed",
@@ -43816,700 +44307,7 @@
       }
     },
     {
-      "id": 590,
-      "full_name": "BUSD / USD",
-      "description": "Binance USD",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "BUSD",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "BUSDUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "BUSDUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "BUSD-USD"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "BUSD"
-              ],
-              "id": [
-                4687
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "BUSD / USD"
-        }
-      }
-    },
-    {
-      "id": 591,
-      "full_name": "BUSD / USDT",
-      "description": "Binance USD",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "BUSD",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "BUSDUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "BUSDUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "BUSD / USD"
-        }
-      }
-    },
-    {
-      "id": 592,
-      "full_name": "USDL / USD",
-      "description": "",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "USDL",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "",
-        "market_hours": "",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "USDL"
-              ],
-              "id": [
-                32454
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "USDL / USD"
-        }
-      }
-    },
-    {
-      "id": 593,
-      "full_name": "C98 / USD",
-      "description": "C98",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "C98",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "C98USDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "C98USDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "C98USDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "C98-USD",
-                "C98-USDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "C98_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "C98_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "C98USD"
-              ],
-              "wsname": [
-                "C98/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "C98-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "C98USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "C98"
-              ],
-              "id": [
-                10903
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "C98 / USD"
-        }
-      }
-    },
-    {
-      "id": 594,
-      "full_name": "C98 / USDT",
-      "description": "C98",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "C98",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "C98USDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "C98USDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "C98USDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "C98-USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "C98_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "C98-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "C98USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "C98 / USD"
-        }
-      }
-    },
-    {
-      "id": 595,
-      "full_name": "WIN / USD",
-      "description": "WINkLink",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "WIN",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "WINUSDC",
-                "WINUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "WINUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "WIN_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "WIN-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "WINUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "WIN-USD",
-                "WIN-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "WIN",
-                "WIN",
-                "WIN"
-              ],
-              "id": [
-                28992,
-                31754,
-                4206
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "WIN / USD"
-        }
-      }
-    },
-    {
-      "id": 596,
-      "full_name": "WIN / USDT",
-      "description": "WINkLink",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "WIN",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "WINUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "WINUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "WIN_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "WIN-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "WINUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "WIN-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "WIN / USD"
-        }
-      }
-    },
-    {
       "id": 597,
-      "full_name": "WIN / USDC",
-      "description": "WINkLink",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "WIN",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "WINUSDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "WIN / USD"
-        }
-      }
-    },
-    {
-      "id": 598,
-      "full_name": "BADGER / USD",
-      "description": "Badger DAO",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "BADGER",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "BADGERUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "BADGERUSDT_SPBL"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "BADGER-USD",
-                "BADGER-USDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "BADGER_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "BADGER_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "BADGERUSD"
-              ],
-              "wsname": [
-                "BADGER/USD"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "BADGERUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "BADGER-USDC",
-                "BADGER-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "BADGER"
-              ],
-              "id": [
-                7859
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "BADGER / USD"
-        }
-      }
-    },
-    {
-      "id": 599,
-      "full_name": "BADGER / USDT",
-      "description": "Badger DAO",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "BADGER",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "BADGERUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "BADGERUSDT_SPBL"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "BADGER-USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "BADGER_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "BADGERUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "BADGER-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "BADGER / USD"
-        }
-      }
-    },
-    {
-      "id": 600,
-      "full_name": "BADGER / USDC",
-      "description": "Badger DAO",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "BADGER",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "BADGER-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "BADGER / USD"
-        }
-      }
-    },
-    {
-      "id": 601,
       "full_name": "BB / USD",
       "description": "BounceBit",
       "type": "price-feed",
@@ -44592,7 +44390,7 @@
       }
     },
     {
-      "id": 602,
+      "id": 598,
       "full_name": "BB / USDT",
       "description": "BounceBit",
       "type": "price-feed",
@@ -44657,7 +44455,7 @@
       }
     },
     {
-      "id": 603,
+      "id": 599,
       "full_name": "BB / USDC",
       "description": "BounceBit",
       "type": "price-feed",
@@ -44702,9 +44500,9 @@
       }
     },
     {
-      "id": 604,
-      "full_name": "GOAT / USD",
-      "description": "Goatseus Maximus",
+      "id": 600,
+      "full_name": "BUSD / USD",
+      "description": "Binance USD",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -44721,92 +44519,50 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "GOAT",
+          "base": "BUSD",
           "quote": "USD"
         },
-        "decimals": 18,
+        "decimals": 8,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Bitget": {
+            "Binance": {
               "symbol": [
-                "GOATUSDT_SPBL"
+                "BUSDUSDT"
               ]
             },
-            "Bybit": {
+            "BinanceUS": {
               "symbol": [
-                "GOATUSDT"
+                "BUSDUSDT"
               ]
             },
-            "CryptoCom": {
-              "instrument_name": [
-                "GOATUSD-PERP",
-                "GOAT_USD",
-                "GOAT_USDT"
-              ]
-            },
-            "GateIo": {
+            "Coinbase": {
               "id": [
-                "GOAT_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "GOATUSD"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "GOATUSD"
-              ],
-              "wsname": [
-                "GOAT/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "GOAT-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "GOATUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "GOAT-USD",
-                "GOAT-USDT"
+                "BUSD-USD"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "GOAT",
-                "GOAT",
-                "GOAT",
-                "GOAT"
+                "BUSD"
               ],
               "id": [
-                30647,
-                33440,
-                33814,
-                9069
+                4687
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "GOAT/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "BUSD / USD"
         }
       }
     },
     {
-      "id": 605,
-      "full_name": "GOAT / USDT",
-      "description": "Goatseus Maximus",
+      "id": 601,
+      "full_name": "BUSD / USDT",
+      "description": "Binance USD",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -44823,53 +44579,257 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "GOAT",
+          "base": "BUSD",
           "quote": "USDT"
         },
-        "decimals": 18,
+        "decimals": 8,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Bitget": {
+            "Binance": {
               "symbol": [
-                "GOATUSDT_SPBL"
+                "BUSDUSDT"
               ]
             },
-            "Bybit": {
+            "BinanceUS": {
               "symbol": [
-                "GOATUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "GOAT_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "GOAT_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "GOAT-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "GOATUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "GOAT-USDT"
+                "BUSDUSDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "GOAT/USD-RefPrice-DS-Premium-Global-003"
+          "chainlink": "BUSD / USD"
+        }
+      }
+    },
+    {
+      "id": 602,
+      "full_name": "USDL / USD",
+      "description": "",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "USDL",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "",
+        "market_hours": "",
+        "arguments": {
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "USDL"
+              ],
+              "id": [
+                32454
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "USDL / USD"
+        }
+      }
+    },
+    {
+      "id": 603,
+      "full_name": "WIN / USD",
+      "description": "WINkLink",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "WIN",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "WINUSDC",
+                "WINUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "WINUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "WIN_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "WIN-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "WINUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "WIN-USD",
+                "WIN-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "WIN",
+                "WIN",
+                "WIN"
+              ],
+              "id": [
+                28992,
+                31754,
+                4206
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "WIN / USD"
+        }
+      }
+    },
+    {
+      "id": 604,
+      "full_name": "WIN / USDT",
+      "description": "WINkLink",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "WIN",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "WINUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "WINUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "WIN_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "WIN-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "WINUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "WIN-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "WIN / USD"
+        }
+      }
+    },
+    {
+      "id": 605,
+      "full_name": "WIN / USDC",
+      "description": "WINkLink",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "WIN",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "WINUSDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "WIN / USD"
         }
       }
     },
@@ -45085,6 +45045,304 @@
     },
     {
       "id": 609,
+      "full_name": "GOAT / USD",
+      "description": "Goatseus Maximus",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "GOAT",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "GOATUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "GOATUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "GOATUSD-PERP",
+                "GOAT_USD",
+                "GOAT_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "GOAT_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "GOATUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "GOATUSD"
+              ],
+              "wsname": [
+                "GOAT/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "GOAT-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "GOATUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "GOAT-USD",
+                "GOAT-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "GOAT",
+                "GOAT",
+                "GOAT",
+                "GOAT"
+              ],
+              "id": [
+                30647,
+                33440,
+                33814,
+                9069
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "GOAT/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 610,
+      "full_name": "GOAT / USDT",
+      "description": "Goatseus Maximus",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "GOAT",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "GOATUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "GOATUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "GOAT_USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "GOAT_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "GOAT-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "GOATUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "GOAT-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "GOAT/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 611,
+      "full_name": "AI / USD",
+      "description": "Sleepless AI",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AI",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "AIUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "AI_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "AIUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "AI",
+                "AI",
+                "AI",
+                "AI",
+                "AI",
+                "AI",
+                "AI",
+                "AI",
+                "AI"
+              ],
+              "id": [
+                10712,
+                11061,
+                14838,
+                23955,
+                27344,
+                28846,
+                28847,
+                28902,
+                28916
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AI/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 612,
+      "full_name": "AI / USDT",
+      "description": "Sleepless AI",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AI",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "AIUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "AI_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "AIUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AI/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 613,
       "full_name": "OMNI / USD",
       "description": "Omni Network",
       "type": "price-feed",
@@ -45183,7 +45441,7 @@
       }
     },
     {
-      "id": 610,
+      "id": 614,
       "full_name": "OMNI / USDT",
       "description": "Omni Network",
       "type": "price-feed",
@@ -45248,7 +45506,7 @@
       }
     },
     {
-      "id": 611,
+      "id": 615,
       "full_name": "OMNI / USDC",
       "description": "Omni Network",
       "type": "price-feed",
@@ -45293,133 +45551,7 @@
       }
     },
     {
-      "id": 612,
-      "full_name": "AI / USD",
-      "description": "Sleepless AI",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AI",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "AIUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "AI_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "AIUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "AI",
-                "AI",
-                "AI",
-                "AI",
-                "AI",
-                "AI",
-                "AI",
-                "AI",
-                "AI"
-              ],
-              "id": [
-                10712,
-                11061,
-                14838,
-                23955,
-                27344,
-                28846,
-                28847,
-                28902,
-                28916
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AI/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 613,
-      "full_name": "AI / USDT",
-      "description": "Sleepless AI",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "AI",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "AIUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "AI_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "AIUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "AI/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 614,
+      "id": 616,
       "full_name": "BONE / USD",
       "description": "Bone ShibaSwap",
       "type": "price-feed",
@@ -45493,7 +45625,7 @@
       }
     },
     {
-      "id": 615,
+      "id": 617,
       "full_name": "BONE / USDT",
       "description": "Bone ShibaSwap",
       "type": "price-feed",
@@ -45553,7 +45685,7 @@
       }
     },
     {
-      "id": 616,
+      "id": 618,
       "full_name": "BONE / USDC",
       "description": "Bone ShibaSwap",
       "type": "price-feed",
@@ -45593,252 +45725,7 @@
       }
     },
     {
-      "id": 617,
-      "full_name": "LUSD / USD",
-      "description": "Liquity USD",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "LUSD",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "LUSD",
-                "LUSD"
-              ],
-              "id": [
-                19714,
-                9566
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "LUSD / USD"
-        }
-      }
-    },
-    {
-      "id": 618,
-      "full_name": "PIXEL / USD",
-      "description": "Pixels",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "PIXEL",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "PIXELUSDC",
-                "PIXELUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "PIXELUSDT_SPBL"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "PIXELUSD-PERP",
-                "PIXEL_USD",
-                "PIXEL_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "PIXEL_USDC",
-                "PIXEL_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "PIXEL-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "PIXELUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "PIXEL-USD",
-                "PIXEL-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "PIXEL"
-              ],
-              "id": [
-                29335
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "PIXEL/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
       "id": 619,
-      "full_name": "PIXEL / USDT",
-      "description": "Pixels",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "PIXEL",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "PIXELUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "PIXELUSDT_SPBL"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "PIXEL_USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "PIXEL_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "PIXEL-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "PIXELUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "PIXEL-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "PIXEL/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 620,
-      "full_name": "PIXEL / USDC",
-      "description": "Pixels",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "PIXEL",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "PIXELUSDC"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "PIXEL_USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "PIXEL/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 621,
       "full_name": "REZ / USD",
       "description": "Renzo",
       "type": "price-feed",
@@ -45923,7 +45810,7 @@
       }
     },
     {
-      "id": 622,
+      "id": 620,
       "full_name": "REZ / USDT",
       "description": "Renzo",
       "type": "price-feed",
@@ -45983,7 +45870,7 @@
       }
     },
     {
-      "id": 623,
+      "id": 621,
       "full_name": "REZ / USDC",
       "description": "Renzo",
       "type": "price-feed",
@@ -46028,7 +45915,7 @@
       }
     },
     {
-      "id": 624,
+      "id": 622,
       "full_name": "DODO / USD",
       "description": "Dodo",
       "type": "price-feed",
@@ -46107,7 +45994,7 @@
       }
     },
     {
-      "id": 625,
+      "id": 623,
       "full_name": "DODO / USDT",
       "description": "Dodo",
       "type": "price-feed",
@@ -46172,7 +46059,52 @@
       }
     },
     {
-      "id": 626,
+      "id": 624,
+      "full_name": "LUSD / USD",
+      "description": "Liquity USD",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "LUSD",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "LUSD",
+                "LUSD"
+              ],
+              "id": [
+                19714,
+                9566
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "LUSD / USD"
+        }
+      }
+    },
+    {
+      "id": 625,
       "full_name": "QI / USD",
       "description": "Benqi",
       "type": "price-feed",
@@ -46252,7 +46184,7 @@
       }
     },
     {
-      "id": 627,
+      "id": 626,
       "full_name": "QI / USDT",
       "description": "Benqi",
       "type": "price-feed",
@@ -46312,142 +46244,7 @@
       }
     },
     {
-      "id": 628,
-      "full_name": "COQ / USD",
-      "description": "Coq Inu",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "COQ",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "COQUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "COQUSDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "COQ_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "COQ_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "COQ-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "COQUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "COQ"
-              ],
-              "id": [
-                28675
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "COQ / USD"
-        }
-      }
-    },
-    {
-      "id": 629,
-      "full_name": "COQ / USDT",
-      "description": "Coq Inu",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "COQ",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "COQUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "COQUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "COQ_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "COQ-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "COQUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "COQ / USD"
-        }
-      }
-    },
-    {
-      "id": 630,
+      "id": 627,
       "full_name": "CYBER / USD",
       "description": "CYBER",
       "type": "price-feed",
@@ -46537,7 +46334,7 @@
       }
     },
     {
-      "id": 631,
+      "id": 628,
       "full_name": "CYBER / USDT",
       "description": "CYBER",
       "type": "price-feed",
@@ -46602,7 +46399,339 @@
       }
     },
     {
+      "id": 629,
+      "full_name": "MERL / USD",
+      "description": "Merlin Chain",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "MERL",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "MERLUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "MERLUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "MERL_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "MERL-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "MERLUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "MERL-USD",
+                "MERL-USDC",
+                "MERL-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "MERL"
+              ],
+              "id": [
+                30712
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "MERL/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 630,
+      "full_name": "MERL / USDT",
+      "description": "Merlin Chain",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "MERL",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "MERLUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "MERLUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "MERL_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "MERL-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "MERLUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "MERL-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "MERL/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 631,
+      "full_name": "MERL / USDC",
+      "description": "Merlin Chain",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "MERL",
+          "quote": "USDC"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "MERL-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "MERL/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
       "id": 632,
+      "full_name": "DEGEN / USD",
+      "description": "Degen (Base)",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "DEGEN",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bybit": {
+              "symbol": [
+                "DEGENUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "DEGEN-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "DEGENUSD-PERP",
+                "DEGEN_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "DEGEN_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "DEGEN-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "DEGENUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "DEGEN-USD",
+                "DEGEN-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "DEGEN",
+                "DEGEN",
+                "DEGEN",
+                "DEGEN",
+                "DEGEN"
+              ],
+              "id": [
+                24276,
+                25514,
+                28773,
+                30096,
+                34380
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "DEGEN / USD"
+        }
+      }
+    },
+    {
+      "id": 633,
+      "full_name": "DEGEN / USDT",
+      "description": "Degen (Base)",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "DEGEN",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bybit": {
+              "symbol": [
+                "DEGENUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "DEGEN_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "DEGEN-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "DEGENUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "DEGEN-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "DEGEN / USD"
+        }
+      }
+    },
+    {
+      "id": 634,
       "full_name": "HIGH / USD",
       "description": "Highstreet",
       "type": "price-feed",
@@ -46683,7 +46812,7 @@
       }
     },
     {
-      "id": 633,
+      "id": 635,
       "full_name": "HIGH / USDT",
       "description": "Highstreet",
       "type": "price-feed",
@@ -46748,7 +46877,564 @@
       }
     },
     {
-      "id": 634,
+      "id": 636,
+      "full_name": "COQ / USD",
+      "description": "Coq Inu",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "COQ",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "COQUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "COQUSDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "COQ_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "COQ_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "COQ-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "COQUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "COQ"
+              ],
+              "id": [
+                28675
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "COQ / USD"
+        }
+      }
+    },
+    {
+      "id": 637,
+      "full_name": "COQ / USDT",
+      "description": "Coq Inu",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "COQ",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "COQUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "COQUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "COQ_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "COQ-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "COQUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "COQ / USD"
+        }
+      }
+    },
+    {
+      "id": 638,
+      "full_name": "GNS / USD",
+      "description": "Gains Network",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "GNS",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "GNSUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "GNSUSDT_SPBL"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "GNS_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "GNS_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "GNS-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "GNSUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "GNS"
+              ],
+              "id": [
+                13663
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "GNS / USD"
+        }
+      }
+    },
+    {
+      "id": 639,
+      "full_name": "GNS / USDT",
+      "description": "Gains Network",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "GNS",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "GNSUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "GNSUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "GNS_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "GNS-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "GNSUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "GNS / USD"
+        }
+      }
+    },
+    {
+      "id": 640,
+      "full_name": "GRIFFAIN / USD",
+      "description": "GRIFFAIN",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "GRIFFAIN",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "GRIFFAINUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "GRIFFAIN_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "GRIFFAINUSD"
+              ],
+              "wsname": [
+                "GRIFFAIN/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "GRIFFAIN-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "GRIFFAINUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "GRIFFAIN"
+              ],
+              "id": [
+                34792
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "GRIFFAIN/USD-RefPrice-mainnet-production"
+        }
+      }
+    },
+    {
+      "id": 641,
+      "full_name": "GRIFFAIN / USDT",
+      "description": "GRIFFAIN",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "GRIFFAIN",
+          "quote": "USDT"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "GRIFFAINUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "GRIFFAIN_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "GRIFFAIN-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "GRIFFAINUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "GRIFFAIN/USD-RefPrice-mainnet-production"
+        }
+      }
+    },
+    {
+      "id": 642,
+      "full_name": "OGN / USD",
+      "description": "Origin Protocol",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "OGN",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "OGNUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "OGNUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "OGNUSDT_SPBL"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "OGN-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "OGNUSD-PERP",
+                "OGN_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "OGN_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "OGNUSD"
+              ],
+              "wsname": [
+                "OGN/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "OGN-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "OGNUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "OGN"
+              ],
+              "id": [
+                5117
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "OGN / USD"
+        }
+      }
+    },
+    {
+      "id": 643,
+      "full_name": "OGN / USDT",
+      "description": "Origin Protocol",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "OGN",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "OGNUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "OGNUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "OGNUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "OGN_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "OGN-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "OGNUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "OGN / USD"
+        }
+      }
+    },
+    {
+      "id": 644,
       "full_name": "MAGIC / USD",
       "description": "Magic",
       "type": "price-feed",
@@ -46846,7 +47532,7 @@
       }
     },
     {
-      "id": 635,
+      "id": 645,
       "full_name": "MAGIC / USDT",
       "description": "Magic",
       "type": "price-feed",
@@ -46926,7 +47612,7 @@
       }
     },
     {
-      "id": 636,
+      "id": 646,
       "full_name": "MAGIC / USDC",
       "description": "Magic",
       "type": "price-feed",
@@ -46966,804 +47652,7 @@
       }
     },
     {
-      "id": 637,
-      "full_name": "DEGEN / USD",
-      "description": "Degen (Base)",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "DEGEN",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bybit": {
-              "symbol": [
-                "DEGENUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "DEGEN-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "DEGENUSD-PERP",
-                "DEGEN_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "DEGEN_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "DEGEN-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "DEGENUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "DEGEN-USD",
-                "DEGEN-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "DEGEN",
-                "DEGEN",
-                "DEGEN",
-                "DEGEN",
-                "DEGEN"
-              ],
-              "id": [
-                24276,
-                25514,
-                28773,
-                30096,
-                34380
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "DEGEN / USD"
-        }
-      }
-    },
-    {
-      "id": 638,
-      "full_name": "DEGEN / USDT",
-      "description": "Degen (Base)",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "DEGEN",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bybit": {
-              "symbol": [
-                "DEGENUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "DEGEN_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "DEGEN-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "DEGENUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "DEGEN-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "DEGEN / USD"
-        }
-      }
-    },
-    {
-      "id": 639,
-      "full_name": "MERL / USD",
-      "description": "Merlin Chain",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "MERL",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "MERLUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "MERLUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "MERL_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "MERL-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "MERLUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "MERL-USD",
-                "MERL-USDC",
-                "MERL-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "MERL"
-              ],
-              "id": [
-                30712
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "MERL/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 640,
-      "full_name": "MERL / USDT",
-      "description": "Merlin Chain",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "MERL",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "MERLUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "MERLUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "MERL_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "MERL-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "MERLUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "MERL-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "MERL/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 641,
-      "full_name": "MERL / USDC",
-      "description": "Merlin Chain",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "MERL",
-          "quote": "USDC"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "MERL-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "MERL/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 642,
-      "full_name": "GNS / USD",
-      "description": "Gains Network",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "GNS",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "GNSUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "GNSUSDT_SPBL"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "GNS_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "GNS_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "GNS-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "GNSUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "GNS"
-              ],
-              "id": [
-                13663
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "GNS / USD"
-        }
-      }
-    },
-    {
-      "id": 643,
-      "full_name": "GNS / USDT",
-      "description": "Gains Network",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "GNS",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "GNSUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "GNSUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "GNS_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "GNS-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "GNSUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "GNS / USD"
-        }
-      }
-    },
-    {
-      "id": 644,
-      "full_name": "GRIFFAIN / USD",
-      "description": "GRIFFAIN",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "GRIFFAIN",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "GRIFFAINUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "GRIFFAIN_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "GRIFFAINUSD"
-              ],
-              "wsname": [
-                "GRIFFAIN/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "GRIFFAIN-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "GRIFFAINUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "GRIFFAIN"
-              ],
-              "id": [
-                34792
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "GRIFFAIN/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 645,
-      "full_name": "GRIFFAIN / USDT",
-      "description": "GRIFFAIN",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "GRIFFAIN",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "GRIFFAINUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "GRIFFAIN_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "GRIFFAIN-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "GRIFFAINUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "GRIFFAIN/USD-RefPrice-mainnet-production"
-        }
-      }
-    },
-    {
-      "id": 646,
-      "full_name": "DPI / USD",
-      "description": "DefiPulse Index",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "DPI",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "DPI"
-              ],
-              "id": [
-                7055
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "DPI / USD"
-        }
-      }
-    },
-    {
       "id": 647,
-      "full_name": "OGN / USD",
-      "description": "Origin Protocol",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "OGN",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "OGNUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "OGNUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "OGNUSDT_SPBL"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "OGN-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "OGNUSD-PERP",
-                "OGN_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "OGN_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "OGNUSD"
-              ],
-              "wsname": [
-                "OGN/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "OGN-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "OGNUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "OGN"
-              ],
-              "id": [
-                5117
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "OGN / USD"
-        }
-      }
-    },
-    {
-      "id": 648,
-      "full_name": "OGN / USDT",
-      "description": "Origin Protocol",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "OGN",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "OGNUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "OGNUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "OGNUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "OGN_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "OGN-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "OGNUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "OGN / USD"
-        }
-      }
-    },
-    {
-      "id": 649,
       "full_name": "STG / USD",
       "description": "Stargate Finance",
       "type": "price-feed",
@@ -47868,7 +47757,7 @@
       }
     },
     {
-      "id": 650,
+      "id": 648,
       "full_name": "STG / USDT",
       "description": "Stargate Finance",
       "type": "price-feed",
@@ -47943,9 +47832,9 @@
       }
     },
     {
-      "id": 651,
-      "full_name": "CUSD / USD",
-      "description": "Celo Dollar",
+      "id": 649,
+      "full_name": "DPI / USD",
+      "description": "DefiPulse Index",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -47962,90 +47851,31 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "CUSD",
+          "base": "DPI",
           "quote": "USD"
         },
         "decimals": 8,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
-          "exchanges": {
-            "Bybit": {
-              "symbol": [
-                "CUSDUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "CUSD_USDT"
-              ]
-            }
-          },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "CUSD",
-                "CUSD"
+                "DPI"
               ],
               "id": [
-                21871,
-                7236
+                7055
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "CUSD / USD"
+          "chainlink": "DPI / USD"
         }
       }
     },
     {
-      "id": 652,
-      "full_name": "CUSD / USDT",
-      "description": "Celo Dollar",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "CUSD",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bybit": {
-              "symbol": [
-                "CUSDUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "CUSD_USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "CUSD / USD"
-        }
-      }
-    },
-    {
-      "id": 653,
+      "id": 650,
       "full_name": "MOODENG / USD",
       "description": "Moo Deng",
       "type": "price-feed",
@@ -48146,7 +47976,7 @@
       }
     },
     {
-      "id": 654,
+      "id": 651,
       "full_name": "MOODENG / USDT",
       "description": "Moo Deng",
       "type": "price-feed",
@@ -48206,7 +48036,7 @@
       }
     },
     {
-      "id": 655,
+      "id": 652,
       "full_name": "MOODENG / USDC",
       "description": "Moo Deng",
       "type": "price-feed",
@@ -48242,6 +48072,201 @@
         },
         "compatibility_info": {
           "chainlink": "MOODENG/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": 653,
+      "full_name": "BADGER / USD",
+      "description": "Badger DAO",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "BADGER",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "BADGERUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "BADGERUSDT_SPBL"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "BADGER-USD",
+                "BADGER-USDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "BADGER_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "BADGER_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "BADGERUSD"
+              ],
+              "wsname": [
+                "BADGER/USD"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "BADGERUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "BADGER-USDC",
+                "BADGER-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "BADGER"
+              ],
+              "id": [
+                7859
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "BADGER / USD"
+        }
+      }
+    },
+    {
+      "id": 654,
+      "full_name": "BADGER / USDT",
+      "description": "Badger DAO",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "BADGER",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "BADGERUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "BADGERUSDT_SPBL"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "BADGER-USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "BADGER_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "BADGERUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "BADGER-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "BADGER / USD"
+        }
+      }
+    },
+    {
+      "id": 655,
+      "full_name": "BADGER / USDC",
+      "description": "Badger DAO",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "BADGER",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "BADGER-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "BADGER / USD"
         }
       }
     },
@@ -48436,6 +48461,108 @@
     },
     {
       "id": 659,
+      "full_name": "CUSD / USD",
+      "description": "Celo Dollar",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "CUSD",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bybit": {
+              "symbol": [
+                "CUSDUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "CUSD_USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "CUSD",
+                "CUSD"
+              ],
+              "id": [
+                21871,
+                7236
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "CUSD / USD"
+        }
+      }
+    },
+    {
+      "id": 660,
+      "full_name": "CUSD / USDT",
+      "description": "Celo Dollar",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "CUSD",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bybit": {
+              "symbol": [
+                "CUSDUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "CUSD_USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "CUSD / USD"
+        }
+      }
+    },
+    {
+      "id": 661,
       "full_name": "MAV / USD",
       "description": "Maverick Protocol",
       "type": "price-feed",
@@ -48512,7 +48639,7 @@
       }
     },
     {
-      "id": 660,
+      "id": 662,
       "full_name": "MAV / USDT",
       "description": "Maverick Protocol",
       "type": "price-feed",
@@ -48572,7 +48699,7 @@
       }
     },
     {
-      "id": 661,
+      "id": 663,
       "full_name": "ALPHA / USD",
       "description": "Alpha Finance",
       "type": "price-feed",
@@ -48667,7 +48794,7 @@
       }
     },
     {
-      "id": 662,
+      "id": 664,
       "full_name": "ALPHA / USDT",
       "description": "Alpha Finance",
       "type": "price-feed",
@@ -48732,7 +48859,7 @@
       }
     },
     {
-      "id": 663,
+      "id": 665,
       "full_name": "ALPHA / USDC",
       "description": "Alpha Finance",
       "type": "price-feed",
@@ -48772,7 +48899,137 @@
       }
     },
     {
-      "id": 664,
+      "id": 666,
+      "full_name": "LISTA / USD",
+      "description": "",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "LISTA",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "",
+        "market_hours": null,
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "LISTAUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "LISTAUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "LISTA_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "LISTA-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "LISTAUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "LISTA"
+              ],
+              "id": [
+                21533
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "LISTA / USD"
+        }
+      }
+    },
+    {
+      "id": 667,
+      "full_name": "LISTA / USDT",
+      "description": "",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "LISTA",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "",
+        "market_hours": null,
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "LISTAUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "LISTAUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "LISTA_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "LISTA-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "LISTAUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "LISTA / USD"
+        }
+      }
+    },
+    {
+      "id": 668,
       "full_name": "AMPL / USD",
       "description": "Ampleforth",
       "type": "price-feed",
@@ -48827,7 +49084,7 @@
       }
     },
     {
-      "id": 665,
+      "id": 669,
       "full_name": "AMPL / USDT",
       "description": "Ampleforth",
       "type": "price-feed",
@@ -48868,274 +49125,6 @@
         },
         "compatibility_info": {
           "chainlink": "AMPL / USD"
-        }
-      }
-    },
-    {
-      "id": 666,
-      "full_name": "ORDER / USD",
-      "description": "Orderly Network",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ORDER",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "ORDERUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ORDERUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ORDER_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ORDER-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ORDERUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "ORDER"
-              ],
-              "id": [
-                32809
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ORDER / USD"
-        }
-      }
-    },
-    {
-      "id": 667,
-      "full_name": "ORDER / USDT",
-      "description": "Orderly Network",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ORDER",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "ORDERUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ORDERUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ORDER_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ORDER-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ORDERUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ORDER / USD"
-        }
-      }
-    },
-    {
-      "id": 668,
-      "full_name": "ZEREBRO / USD",
-      "description": "Zerebro",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ZEREBRO",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "ZEREBROUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ZEREBROUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ZEREBRO_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "ZEREBROUSD"
-              ],
-              "wsname": [
-                "ZEREBRO/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ZEREBRO-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ZEREBROUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "ZEREBRO"
-              ],
-              "id": [
-                34083
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ZEREBRO/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 669,
-      "full_name": "ZEREBRO / USDT",
-      "description": "Zerebro",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ZEREBRO",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "ZEREBROUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "ZEREBROUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ZEREBRO_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "ZEREBRO-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ZEREBROUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ZEREBRO/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
@@ -49271,8 +49260,8 @@
     },
     {
       "id": 672,
-      "full_name": "LISTA / USD",
-      "description": "",
+      "full_name": "ZEREBRO / USD",
+      "description": "Zerebro",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -49289,60 +49278,68 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "LISTA",
+          "base": "ZEREBRO",
           "quote": "USD"
         },
-        "decimals": 8,
-        "category": "",
-        "market_hours": null,
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "LISTAUSDT"
-              ]
-            },
             "Bitget": {
               "symbol": [
-                "LISTAUSDT_SPBL"
+                "ZEREBROUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ZEREBROUSDT"
               ]
             },
             "GateIo": {
               "id": [
-                "LISTA_USDT"
+                "ZEREBRO_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "ZEREBROUSD"
+              ],
+              "wsname": [
+                "ZEREBRO/USD"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "LISTA-USDT"
+                "ZEREBRO-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "LISTAUSDT"
+                "ZEREBROUSDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "LISTA"
+                "ZEREBRO"
               ],
               "id": [
-                21533
+                34083
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "LISTA / USD"
+          "chainlink": "ZEREBRO/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
       "id": 673,
-      "full_name": "LISTA / USDT",
-      "description": "",
+      "full_name": "ZEREBRO / USDT",
+      "description": "Zerebro",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -49359,48 +49356,178 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "LISTA",
+          "base": "ZEREBRO",
           "quote": "USDT"
         },
-        "decimals": 8,
-        "category": "",
-        "market_hours": null,
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "LISTAUSDT"
-              ]
-            },
             "Bitget": {
               "symbol": [
-                "LISTAUSDT_SPBL"
+                "ZEREBROUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ZEREBROUSDT"
               ]
             },
             "GateIo": {
               "id": [
-                "LISTA_USDT"
+                "ZEREBRO_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "LISTA-USDT"
+                "ZEREBRO-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "LISTAUSDT"
+                "ZEREBROUSDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "LISTA / USD"
+          "chainlink": "ZEREBRO/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
       "id": 674,
+      "full_name": "ORDER / USD",
+      "description": "Orderly Network",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ORDER",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "ORDERUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ORDERUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ORDER_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ORDER-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ORDERUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "ORDER"
+              ],
+              "id": [
+                32809
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ORDER / USD"
+        }
+      }
+    },
+    {
+      "id": 675,
+      "full_name": "ORDER / USDT",
+      "description": "Orderly Network",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ORDER",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Bitget": {
+              "symbol": [
+                "ORDERUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "ORDERUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ORDER_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "ORDER-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "ORDERUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ORDER / USD"
+        }
+      }
+    },
+    {
+      "id": 676,
       "full_name": "RDNT / USD",
       "description": "Radiant Capital",
       "type": "price-feed",
@@ -49486,7 +49613,7 @@
       }
     },
     {
-      "id": 675,
+      "id": 677,
       "full_name": "RDNT / USDT",
       "description": "Radiant Capital",
       "type": "price-feed",
@@ -49556,7 +49683,7 @@
       }
     },
     {
-      "id": 676,
+      "id": 678,
       "full_name": "RDNT / USDC",
       "description": "Radiant Capital",
       "type": "price-feed",
@@ -49596,7 +49723,7 @@
       }
     },
     {
-      "id": 677,
+      "id": 679,
       "full_name": "MLN / USD",
       "description": "Enzyme",
       "type": "price-feed",
@@ -49658,6 +49785,7 @@
             },
             "OKX": {
               "instId": [
+                "MLN-USD",
                 "MLN-USDC",
                 "MLN-USDT"
               ]
@@ -49680,7 +49808,7 @@
       }
     },
     {
-      "id": 678,
+      "id": 680,
       "full_name": "MLN / ETH",
       "description": "Melon",
       "type": "price-feed",
@@ -49720,7 +49848,7 @@
       }
     },
     {
-      "id": 679,
+      "id": 681,
       "full_name": "MLN / USDT",
       "description": "Enzyme",
       "type": "price-feed",
@@ -49775,7 +49903,7 @@
       }
     },
     {
-      "id": 680,
+      "id": 682,
       "full_name": "MLN / USDC",
       "description": "Enzyme",
       "type": "price-feed",
@@ -49815,626 +49943,7 @@
       }
     },
     {
-      "id": 681,
-      "full_name": "ALCX / USD",
-      "description": "Alchemix",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ALCX",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ALCXUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "ALCX-USD",
-                "ALCX-USDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "ALCX_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ALCX_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "ALCXUSD"
-              ],
-              "wsname": [
-                "ALCX/USD"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ALCX-USDC",
-                "ALCX-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "ALCX"
-              ],
-              "id": [
-                8613
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ALCX / USD"
-        }
-      }
-    },
-    {
-      "id": 682,
-      "full_name": "ALCX / USDT",
-      "description": "Alchemix",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ALCX",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "ALCXUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "ALCX-USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "ALCX_USDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ALCX-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ALCX / USD"
-        }
-      }
-    },
-    {
       "id": 683,
-      "full_name": "ALCX / USDC",
-      "description": "Alchemix",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ALCX",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "ALCX-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ALCX / USD"
-        }
-      }
-    },
-    {
-      "id": 684,
-      "full_name": "PERP / USD",
-      "description": "Perpetual Protocol",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "PERP",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "PERPUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "PERPUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "PERPUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "PERP-USD",
-                "PERP-USDT"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "PERP_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "PERP_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "PERPUSD"
-              ],
-              "wsname": [
-                "PERP/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "PERP-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "PERPUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "PERP-USDC",
-                "PERP-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "PERP"
-              ],
-              "id": [
-                6950
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "PERP / USD"
-        }
-      }
-    },
-    {
-      "id": 685,
-      "full_name": "PERP / USDT",
-      "description": "Perpetual Protocol",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "PERP",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "PERPUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "PERPUSDT_SPBL"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "PERPUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "PERP-USDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "PERP_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "PERP-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "PERPUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "PERP-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "PERP / USD"
-        }
-      }
-    },
-    {
-      "id": 686,
-      "full_name": "PERP / USDC",
-      "description": "Perpetual Protocol",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "PERP",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "PERP-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "PERP / USD"
-        }
-      }
-    },
-    {
-      "id": 687,
-      "full_name": "GHST / ETH",
-      "description": "Aavegotchi",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "GHST",
-          "quote": "ETH"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "GHSTETH"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "GHST / ETH"
-        }
-      }
-    },
-    {
-      "id": 688,
-      "full_name": "GHST / USD",
-      "description": "Aavegotchi",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "GHST",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "GHSTUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "GHSTUSDT_SPBL"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "GHST-USD"
-              ]
-            },
-            "CryptoCom": {
-              "instrument_name": [
-                "GHST_USD"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "GHST_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "GHSTUSD"
-              ],
-              "wsname": [
-                "GHST/USD"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "GHSTUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "GHST-USDC",
-                "GHST-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "GHST"
-              ],
-              "id": [
-                7046
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "GHST / USD"
-        }
-      }
-    },
-    {
-      "id": 689,
-      "full_name": "GHST / USDT",
-      "description": "Aavegotchi",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "GHST",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "GHSTUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "GHSTUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "GHST_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "GHSTUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "GHST-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "GHST / USD"
-        }
-      }
-    },
-    {
-      "id": 690,
-      "full_name": "GHST / USDC",
-      "description": "Aavegotchi",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "GHST",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "GHST-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "GHST / USD"
-        }
-      }
-    },
-    {
-      "id": 691,
       "full_name": "QUICK / USD",
       "description": "Quickswap",
       "type": "price-feed",
@@ -50516,7 +50025,7 @@
       }
     },
     {
-      "id": 692,
+      "id": 684,
       "full_name": "QUICK / USDT",
       "description": "Quickswap",
       "type": "price-feed",
@@ -50576,7 +50085,628 @@
       }
     },
     {
+      "id": 685,
+      "full_name": "ALCX / USD",
+      "description": "Alchemix",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ALCX",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ALCXUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "ALCX-USD",
+                "ALCX-USDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "ALCX_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ALCX_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "ALCXUSD"
+              ],
+              "wsname": [
+                "ALCX/USD"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ALCX-USDC",
+                "ALCX-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "ALCX"
+              ],
+              "id": [
+                8613
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ALCX / USD"
+        }
+      }
+    },
+    {
+      "id": 686,
+      "full_name": "ALCX / USDT",
+      "description": "Alchemix",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ALCX",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "ALCXUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "ALCX-USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "ALCX_USDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ALCX-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ALCX / USD"
+        }
+      }
+    },
+    {
+      "id": 687,
+      "full_name": "ALCX / USDC",
+      "description": "Alchemix",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ALCX",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "ALCX-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ALCX / USD"
+        }
+      }
+    },
+    {
+      "id": 688,
+      "full_name": "PERP / USD",
+      "description": "Perpetual Protocol",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "PERP",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "PERPUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "PERPUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "PERPUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "PERP-USD",
+                "PERP-USDT"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "PERP_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "PERP_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "PERPUSD"
+              ],
+              "wsname": [
+                "PERP/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "PERP-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "PERPUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "PERP-USD",
+                "PERP-USDC",
+                "PERP-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "PERP"
+              ],
+              "id": [
+                6950
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "PERP / USD"
+        }
+      }
+    },
+    {
+      "id": 689,
+      "full_name": "PERP / USDT",
+      "description": "Perpetual Protocol",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "PERP",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "PERPUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "PERPUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "PERPUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "PERP-USDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "PERP_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "PERP-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "PERPUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "PERP-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "PERP / USD"
+        }
+      }
+    },
+    {
+      "id": 690,
+      "full_name": "PERP / USDC",
+      "description": "Perpetual Protocol",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "PERP",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "PERP-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "PERP / USD"
+        }
+      }
+    },
+    {
+      "id": 691,
+      "full_name": "GHST / ETH",
+      "description": "Aavegotchi",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "GHST",
+          "quote": "ETH"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "GHSTETH"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "GHST / ETH"
+        }
+      }
+    },
+    {
+      "id": 692,
+      "full_name": "GHST / USD",
+      "description": "Aavegotchi",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "GHST",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "GHSTUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "GHSTUSDT_SPBL"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "GHST-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "GHST_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "GHST_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "GHSTUSD"
+              ],
+              "wsname": [
+                "GHST/USD"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "GHSTUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "GHST-USD",
+                "GHST-USDC",
+                "GHST-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "GHST"
+              ],
+              "id": [
+                7046
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "GHST / USD"
+        }
+      }
+    },
+    {
       "id": 693,
+      "full_name": "GHST / USDT",
+      "description": "Aavegotchi",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "GHST",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "GHSTUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "GHSTUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "GHST_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "GHSTUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "GHST-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "GHST / USD"
+        }
+      }
+    },
+    {
+      "id": 694,
+      "full_name": "GHST / USDC",
+      "description": "Aavegotchi",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "GHST",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "GHST-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "GHST / USD"
+        }
+      }
+    },
+    {
+      "id": 695,
       "full_name": "BSW / USD",
       "description": "Biswap",
       "type": "price-feed",
@@ -50648,7 +50778,7 @@
       }
     },
     {
-      "id": 694,
+      "id": 696,
       "full_name": "BSW / USDT",
       "description": "Biswap",
       "type": "price-feed",
@@ -50708,9 +50838,9 @@
       }
     },
     {
-      "id": 695,
-      "full_name": "ULTI / USD",
-      "description": "Ultiverse",
+      "id": 697,
+      "full_name": "NULS / USD",
+      "description": "Nuls",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -50727,7 +50857,291 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "ULTI",
+          "base": "NULS",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "NULSUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "NULS_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "NULSUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "NULS-USD",
+                "NULS-USDC",
+                "NULS-USDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "NULS"
+              ],
+              "id": [
+                2092
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "NULS / USD"
+        }
+      }
+    },
+    {
+      "id": 698,
+      "full_name": "NULS / USDT",
+      "description": "Nuls",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "NULS",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "NULSUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "NULS_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "NULSUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "NULS-USDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "NULS / USD"
+        }
+      }
+    },
+    {
+      "id": 699,
+      "full_name": "NULS / USDC",
+      "description": "Nuls",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "NULS",
+          "quote": "USDC"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "OKX": {
+              "instId": [
+                "NULS-USDC"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "NULS / USD"
+        }
+      }
+    },
+    {
+      "id": 700,
+      "full_name": "WING / USD",
+      "description": "Wing Finance",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "WING",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "WINGUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "WINGUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "WING_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "WINGUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "WING",
+                "WING"
+              ],
+              "id": [
+                33798,
+                7048
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "WING / USD"
+        }
+      }
+    },
+    {
+      "id": 701,
+      "full_name": "WING / USDT",
+      "description": "Wing Finance",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "WING",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "WINGUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "WINGUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "WING_USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "WINGUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "WING / USD"
+        }
+      }
+    },
+    {
+      "id": 702,
+      "full_name": "TOKEN / USD",
+      "description": "TokenFi",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "TOKEN",
           "quote": "USD"
         },
         "decimals": 18,
@@ -50735,58 +51149,60 @@
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Bitget": {
+            "Bitfinex": {
               "symbol": [
-                "ULTIUSDT_SPBL"
+                "TOKEN:USD"
               ]
             },
             "Bybit": {
               "symbol": [
-                "ULTIUSDT"
+                "TOKENUSDT"
               ]
             },
             "GateIo": {
               "id": [
-                "ULTI_USDT"
+                "TOKEN_USDT"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "TOKENUSD"
+              ],
+              "wsname": [
+                "TOKEN/USD"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "ULTI-USDT"
+                "TOKEN-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "ULTIUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ULTI-USD",
-                "ULTI-USDT"
+                "TOKENUSDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "ULTI"
+                "TOKEN"
               ],
               "id": [
-                31504
+                28299
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "ULTI / USD"
+          "chainlink": "TOKEN/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 696,
-      "full_name": "ULTI / USDT",
-      "description": "Ultiverse",
+      "id": 703,
+      "full_name": "TOKEN / USDT",
+      "description": "TokenFi",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -50803,7 +51219,7 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "ULTI",
+          "base": "TOKEN",
           "quote": "USDT"
         },
         "decimals": 18,
@@ -50811,45 +51227,165 @@
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Bitget": {
-              "symbol": [
-                "ULTIUSDT_SPBL"
-              ]
-            },
             "Bybit": {
               "symbol": [
-                "ULTIUSDT"
+                "TOKENUSDT"
               ]
             },
             "GateIo": {
               "id": [
-                "ULTI_USDT"
+                "TOKEN_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "ULTI-USDT"
+                "TOKEN-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "ULTIUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "ULTI-USDT"
+                "TOKENUSDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "ULTI / USD"
+          "chainlink": "TOKEN/USD-RefPrice-DS-Premium-Global-003"
         }
       }
     },
     {
-      "id": 697,
+      "id": 704,
+      "full_name": "LINA / USD",
+      "description": "Linear",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "LINA",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "LINAUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "LINAUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "LINA_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "LINA-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "LINAUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "LINA"
+              ],
+              "id": [
+                7102
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "LINA / USD"
+        }
+      }
+    },
+    {
+      "id": 705,
+      "full_name": "LINA / USDT",
+      "description": "Linear",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "LINA",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "LINAUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "LINAUSDT_SPBL"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "LINA_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "LINA-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "LINAUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "LINA / USD"
+        }
+      }
+    },
+    {
+      "id": 706,
       "full_name": "TRUMP / USD",
       "description": "Official Trump",
       "type": "price-feed",
@@ -50930,6 +51466,7 @@
             },
             "KuCoin": {
               "symbol": [
+                "TRUMP-USDC",
                 "TRUMP-USDT"
               ]
             },
@@ -50978,8 +51515,6 @@
                 "TRUMP",
                 "TRUMP",
                 "TRUMP",
-                "TRUMP",
-                "TRUMP",
                 "TRUMP"
               ],
               "id": [
@@ -50990,7 +51525,6 @@
                 29382,
                 29561,
                 29602,
-                30055,
                 31400,
                 31553,
                 31680,
@@ -51005,7 +51539,6 @@
                 32929,
                 32932,
                 33561,
-                33772,
                 33831,
                 33888,
                 34490,
@@ -51020,7 +51553,7 @@
       }
     },
     {
-      "id": 698,
+      "id": 707,
       "full_name": "TRUMP / USDT",
       "description": "Official Trump",
       "type": "price-feed",
@@ -51113,7 +51646,7 @@
       }
     },
     {
-      "id": 699,
+      "id": 708,
       "full_name": "TRUMP / USDC",
       "description": "Official Trump",
       "type": "price-feed",
@@ -51163,6 +51696,11 @@
                 "TRUMP/USDC"
               ]
             },
+            "KuCoin": {
+              "symbol": [
+                "TRUMP-USDC"
+              ]
+            },
             "MEXC": {
               "symbol": [
                 "TRUMPUSDC"
@@ -51176,555 +51714,9 @@
       }
     },
     {
-      "id": 700,
-      "full_name": "NULS / USD",
-      "description": "Nuls",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "NULS",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "NULSUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "NULS_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "NULSUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "NULS-USDC",
-                "NULS-USDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "NULS"
-              ],
-              "id": [
-                2092
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "NULS / USD"
-        }
-      }
-    },
-    {
-      "id": 701,
-      "full_name": "NULS / USDT",
-      "description": "Nuls",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "NULS",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "NULSUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "NULS_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "NULSUSDT"
-              ]
-            },
-            "OKX": {
-              "instId": [
-                "NULS-USDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "NULS / USD"
-        }
-      }
-    },
-    {
-      "id": 702,
-      "full_name": "NULS / USDC",
-      "description": "Nuls",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "NULS",
-          "quote": "USDC"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "OKX": {
-              "instId": [
-                "NULS-USDC"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "NULS / USD"
-        }
-      }
-    },
-    {
-      "id": 703,
-      "full_name": "TOKEN / USD",
-      "description": "TokenFi",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "TOKEN",
-          "quote": "USD"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bitfinex": {
-              "symbol": [
-                "TOKEN:USD"
-              ]
-            },
-            "Bybit": {
-              "symbol": [
-                "TOKENUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "TOKEN_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "TOKENUSD"
-              ],
-              "wsname": [
-                "TOKEN/USD"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "TOKEN-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "TOKENUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "TOKEN"
-              ],
-              "id": [
-                28299
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "TOKEN/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 704,
-      "full_name": "TOKEN / USDT",
-      "description": "TokenFi",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "TOKEN",
-          "quote": "USDT"
-        },
-        "decimals": 18,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Bybit": {
-              "symbol": [
-                "TOKENUSDT"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "TOKEN_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "TOKEN-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "TOKENUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "TOKEN/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 705,
-      "full_name": "LINA / USD",
-      "description": "Linear",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "LINA",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "LINAUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "LINAUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "LINA_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "LINA-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "LINAUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "LINA"
-              ],
-              "id": [
-                7102
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "LINA / USD"
-        }
-      }
-    },
-    {
-      "id": 706,
-      "full_name": "LINA / USDT",
-      "description": "Linear",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "LINA",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "LINAUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "LINAUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "LINA_USDT"
-              ]
-            },
-            "KuCoin": {
-              "symbol": [
-                "LINA-USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "LINAUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "LINA / USD"
-        }
-      }
-    },
-    {
-      "id": 707,
-      "full_name": "WING / USD",
-      "description": "Wing Finance",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "WING",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "WINGUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "WINGUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "WING_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "WINGUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "WING",
-                "WING"
-              ],
-              "id": [
-                33798,
-                7048
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "WING / USD"
-        }
-      }
-    },
-    {
-      "id": 708,
-      "full_name": "WING / USDT",
-      "description": "Wing Finance",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "WING",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "Crypto",
-        "market_hours": "Crypto",
-        "arguments": {
-          "exchanges": {
-            "Binance": {
-              "symbol": [
-                "WINGUSDT"
-              ]
-            },
-            "Bitget": {
-              "symbol": [
-                "WINGUSDT_SPBL"
-              ]
-            },
-            "GateIo": {
-              "id": [
-                "WING_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "WINGUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "WING / USD"
-        }
-      }
-    },
-    {
       "id": 709,
-      "full_name": "REN / USD",
-      "description": "Ren",
+      "full_name": "ULTI / USD",
+      "description": "Ultiverse",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -51741,88 +51733,66 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "REN",
+          "base": "ULTI",
           "quote": "USD"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "RENUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "RENUSDT"
-              ]
-            },
             "Bitget": {
               "symbol": [
-                "RENUSDT_SPBL"
+                "ULTIUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "RENUSDT"
-              ]
-            },
-            "Coinbase": {
-              "id": [
-                "REN-USD"
+                "ULTIUSDT"
               ]
             },
             "GateIo": {
               "id": [
-                "REN_USDT"
-              ]
-            },
-            "Gemini": {
-              "symbol": [
-                "RENUSD"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "RENUSD"
-              ],
-              "wsname": [
-                "REN/USD"
+                "ULTI_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "REN-USDT"
+                "ULTI-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "RENUSDT"
+                "ULTIUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ULTI-USD",
+                "ULTI-USDT"
               ]
             }
           },
           "aggregators": {
             "CoinMarketCap": {
               "symbol": [
-                "REN"
+                "ULTI"
               ],
               "id": [
-                2539
+                31504
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "REN / USD"
+          "chainlink": "ULTI / USD"
         }
       }
     },
     {
       "id": 710,
-      "full_name": "REN / USDT",
-      "description": "Ren",
+      "full_name": "ULTI / USDT",
+      "description": "Ultiverse",
       "type": "price-feed",
       "oracle_id": "crypto-price-feeds",
       "value_type": "numerical",
@@ -51839,53 +51809,48 @@
       },
       "additional_feed_info": {
         "pair": {
-          "base": "REN",
+          "base": "ULTI",
           "quote": "USDT"
         },
-        "decimals": 8,
+        "decimals": 18,
         "category": "Crypto",
         "market_hours": "Crypto",
         "arguments": {
           "exchanges": {
-            "Binance": {
-              "symbol": [
-                "RENUSDT"
-              ]
-            },
-            "BinanceUS": {
-              "symbol": [
-                "RENUSDT"
-              ]
-            },
             "Bitget": {
               "symbol": [
-                "RENUSDT_SPBL"
+                "ULTIUSDT_SPBL"
               ]
             },
             "Bybit": {
               "symbol": [
-                "RENUSDT"
+                "ULTIUSDT"
               ]
             },
             "GateIo": {
               "id": [
-                "REN_USDT"
+                "ULTI_USDT"
               ]
             },
             "KuCoin": {
               "symbol": [
-                "REN-USDT"
+                "ULTI-USDT"
               ]
             },
             "MEXC": {
               "symbol": [
-                "RENUSDT"
+                "ULTIUSDT"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "ULTI-USDT"
               ]
             }
           }
         },
         "compatibility_info": {
-          "chainlink": "REN / USD"
+          "chainlink": "ULTI / USD"
         }
       }
     },
@@ -52011,6 +51976,174 @@
     },
     {
       "id": 713,
+      "full_name": "REN / USD",
+      "description": "Ren",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "REN",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "RENUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "RENUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "RENUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "RENUSDT"
+              ]
+            },
+            "Coinbase": {
+              "id": [
+                "REN-USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "REN_USDT"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "RENUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "RENUSD"
+              ],
+              "wsname": [
+                "REN/USD"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "REN-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "RENUSDT"
+              ]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": [
+                "REN"
+              ],
+              "id": [
+                2539
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "REN / USD"
+        }
+      }
+    },
+    {
+      "id": 714,
+      "full_name": "REN / USDT",
+      "description": "Ren",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "REN",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": [
+                "RENUSDT"
+              ]
+            },
+            "BinanceUS": {
+              "symbol": [
+                "RENUSDT"
+              ]
+            },
+            "Bitget": {
+              "symbol": [
+                "RENUSDT_SPBL"
+              ]
+            },
+            "Bybit": {
+              "symbol": [
+                "RENUSDT"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "REN_USDT"
+              ]
+            },
+            "KuCoin": {
+              "symbol": [
+                "REN-USDT"
+              ]
+            },
+            "MEXC": {
+              "symbol": [
+                "RENUSDT"
+              ]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "REN / USD"
+        }
+      }
+    },
+    {
+      "id": 715,
       "full_name": "MAVIA / USD",
       "description": "Heroes of Mavia",
       "type": "price-feed",
@@ -52086,7 +52219,7 @@
       }
     },
     {
-      "id": 714,
+      "id": 716,
       "full_name": "MAVIA / USDT",
       "description": "Heroes of Mavia",
       "type": "price-feed",
@@ -52151,7 +52284,7 @@
       }
     },
     {
-      "id": 715,
+      "id": 717,
       "full_name": "KLIMA / USD",
       "description": "",
       "type": "price-feed",
@@ -52206,7 +52339,7 @@
       }
     },
     {
-      "id": 716,
+      "id": 718,
       "full_name": "KLIMA / USDT",
       "description": "",
       "type": "price-feed",
@@ -52251,7 +52384,7 @@
       }
     },
     {
-      "id": 717,
+      "id": 719,
       "full_name": "SKY / USD",
       "description": "Sky",
       "type": "price-feed",
@@ -52316,7 +52449,7 @@
       }
     },
     {
-      "id": 718,
+      "id": 720,
       "full_name": "SKY / USDT",
       "description": "Sky",
       "type": "price-feed",
@@ -52361,7 +52494,7 @@
       }
     },
     {
-      "id": 719,
+      "id": 721,
       "full_name": "WELL / USD",
       "description": "Moonwell",
       "type": "price-feed",
@@ -52444,7 +52577,7 @@
       }
     },
     {
-      "id": 720,
+      "id": 722,
       "full_name": "WELL / USDT",
       "description": "Moonwell",
       "type": "price-feed",
@@ -52504,7 +52637,7 @@
       }
     },
     {
-      "id": 721,
+      "id": 723,
       "full_name": "FOXY / USD",
       "description": "Foxy",
       "type": "price-feed",
@@ -52571,7 +52704,7 @@
       }
     },
     {
-      "id": 722,
+      "id": 724,
       "full_name": "FOXY / USDT",
       "description": "Foxy",
       "type": "price-feed",
@@ -52626,7 +52759,7 @@
       }
     },
     {
-      "id": 723,
+      "id": 725,
       "full_name": "MELANIA / USD",
       "description": "Melania Meme",
       "type": "price-feed",
@@ -52711,7 +52844,7 @@
       }
     },
     {
-      "id": 724,
+      "id": 726,
       "full_name": "MELANIA / USDT",
       "description": "Melania Meme",
       "type": "price-feed",
@@ -52779,7 +52912,7 @@
       }
     },
     {
-      "id": 725,
+      "id": 727,
       "full_name": "MELANIA / USDC",
       "description": "Melania Meme",
       "type": "price-feed",
@@ -52823,116 +52956,6 @@
         },
         "compatibility_info": {
           "chainlink": "MELANIA/USD-RefPrice-DS-Premium-Global-003"
-        }
-      }
-    },
-    {
-      "id": 726,
-      "full_name": "ANON / USD",
-      "description": "",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ANON",
-          "quote": "USD"
-        },
-        "decimals": 8,
-        "category": "",
-        "market_hours": "",
-        "arguments": {
-          "exchanges": {
-            "GateIo": {
-              "id": [
-                "ANON_USDT"
-              ]
-            },
-            "Kraken": {
-              "pair": [
-                "ANONUSD"
-              ],
-              "wsname": [
-                "ANON/USD"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ANONUSDT"
-              ]
-            }
-          },
-          "aggregators": {
-            "CoinMarketCap": {
-              "symbol": [
-                "ANON",
-                "ANON"
-              ],
-              "id": [
-                30846,
-                31734
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ANON / USD"
-        }
-      }
-    },
-    {
-      "id": 727,
-      "full_name": "ANON / USDT",
-      "description": "",
-      "type": "price-feed",
-      "oracle_id": "crypto-price-feeds",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 100,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "ANON",
-          "quote": "USDT"
-        },
-        "decimals": 8,
-        "category": "",
-        "market_hours": "",
-        "arguments": {
-          "exchanges": {
-            "GateIo": {
-              "id": [
-                "ANON_USDT"
-              ]
-            },
-            "MEXC": {
-              "symbol": [
-                "ANONUSDT"
-              ]
-            }
-          }
-        },
-        "compatibility_info": {
-          "chainlink": "ANON / USD"
         }
       }
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1965,6 +1965,7 @@ __metadata:
     "@blocksense/base-utils": "workspace:*"
     "@blocksense/config-types": "workspace:*"
     "@blocksense/contracts": "workspace:*"
+    "@octokit/rest": "npm:^21.1.1"
     "@types/keccak": "npm:^3"
     "@types/node": "npm:^22.10.2"
     effect: "npm:^3.12.1"
@@ -4912,6 +4913,130 @@ __metadata:
   dependencies:
     semver: "npm:^7.3.5"
   checksum: 10c0/c37a5b4842bfdece3d14dfdb054f73fe15ed2d3da61b34ff76629fb5b1731647c49166fd2a8bf8b56fcfa51200382385ea8909a3cbecdad612310c114d3f6c99
+  languageName: node
+  linkType: hard
+
+"@octokit/auth-token@npm:^5.0.0":
+  version: 5.1.2
+  resolution: "@octokit/auth-token@npm:5.1.2"
+  checksum: 10c0/bd4952571d9c559ede1f6ef8f7756900256d19df0180db04da88886a05484c7e6a4397611422e4804465a82addc8c2daa21d0bb4f450403552ee81041a4046d1
+  languageName: node
+  linkType: hard
+
+"@octokit/core@npm:^6.1.4":
+  version: 6.1.4
+  resolution: "@octokit/core@npm:6.1.4"
+  dependencies:
+    "@octokit/auth-token": "npm:^5.0.0"
+    "@octokit/graphql": "npm:^8.1.2"
+    "@octokit/request": "npm:^9.2.1"
+    "@octokit/request-error": "npm:^6.1.7"
+    "@octokit/types": "npm:^13.6.2"
+    before-after-hook: "npm:^3.0.2"
+    universal-user-agent: "npm:^7.0.0"
+  checksum: 10c0/bcb05e83c54f686ae55bd3793e63a1832f83cbe804586b52c61b0e18942609dcc209af501720de6f2c87dc575047645b074f4cd5822d461e892058ea9654aebc
+  languageName: node
+  linkType: hard
+
+"@octokit/endpoint@npm:^10.1.3":
+  version: 10.1.3
+  resolution: "@octokit/endpoint@npm:10.1.3"
+  dependencies:
+    "@octokit/types": "npm:^13.6.2"
+    universal-user-agent: "npm:^7.0.2"
+  checksum: 10c0/096956534efee1f683b4749673c2d1673c6fbe5362b9cce553f9f4b956feaf59bde816594de72f4352f749b862d0b15bc0e2fa7fb0e198deb1fe637b5f4a8bc7
+  languageName: node
+  linkType: hard
+
+"@octokit/graphql@npm:^8.1.2":
+  version: 8.2.1
+  resolution: "@octokit/graphql@npm:8.2.1"
+  dependencies:
+    "@octokit/request": "npm:^9.2.2"
+    "@octokit/types": "npm:^13.8.0"
+    universal-user-agent: "npm:^7.0.0"
+  checksum: 10c0/79fe7b50113bef90a32e3b6ee48923cad2afc049aba5c22e44167cf5773e2688a4e953f3ee1e24bee9706ccf7588ae14451933b282f63f1f7d5c95d319df23dd
+  languageName: node
+  linkType: hard
+
+"@octokit/openapi-types@npm:^23.0.1":
+  version: 23.0.1
+  resolution: "@octokit/openapi-types@npm:23.0.1"
+  checksum: 10c0/ab734ceb26343d9f051a59503b8cb5bdc7fec9ca044b60511b227179bec73141dd9144a6b2d68bcd737741881b136c1b7d5392da89ae2e35e39acc489e5eb4c1
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-paginate-rest@npm:^11.4.2":
+  version: 11.4.3
+  resolution: "@octokit/plugin-paginate-rest@npm:11.4.3"
+  dependencies:
+    "@octokit/types": "npm:^13.7.0"
+  peerDependencies:
+    "@octokit/core": ">=6"
+  checksum: 10c0/132fa9c4eacec84d8025866775f0325a752a4c7496a61ebafbd72c80626ead44d1efdae738f1dffd70e2bf3a34e007693ea2356fca5c2a1be445ac466231c395
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-request-log@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "@octokit/plugin-request-log@npm:5.3.1"
+  peerDependencies:
+    "@octokit/core": ">=6"
+  checksum: 10c0/2f959934b8285cf39a1d1d0b92ec881b3ae171ae74738225f87b89381afd72a32bc7ea9c04d2dcee74f74ad24c22cce0c5f3e5b4333d531ea67b985e4ee90cb0
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-rest-endpoint-methods@npm:^13.3.0":
+  version: 13.3.1
+  resolution: "@octokit/plugin-rest-endpoint-methods@npm:13.3.1"
+  dependencies:
+    "@octokit/types": "npm:^13.8.0"
+  peerDependencies:
+    "@octokit/core": ">=6"
+  checksum: 10c0/bb9c16c4a05299ed32d871c170c658db5bb81104a276cc2dda80b8ed3038a467124ef5c7d6f3a170a215197f0507c15915f0dc91f0651233d992cee8a9cf3eb0
+  languageName: node
+  linkType: hard
+
+"@octokit/request-error@npm:^6.1.7":
+  version: 6.1.7
+  resolution: "@octokit/request-error@npm:6.1.7"
+  dependencies:
+    "@octokit/types": "npm:^13.6.2"
+  checksum: 10c0/24bd6f98b1d7b2d4062de34777b4195d3cc4dc40c3187a0321dd588291ec5e13b5760765aacdef3a73796a529d3dec0bfb820780be6ef526a3e774d13566b5b0
+  languageName: node
+  linkType: hard
+
+"@octokit/request@npm:^9.2.1, @octokit/request@npm:^9.2.2":
+  version: 9.2.2
+  resolution: "@octokit/request@npm:9.2.2"
+  dependencies:
+    "@octokit/endpoint": "npm:^10.1.3"
+    "@octokit/request-error": "npm:^6.1.7"
+    "@octokit/types": "npm:^13.6.2"
+    fast-content-type-parse: "npm:^2.0.0"
+    universal-user-agent: "npm:^7.0.2"
+  checksum: 10c0/14cb523c17ed619c63e52025af9fdc67357b63d113905ec0ccb47badd20926e6f37a17a0620d3a906823b496e3b7efb29ed1e2af658cde5daf3ed3f88b421973
+  languageName: node
+  linkType: hard
+
+"@octokit/rest@npm:^21.1.1":
+  version: 21.1.1
+  resolution: "@octokit/rest@npm:21.1.1"
+  dependencies:
+    "@octokit/core": "npm:^6.1.4"
+    "@octokit/plugin-paginate-rest": "npm:^11.4.2"
+    "@octokit/plugin-request-log": "npm:^5.3.1"
+    "@octokit/plugin-rest-endpoint-methods": "npm:^13.3.0"
+  checksum: 10c0/59e4fe55942e6f94ff6924934418fbfdee516f6df00889f9417add037c2163b45079a600b6c43449bc824641c9f1b9ac6fe9d3b52a5a1ed3e5e12de697171b78
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^13.6.2, @octokit/types@npm:^13.7.0, @octokit/types@npm:^13.8.0":
+  version: 13.8.0
+  resolution: "@octokit/types@npm:13.8.0"
+  dependencies:
+    "@octokit/openapi-types": "npm:^23.0.1"
+  checksum: 10c0/e08c2fcf10e374f18e4c9fa12a6ada33a40f112d1209012a39f0ce40ae7aa9dcf0598b6007b467f63cc4a97e7b1388d6eed34ddef61494655e08b5a95afaad97
   languageName: node
   linkType: hard
 
@@ -10378,6 +10503,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"before-after-hook@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "before-after-hook@npm:3.0.2"
+  checksum: 10c0/dea640f9e88a1085372c9bcc974b7bf379267490693da92ec102a7d8b515dd1e95f00ef575a146b83ca638104c57406c3427d37bdf082f602dde4b56d05bba14
+  languageName: node
+  linkType: hard
+
 "better-opn@npm:^3.0.2":
   version: 3.0.2
   resolution: "better-opn@npm:3.0.2"
@@ -14503,6 +14635,13 @@ __metadata:
   dependencies:
     pure-rand: "npm:^6.1.0"
   checksum: 10c0/16fcff3c80321ee765e23c3aebd0f6427f175c9c6c1753104ec658970162365dc2d56bda046d815e8f2e90634c07ba7d6f0bcfd327fbd576d98c56a18a9765ed
+  languageName: node
+  linkType: hard
+
+"fast-content-type-parse@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "fast-content-type-parse@npm:2.0.1"
+  checksum: 10c0/e5ff87d75a35ae4cf377df1dca46ec49e7abbdc8513689676ecdef548b94900b50e66e516e64470035d79b9f7010ef15d98c24d8ae803a881363cc59e0715e19
   languageName: node
   linkType: hard
 
@@ -25204,6 +25343,13 @@ __metadata:
     unist-util-is: "npm:^6.0.0"
     unist-util-visit-parents: "npm:^6.0.0"
   checksum: 10c0/51434a1d80252c1540cce6271a90fd1a106dbe624997c09ed8879279667fb0b2d3a685e02e92bf66598dcbe6cdffa7a5f5fb363af8fdf90dda6c855449ae39a5
+  languageName: node
+  linkType: hard
+
+"universal-user-agent@npm:^7.0.0, universal-user-agent@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "universal-user-agent@npm:7.0.2"
+  checksum: 10c0/e60517ee929813e6b3ac0ceb3c66deccafadc71341edca160279ff046319c684fd7090a60d63aa61cd34a06c2d2acebeb8c2f8d364244ae7bf8ab788e20cd8c8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changes

- Integrated artifacts from `blocksense-network/dfcg-artifacts` for better consistency.  
- Introduced scripts for fetching provider data and CoinMarketCap market cap data.
- Renamed `getOrCreateArtifact` → `createArtifact`, removing the logic to load existing artifacts.  
- Now, artifacts are prepared as an array instead of being written to files directly, improving log readability.  
- Reduced duplication of saved artifacts and improved artifact handling.  

- Filter out feeds with not exchanges arguments 

  Removed feeds:
    - "WSTETH / USD"
    - "SUSDE / USD"
    - "cbBTC / USD"
    - "USD0 / USD"
    - "USD0++ / USD"
    - "ezETH / USD"
    - "RLUSD / USD"
    - "USDX / USD"
    - "USDL / USD"
    - "LUSD / USD"
    - "DPI / USD"
    - "AUSD / USD"
    - "USR / USD"
- Update configs

### How to test:
Run:
```bash
cd apps/data-feeds-config-generator 
yarn generate-data-feeds-config
```

> You need to set `DFCG_ARTIFACTS_ACCESS_TOKEN` env - A token with `Contents: Read` scope for `blocksense-network/dfcg-artifacts`

