### PR TITLE
[docs.ws/refactor.ui]: Organize `Utility Functions` to prevent `Code Duplication`

### DIFF
--- a/apps/docs.blocksense.network/components/common/Command.tsx
+++ b/apps/docs.blocksense.network/components/common/Command.tsx
@@ -2,7 +2,7 @@ import { ReactNode, HTMLAttributes, ComponentProps } from 'react';
 
 import { Command as CommandPrimitive } from 'cmdk';
 
-import { cn } from '@/lib/utils';
+import { cn } from '@blocksense/ui/utils';
 import { Icon } from '@blocksense/ui/Icon';
 import { Dialog, DialogContent } from '@blocksense/ui/Dialog';
 

--- a/apps/docs.blocksense.network/components/common/Table.tsx
+++ b/apps/docs.blocksense.network/components/common/Table.tsx
@@ -2,7 +2,7 @@
 
 import { HTMLAttributes, TdHTMLAttributes, ThHTMLAttributes } from 'react';
 
-import { cn } from '@/lib/utils';
+import { cn } from '@blocksense/ui/utils';
 
 interface TableProps extends HTMLAttributes<HTMLTableElement> {
   containerClassName?: string;

--- a/apps/docs.blocksense.network/components/ui/DataTable/DataTable.tsx
+++ b/apps/docs.blocksense.network/components/ui/DataTable/DataTable.tsx
@@ -26,7 +26,7 @@ import {
 } from '@/components/common/Table';
 import { DataTablePagination } from '@/components/ui/DataTable/DataTablePagination';
 import { DataTableToolbar } from '@/components/ui/DataTable/DataTableToolbar';
-import { cn } from '@/lib/utils';
+import { cn } from '@blocksense/ui/utils';
 import { onLinkClick } from '@/src/utils';
 
 export type OptionType = {

--- a/apps/docs.blocksense.network/components/ui/DataTable/DataTableFacetedFilter.tsx
+++ b/apps/docs.blocksense.network/components/ui/DataTable/DataTableFacetedFilter.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Check, ChevronDown } from 'lucide-react';
 import { Column } from '@tanstack/react-table';
 
-import { cn } from '@/lib/utils';
+import { cn } from '@blocksense/ui/utils';
 import { Button } from '@blocksense/ui/Button';
 import {
   Command,

--- a/apps/docs.blocksense.network/components/ui/popover.tsx
+++ b/apps/docs.blocksense.network/components/ui/popover.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 
-import { cn } from '@/lib/utils';
+import { cn } from '@blocksense/ui/utils';
 
 const Popover = PopoverPrimitive.Root;
 

--- a/apps/docs.blocksense.network/lib/utils.ts
+++ b/apps/docs.blocksense.network/lib/utils.ts
@@ -1,6 +1,0 @@
-import { type ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}

--- a/libs/ts/ui/package.json
+++ b/libs/ts/ui/package.json
@@ -23,7 +23,8 @@
     "./DropdownMenu": "./src/components/DropdownMenu/index.tsx",
     "./Drawer": "./src/components/Drawer/index.tsx",
     "./Dialog": "./src/components/Dialog/index.tsx",
-    "./Select": "./src/components/Select/index.tsx"
+    "./Select": "./src/components/Select/index.tsx",
+    "./utils": "./src/lib/utils.ts"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.0.7",

--- a/libs/ts/ui/src/components/Accordion/Accordion.tsx
+++ b/libs/ts/ui/src/components/Accordion/Accordion.tsx
@@ -12,7 +12,7 @@ import React, {
 } from 'react';
 
 import { ImageWrapper } from '@blocksense/ui/ImageWrapper';
-import { cn } from '../../utils';
+import { cn } from '@blocksense/ui/utils';
 
 type AccordionContextType = {
   openItems: string[];

--- a/libs/ts/ui/src/components/Badge/Badge.tsx
+++ b/libs/ts/ui/src/components/Badge/Badge.tsx
@@ -2,7 +2,7 @@
 
 import React, { ReactNode } from 'react';
 
-import { cn } from '../../utils';
+import { cn } from '@blocksense/ui/utils';
 
 type Variant = 'primary' | 'highlight' | 'accentary' | 'danger' | 'outline';
 

--- a/libs/ts/ui/src/components/Button/Button.tsx
+++ b/libs/ts/ui/src/components/Button/Button.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { FocusEventHandler, MouseEventHandler, ReactNode } from 'react';
 
-import { cn } from '../../utils';
+import { cn } from '@blocksense/ui/utils';
 
 type Variant =
   | 'action'

--- a/libs/ts/ui/src/components/Callout/Callout.tsx
+++ b/libs/ts/ui/src/components/Callout/Callout.tsx
@@ -2,7 +2,7 @@
 
 import React, { ReactNode, ReactElement } from 'react';
 
-import { cn } from '../../utils';
+import { cn } from '@blocksense/ui/utils';
 
 const typeToEmoji = {
   default: 'ℹ️',

--- a/libs/ts/ui/src/components/Card/Card.tsx
+++ b/libs/ts/ui/src/components/Card/Card.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { HTMLAttributes } from 'react';
 
-import { cn } from '../../utils';
+import { cn } from '@blocksense/ui/utils';
 
 type Variant = 'default' | 'bordered' | 'shadow' | 'transparent';
 type Size = 'sm' | 'md' | 'lg';

--- a/libs/ts/ui/src/components/Dialog/Dialog.tsx
+++ b/libs/ts/ui/src/components/Dialog/Dialog.tsx
@@ -13,7 +13,7 @@ import React, {
   ButtonHTMLAttributes,
 } from 'react';
 
-import { cn } from '../../utils';
+import { cn } from '@blocksense/ui/utils';
 import { Icon } from '@blocksense/ui/Icon';
 import { Button } from '@blocksense/ui/Button';
 

--- a/libs/ts/ui/src/components/Drawer/Drawer.tsx
+++ b/libs/ts/ui/src/components/Drawer/Drawer.tsx
@@ -9,7 +9,7 @@ import React, {
   ReactNode,
 } from 'react';
 
-import { cn } from '../../utils';
+import { cn } from '@blocksense/ui/utils';
 
 interface DrawerContextValue {
   isOpen: boolean;

--- a/libs/ts/ui/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/libs/ts/ui/src/components/DropdownMenu/DropdownMenu.tsx
@@ -13,7 +13,7 @@ import React, {
 } from 'react';
 
 import { Icon } from '@blocksense/ui/Icon';
-import { cn } from '../../utils';
+import { cn, getSideAlignClasses, Align, Side } from '@blocksense/ui/utils';
 
 interface DropdownContextValue {
   open: boolean;
@@ -79,69 +79,6 @@ export const DropdownMenuTrigger = ({
     </div>
   );
 };
-
-type Side = 'left' | 'right' | 'top' | 'bottom';
-type Align = 'start' | 'center' | 'end';
-
-function getSideAlignClasses(side: Side, align: Align): string {
-  let sideClass = '';
-  let alignClass = '';
-  let marginClass = '';
-
-  switch (side) {
-    case 'left':
-      sideClass = 'right-full';
-      marginClass = 'mr-2';
-      break;
-    case 'right':
-      sideClass = 'left-full';
-      marginClass = 'ml-2';
-      break;
-    case 'top':
-      sideClass = 'bottom-full';
-      marginClass = 'mb-2';
-      break;
-    case 'bottom':
-      sideClass = 'top-full';
-      marginClass = 'mt-2';
-      break;
-    default:
-      sideClass = 'top-full';
-      marginClass = 'mt-2';
-  }
-
-  if (side === 'left' || side === 'right') {
-    switch (align) {
-      case 'start':
-        alignClass = 'top-0';
-        break;
-      case 'center':
-        alignClass = 'top-1/2 -translate-y-1/2';
-        break;
-      case 'end':
-        alignClass = 'bottom-0';
-        break;
-      default:
-        alignClass = 'top-0';
-    }
-  } else {
-    switch (align) {
-      case 'start':
-        alignClass = 'left-0';
-        break;
-      case 'center':
-        alignClass = 'left-1/2 -translate-x-1/2';
-        break;
-      case 'end':
-        alignClass = 'right-0';
-        break;
-      default:
-        alignClass = 'left-0';
-    }
-  }
-
-  return `${sideClass} ${alignClass} ${marginClass}`;
-}
 
 export const DropdownMenuContent = ({
   className,

--- a/libs/ts/ui/src/components/Input/Input.tsx
+++ b/libs/ts/ui/src/components/Input/Input.tsx
@@ -9,7 +9,7 @@ import {
   ReactNode,
 } from 'react';
 
-import { cn } from '../../utils';
+import { cn } from '@blocksense/ui/utils';
 
 type Variant = 'outline' | 'filled' | 'transparent' | 'error';
 

--- a/libs/ts/ui/src/components/Label/Label.tsx
+++ b/libs/ts/ui/src/components/Label/Label.tsx
@@ -2,7 +2,7 @@
 
 import React, { ReactNode, LabelHTMLAttributes } from 'react';
 
-import { cn } from '../../utils';
+import { cn } from '@blocksense/ui/utils';
 
 type LabelProps = {
   className?: string;

--- a/libs/ts/ui/src/components/ScrollArea/ScrollArea.tsx
+++ b/libs/ts/ui/src/components/ScrollArea/ScrollArea.tsx
@@ -8,7 +8,7 @@ import React, {
   ReactNode,
 } from 'react';
 
-import { cn } from '../../utils';
+import { cn } from '@blocksense/ui/utils';
 
 type ScrollAreaContextType = {
   scrollPosition: number;

--- a/libs/ts/ui/src/components/Select/Select.tsx
+++ b/libs/ts/ui/src/components/Select/Select.tsx
@@ -10,7 +10,7 @@ import React, {
   HTMLAttributes,
 } from 'react';
 
-import { cn } from '../../utils';
+import { cn, getSideAlignClasses, Align, Side } from '@blocksense/ui/utils';
 import { Icon } from '@blocksense/ui/Icon';
 import { Button } from '@blocksense/ui/Button';
 
@@ -150,45 +150,6 @@ export const SelectValue = ({
     </span>
   );
 };
-
-type Side = 'top' | 'bottom';
-type Align = 'start' | 'center' | 'end';
-
-function getSideAlignClasses(side: Side, align: Align): string {
-  let sideClass = '';
-  let alignClass = '';
-  let marginClass = '';
-
-  switch (side) {
-    case 'top':
-      sideClass = 'bottom-full';
-      marginClass = 'mb-2';
-      break;
-    case 'bottom':
-      sideClass = 'top-full';
-      marginClass = 'mt-2';
-      break;
-    default:
-      sideClass = 'top-full';
-      marginClass = 'mt-2';
-  }
-
-  switch (align) {
-    case 'start':
-      alignClass = 'left-0';
-      break;
-    case 'center':
-      alignClass = 'left-1/2 -translate-x-1/2';
-      break;
-    case 'end':
-      alignClass = 'right-0';
-      break;
-    default:
-      alignClass = 'left-0';
-  }
-
-  return `${sideClass} ${alignClass} ${marginClass}`;
-}
 
 type SelectContentProps = HTMLAttributes<HTMLDivElement> & {
   className?: string;

--- a/libs/ts/ui/src/components/Switch/Switch.tsx
+++ b/libs/ts/ui/src/components/Switch/Switch.tsx
@@ -2,7 +2,7 @@
 
 import React, { ButtonHTMLAttributes } from 'react';
 
-import { cn } from '../../utils';
+import { cn } from '@blocksense/ui/utils';
 
 type SwitchProps = {
   checked?: boolean;

--- a/libs/ts/ui/src/components/Tabs/Tabs.tsx
+++ b/libs/ts/ui/src/components/Tabs/Tabs.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { createContext, useContext, useState, ReactNode } from 'react';
 
-import { cn } from '../../utils';
+import { cn } from '@blocksense/ui/utils';
 
 type TabsContextType = {
   activeTab: string;

--- a/libs/ts/ui/src/components/Tooltip/Tooltip.tsx
+++ b/libs/ts/ui/src/components/Tooltip/Tooltip.tsx
@@ -5,7 +5,7 @@ import React, {
   isValidElement,
 } from 'react';
 
-import { cn } from '../../utils';
+import { cn } from '@blocksense/ui/utils';
 
 type TooltipProps = {
   position?: 'top' | 'right' | 'bottom' | 'left';

--- a/libs/ts/ui/src/index.tsx
+++ b/libs/ts/ui/src/index.tsx
@@ -14,3 +14,4 @@ export * from './components/Accordion';
 export * from './components/Icon';
 export * from './components/Dialog';
 export * from './components/Select';
+export * from './lib/utils';

--- a/libs/ts/ui/src/lib/utils.ts
+++ b/libs/ts/ui/src/lib/utils.ts
@@ -1,0 +1,69 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+export type Side = 'left' | 'right' | 'top' | 'bottom';
+export type Align = 'start' | 'center' | 'end';
+
+export function getSideAlignClasses(side: Side, align: Align): string {
+  let sideClass = '';
+  let alignClass = '';
+  let marginClass = '';
+
+  switch (side) {
+    case 'left':
+      sideClass = 'right-full';
+      marginClass = 'mr-2';
+      break;
+    case 'right':
+      sideClass = 'left-full';
+      marginClass = 'ml-2';
+      break;
+    case 'top':
+      sideClass = 'bottom-full';
+      marginClass = 'mb-2';
+      break;
+    case 'bottom':
+      sideClass = 'top-full';
+      marginClass = 'mt-2';
+      break;
+    default:
+      sideClass = 'top-full';
+      marginClass = 'mt-2';
+  }
+
+  if (side === 'left' || side === 'right') {
+    switch (align) {
+      case 'start':
+        alignClass = 'top-0';
+        break;
+      case 'center':
+        alignClass = 'top-1/2 -translate-y-1/2';
+        break;
+      case 'end':
+        alignClass = 'bottom-0';
+        break;
+      default:
+        alignClass = 'top-0';
+    }
+  } else {
+    switch (align) {
+      case 'start':
+        alignClass = 'left-0';
+        break;
+      case 'center':
+        alignClass = 'left-1/2 -translate-x-1/2';
+        break;
+      case 'end':
+        alignClass = 'right-0';
+        break;
+      default:
+        alignClass = 'left-0';
+    }
+  }
+
+  return `${sideClass} ${alignClass} ${marginClass}`;
+}

--- a/libs/ts/ui/src/utils.ts
+++ b/libs/ts/ui/src/utils.ts
@@ -1,6 +1,0 @@
-import { type ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}


### PR DESCRIPTION
## Pull Request Description

### Summary

This PR introduces several changes related to the `utils.ts` services in the `@blocksense/ui` library. The idea behind these changes is to make the code clean and prevent code duplication by centralizing utility functions.

### Changes

1. **Added**: `utils.ts` in `/libs/ts/ui/src/lib`.
2. **Updated**: `@blocksense/ui` to properly export `utils.ts`.
3. **Updated**: Component imports to use the new `utils.ts` location.
4. **Deleted**: `utils.ts` from `@blocksense/ui` as it is no longer needed.
5. **Deleted**: `utils.ts` from `@blocksense/docs.blocksense.network` as it is no longer needed.

### Impact

- The `utils.ts` file is now located in `@blocksense/ui/src/lib`.
- The `@blocksense/ui` library has been updated to properly export `utils.ts`.
- Components have been updated to import utilities from the new location.

### Notes

- These changes are part of an effort to improve the organization and maintainability of the `@blocksense/ui` library by `centralizing utility functions` and `preventing code duplication`.