### PR TITLE
feat(nix/process-compose): Complete reporter-v2 + crypto-price-feed oracle script setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,7 @@ apps/data-feeds-config-generator/artifacts
 # Storybook
 *storybook.log
 libs/ts/ui/storybook-static
+
+# wasm artifacts
+.spin/
+*.wasm

--- a/Justfile
+++ b/Justfile
@@ -14,3 +14,12 @@ start-oracle oracle-name:
   set -euo pipefail
   cd "{{root-dir}}/apps/oracles/{{oracle-name}}"
   RUST_LOG=trigger=trace "${SPIN:-spin}" build --up
+
+clean:
+  git clean -fdx \
+    -e .env \
+    -e .direnv \
+    -e .yarn \
+    -e .vscode \
+    -e .pre-commit-config.yaml \
+    -- {{root-dir}}

--- a/apps/cli/src/spin_manifest.rs
+++ b/apps/cli/src/spin_manifest.rs
@@ -44,6 +44,8 @@ pub struct Trigger {
 pub struct Component {
     source: ComponentSource,
     allowed_outbound_hosts: Vec<String>,
+    #[serde(default)]
+    key_value_stores: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -128,6 +130,7 @@ impl From<BlocksenseConfig> for AppManifest {
                 Component {
                     source: ComponentSource::Local(oracle.oracle_script_wasm.clone()),
                     allowed_outbound_hosts: oracle.allowed_outbound_hosts.clone(),
+                    key_value_stores: Some(vec!["default".into()]),
                 },
             );
         }
@@ -276,14 +279,17 @@ data = ""
 [component.revolut]
 source = "revolut_oracle.wasm"
 allowed_outbound_hosts = ["https://pro-api.coinmarketcap.com"]
+key_value_stores = ["default"]
 
 [component.yahoo]
 source = "yahoo_oracle.wasm"
 allowed_outbound_hosts = ["https://yfapi.net:443"]
+key_value_stores = ["default"]
 
 [component.cmc]
 source = "cmc_oracle.wasm"
 allowed_outbound_hosts = ["https://pro-api.coinmarketcap.com"]
+key_value_stores = ["default"]
 "#;
         let config: BlocksenseConfig = serde_json::from_str(json).expect("Failed to parse json.");
         let toml_config: AppManifest = toml::from_str(toml).expect("Failed to parse toml.");

--- a/nix/modules/sequencer/backends/process-compose.nix
+++ b/nix/modules/sequencer/backends/process-compose.nix
@@ -124,7 +124,7 @@ let
     name:
     { log-level, ... }:
     {
-      name = "reporter-v2-${name}";
+      name = "blocksense-reporter-v2-${name}";
       value.process-compose = {
         command = "${blocksense.program} node build --from ${reportersV2ConfigJSON.${name}} --up";
         environment = [ "RUST_LOG=${log-level}" ];

--- a/nix/modules/sequencer/backends/process-compose.nix
+++ b/nix/modules/sequencer/backends/process-compose.nix
@@ -100,26 +100,6 @@ let
     };
   }) cfg.reporters;
 
-  oracleScriptBuilder = lib.mapAttrs' (
-    name:
-    {
-      path,
-      source,
-      build-command,
-      ...
-    }:
-    {
-      name = "oracle-script-builder-${name}";
-      value.process-compose = {
-        command = ''
-          ${build-command} &&
-          cp -v ${source} ${cfg.oracle-scripts.base-dir}
-        '';
-        working_dir = path;
-      };
-    }
-  ) cfg.oracle-scripts.oracles;
-
   reporterV2Instances = lib.mapAttrs' (
     name:
     { log-level, ... }:
@@ -187,7 +167,6 @@ in
   config = lib.mkIf cfg.enable {
     processes =
       anvilImpersonateAndFundInstances
-      // oracleScriptBuilder
       // reporterV2Instances
       // sequencerInstance
       // anvilInstances

--- a/nix/modules/sequencer/backends/process-compose.nix
+++ b/nix/modules/sequencer/backends/process-compose.nix
@@ -45,7 +45,7 @@ let
 
   reportersV2ConfigJSON = builtins.mapAttrs (
     name: _value: pkgs.writers.writeJSON "blocksense-config.json" cfg._blocksense-config-txt.${name}
-  ) cfg.reporters;
+  ) cfg.reporters-v2;
 
   anvilInstances = lib.mapAttrs' (
     name:

--- a/nix/modules/sequencer/backends/process-compose.nix
+++ b/nix/modules/sequencer/backends/process-compose.nix
@@ -64,6 +64,8 @@ let
               -H 'content-type: application/json' \
               --data-raw '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":0}'
           '';
+          initial_delay_seconds = 0;
+          period_seconds = 1;
           timeout_seconds = 30;
         };
         log_configuration = logsConfig;
@@ -142,6 +144,8 @@ let
           curl -fsSL http://127.0.0.1:${toString cfg.sequencer.admin-port}/health \
             -H 'content-type: application/json'
         '';
+        initial_delay_seconds = 0;
+        period_seconds = 1;
         timeout_seconds = 30;
       };
       environment = [

--- a/nix/modules/sequencer/backends/process-compose.nix
+++ b/nix/modules/sequencer/backends/process-compose.nix
@@ -128,14 +128,9 @@ let
       value.process-compose = {
         command = "${blocksense.program} node build --from ${reportersV2ConfigJSON.${name}} --up";
         environment = [ "RUST_LOG=${log-level}" ];
-        depends_on =
-          let
-            oracle-scripts = lib.mapAttrs' (
-              key: _value:
-              lib.nameValuePair "oracle-script-builder-${key}" { condition = "process_completed_successfully"; }
-            ) cfg.oracle-scripts.oracles;
-          in
-          oracle-scripts // { blocksense-sequencer.condition = "process_healthy"; };
+        depends_on = {
+          blocksense-sequencer.condition = "process_healthy";
+        };
         working_dir = cfg.oracle-scripts.base-dir;
         log_configuration = logsConfig;
         log_location = cfg.logsDir + "/reporter-v2-${name}.log";

--- a/nix/modules/sequencer/oracle-script-opts.nix
+++ b/nix/modules/sequencer/oracle-script-opts.nix
@@ -1,21 +1,41 @@
-{ lib, ... }:
+{
+  lib,
+  self',
+  name,
+  ...
+}:
 with lib;
 {
   options = {
-    path = mkOption {
-      type = types.path;
-      description = mdDoc "Path to the oracle script.";
+    id = mkOption {
+      type =
+        let
+          availableScripts = builtins.attrNames self'.legacyPackages.oracle-scripts;
+        in
+        types.enum availableScripts;
+      default = name;
     };
 
-    build-command = mkOption {
+    name = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+    };
+
+    description = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+    };
+
+    oracle_script_wasm = mkOption {
       type = types.str;
-      description = mdDoc "Command for building the oracle scripts to wasm.";
-      default = "cargo build --target wasm32-wasip1 --release";
     };
 
-    source = mkOption {
-      type = types.path;
-      description = mdDoc "Path to the wasm target.";
+    allowed_outbound_hosts = mkOption {
+      type = types.listOf types.str;
+    };
+
+    capabilities = mkOption {
+      type = types.listOf types.str;
     };
   };
 }

--- a/nix/modules/sequencer/reporter-opts-v2.nix
+++ b/nix/modules/sequencer/reporter-opts-v2.nix
@@ -30,15 +30,12 @@ with lib;
       };
     };
 
-    api-keys = {
-      CMC_API_KEY = mkOption {
-        type = types.path;
-        description = "The path to the CMC api key.";
-      };
-
-      YAHOO_API_KEY = mkOption {
-        type = types.path;
-        description = "The path to the YF api key.";
+    api-keys = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example = {
+        CMC_API_KEY = "/secrets/CMC_API_KEY";
+        YAHOO_API_KEY = "/secrets/YH_FINANCE_API_KEY";
       };
     };
 

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -60,11 +60,11 @@
       legacyPackages = {
         oracle-scripts = {
           crypto-price-feeds = mkOracleScript /apps/oracles/crypto-price-feeds false;
-          exsat-wasm = mkOracleScript /libs/sdk/examples/exsat_network true;
+          exsat = mkOracleScript /libs/sdk/examples/exsat_network true;
 
           # Legacy oracle scripts
-          cmc-wasm = mkOracleScript /libs/sdk/examples/cmc true;
-          yahoo-wasm = mkOracleScript /libs/sdk/examples/yahoo true;
+          cmc = mkOracleScript /libs/sdk/examples/cmc true;
+          yahoo = mkOracleScript /libs/sdk/examples/yahoo true;
         };
 
         spinPlugins = {

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -25,9 +25,14 @@
       };
 
       mkOracleScript =
-        oracle-name:
+        oracle-path: standalone:
         pkgs.callPackage ./oracle-script {
-          inherit craneLib version oracle-name;
+          inherit
+            craneLib
+            version
+            oracle-path
+            standalone
+            ;
           inherit (self.lib) filesets;
         };
 
@@ -54,9 +59,12 @@
       };
       legacyPackages = {
         oracle-scripts = {
-          cmc-wasm = mkOracleScript "cmc";
-          yahoo-wasm = mkOracleScript "yahoo";
-          exsat-wasm = mkOracleScript "exsat_network";
+          crypto-price-feeds = mkOracleScript /apps/oracles/crypto-price-feeds false;
+          exsat-wasm = mkOracleScript /libs/sdk/examples/exsat_network true;
+
+          # Legacy oracle scripts
+          cmc-wasm = mkOracleScript /libs/sdk/examples/cmc true;
+          yahoo-wasm = mkOracleScript /libs/sdk/examples/yahoo true;
         };
 
         spinPlugins = {

--- a/nix/pkgs/oracle-script/default.nix
+++ b/nix/pkgs/oracle-script/default.nix
@@ -1,28 +1,35 @@
 {
+  lib,
   craneLib,
   pkg-config,
   filesets,
   version ? "dev",
-  oracle-name,
+  oracle-path,
+
+  # whether the given oracle script is part of the main workspace
+  # or it's standalone
+  standalone,
 }:
 let
+  oracle-name = builtins.baseNameOf oracle-path;
+
   sharedAttrs = rec {
     pname = "oracle-script-${oracle-name}";
     inherit (filesets.rustSrc) src;
 
-    postUnpack = ''
-      cd $sourceRoot/libs/sdk/examples/${oracle-name}
+    postUnpack = lib.optionalString standalone ''
+      cd $sourceRoot/${builtins.toString oracle-path}
       sourceRoot="."
     '';
 
-    cargoLock = ../../../libs/sdk/examples/${oracle-name}/Cargo.lock;
-    cargoToml = ../../../libs/sdk/examples/${oracle-name}/Cargo.toml;
+    cargoToml = ../../.. + oracle-path + /Cargo.toml;
 
     nativeBuildInputs = [
       pkg-config
     ];
 
-    cargoExtraArgs = "--target wasm32-wasip1";
+    cargoExtraArgs =
+      "--target wasm32-wasip1" + lib.optionalString (!standalone) " --package=${oracle-name}";
     doCheck = false;
     strictDeps = true;
   };

--- a/nix/test-environments/example-setup-01.nix
+++ b/nix/test-environments/example-setup-01.nix
@@ -130,5 +130,40 @@ in
         api-keys = { };
       };
     };
+
+    oracles = {
+      exsat = {
+        oracle_script_wasm = "exsat_holdings_oracle.wasm";
+        capabilities = [ ];
+        allowed_outbound_hosts = [
+          "https://raw.githubusercontent.com"
+          "https://rpc-us.exsat.network"
+          "https://blockchain.info"
+        ];
+      };
+
+      crypto-price-feeds = {
+        oracle_script_wasm = "crypto_price_feeds.wasm";
+
+        capabilities = [ ];
+        allowed_outbound_hosts = [
+          "https://api.kraken.com"
+          "https://api.bybit.com"
+          "https://api.coinbase.com"
+          "https://api.exchange.coinbase.com"
+          "https://api1.binance.com"
+          "https://api.kucoin.com"
+          "https://api.mexc.com"
+          "https://api.crypto.com"
+          "https://api.binance.us"
+          "https://api.gemini.com"
+          "https://api-pub.bitfinex.com"
+          "https://api.upbit.com"
+          "https://api.bitget.com"
+          "https://api.gateio.ws"
+          "https://www.okx.com"
+        ];
+      };
+    };
   };
 }

--- a/nix/test-environments/example-setup-01.nix
+++ b/nix/test-environments/example-setup-01.nix
@@ -144,10 +144,7 @@ in
           interval_time_in_seconds = 6;
           secret_key = "${testKeysDir}/reporter_secret_key";
         };
-        api-keys = {
-          CMC_API_KEY = "${testKeysDir}/CMC_API_KEY";
-          YAHOO_API_KEY = "${testKeysDir}/YH_FINANCE_API_KEY";
-        };
+        api-keys = { };
       };
     };
   };

--- a/nix/test-environments/example-setup-01.nix
+++ b/nix/test-environments/example-setup-01.nix
@@ -120,23 +120,6 @@ in
       log-level = "info";
     };
 
-    reporters = {
-      a = {
-        full-batch = true;
-        batch-size = 5;
-        resources = {
-          SECRET_KEY_PATH = "${testKeysDir}/reporter_secret_key";
-          CMC_API_KEY_PATH = "${testKeysDir}/CMC_API_KEY";
-          YH_FINANCE_API_KEY_PATH = "${testKeysDir}/YH_FINANCE_API_KEY";
-        };
-        reporter = {
-          id = 0;
-          pub_key = "ea30af86b930d539c55677b05b4a5dad9fce1f758ba09d152d19a7d6940f8d8a8a8fb9f90d38a19e988d721cddaee4567d2e";
-          address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
-        };
-      };
-    };
-
     reporters-v2 = {
       a = {
         reporter-info = {


### PR DESCRIPTION
## Description

[![asciicast](https://asciinema.org/a/v1vXiFWYMEHSoDjWUJBLxrmTY.svg)](https://asciinema.org/a/v1vXiFWYMEHSoDjWUJBLxrmTY)

* Refactor the `nix/pkgs/oracle-script` derivation to make it possible to build both standalone oracle scripts and scripts part of the workspace
* Expose `crypto-price-feeds` oracle script
* Improve process-compose readiness start up time
* Fix small bugs and adjust git ignore
* Remove reporters-v1 from the example setup
* Change reporter-v2 working to `

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (refactoring already existing functionality)

## Changes

- **feat(nix/pkgs): Expose `crypto-price-feeds` and allow building oracles parts of the workspace**
- **refactor(nix/pkgs): Remove `-wasm` pkg suffix**
- **config(git): Ignore `.wasm` and `.spin` dir**
- **fix(nix/modules/process-compose): Fix iteration over the old reporters**
- **fix(nix/modules/process-compose): Remove reporter-v2 -> oracle script depends-on**
- **refactor(nix/modules/reporter-opts-v2): Change `api-keys` option type to a free-form key-value attrset**
- **config(nix/test-environments/example-setup-01): Remove repoters-v1**
- **refactor(nix/modules/process-compose): Replace build command with copy of nix artifacts**
- **improve(nix/modules/process-compose): Use tigher healthcheck period for faster startup**
- **feat(just): Add `clean` command**
- **feat(cli/spin_manifest): Enable Spin key-value store by default**
- **feat(nix/{modules,example-setup-01}): List enabled oracle scripts in the Nix config**
- **config(nix/modules/process-compose): Set working dir (which includes spin.toml) to `$GIT_ROOT/libs/sdk/oracles`**

## How to test

```
direnv reload
sed -i 's|CoinMarketCap|crypto-price-feeds|g' config/feeds_config.json
process-compose
```

## Checklist

- [x] The new changes/fixes are tested
- [ ] Documentation is updated
- [x] I have performed a self-review of my own code
- [ ] All newly added code is well commented
