### PR TITLE
gecko terminal post merge fixes

### DIFF
--- a/config/feeds_config.json
+++ b/config/feeds_config.json
@@ -7148,7 +7148,7 @@
       "stride": 0
     },
     {
-      "id": 606,
+      "id": 100000,
       "name": "ExSat BTC",
       "fullName": "Exsat network bitcoin wallet total holdings in satoshi",
       "description": "ExSat / sats",
@@ -7173,7 +7173,7 @@
       "stride": 0
     },
     {
-      "id": 607,
+      "id": 1000000,
       "name": "USDT / WMON 0.2%",
       "fullName": "WMON on monad-testnet pool with contract 0x8552706d9a27013f20ea0f9df8e20b61e283d2d3",
       "description": "WMON / USDT",

--- a/nix/filesets.nix
+++ b/nix/filesets.nix
@@ -10,15 +10,20 @@ with lib.fileset;
     fileset = unions [
       (root + "/Cargo.toml")
       (root + "/Cargo.lock")
+
       (fileFilter (
         file:
         builtins.any file.hasExt [
           "rs"
           "toml"
           "wit"
-          "json"
         ]
       ) root)
+
+      # JSON files
+      (root + "/apps/sequencer_tests/Safe.json")
+      (root + "/apps/sequencer_tests/SafeProxyFactory.json")
+      (root + "/libs/gnosis_safe/safe_abi.json")
     ];
     src = toSource { inherit root fileset; };
   };


### PR DESCRIPTION
- config(feed_config_v1): Assign higher ids for `exsat` and `gecko-terminal` to make room for future feeds
- build(nix/filesets): Reduce rebuilds on json config files changes
