### PR TITLE
fix(tests): Make all unit tests pass clippy check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,10 +118,6 @@ jobs:
         if: ${{ runner.environment == 'self-hosted' }}
         run: cargo test
 
-      - name: Run Cargo Clippy
-        if: ${{ runner.environment == 'self-hosted' }}
-        run: cargo clippy -- --deny warnings
-
   deploy_websites:
     timeout-minutes: 360
     runs-on: [self-hosted, nixos, x86-64-v3]

--- a/apps/oracles/gecko-terminal/src/lib.rs
+++ b/apps/oracles/gecko-terminal/src/lib.rs
@@ -222,6 +222,6 @@ mod tests {
             value.data.attributes.address,
             "0x8552706d9a27013f20ea0f9df8e20b61e283d2d3"
         );
-        assert_eq!(value.data.attributes.price_in_usd, 181.783899458886 as f64);
+        assert_eq!(value.data.attributes.price_in_usd, 181.783899458886_f64);
     }
 }

--- a/apps/sequencer/src/feeds/feed_allocator.rs
+++ b/apps/sequencer/src/feeds/feed_allocator.rs
@@ -434,7 +434,6 @@ mod tests {
         let handles: Vec<_> = (0..5)
             .map(|_| {
                 let allocator = Arc::clone(&allocator);
-                let schema_id = schema_id;
                 thread::spawn(move || {
                     allocator.allocate(
                         number_of_slots,

--- a/apps/sequencer/src/feeds/feed_slots_processor.rs
+++ b/apps/sequencer/src/feeds/feed_slots_processor.rs
@@ -766,7 +766,7 @@ pub mod tests {
             history_guard.push_next(
                 feed_id,
                 FeedType::Numerical(130.0),
-                slot_start_in_ms + 1 * report_interval_ms as u128,
+                slot_start_in_ms + report_interval_ms as u128,
             );
             history_guard.push_next(
                 feed_id,
@@ -874,7 +874,7 @@ pub mod tests {
             history_guard.push_next(
                 feed_id,
                 FeedType::Numerical(130.0),
-                slot_start_in_ms + 1 * report_interval_ms as u128,
+                slot_start_in_ms + report_interval_ms as u128,
             );
             history_guard.push_next(
                 feed_id,
@@ -981,7 +981,7 @@ pub mod tests {
             history_guard.push_next(
                 feed_id,
                 FeedType::Numerical(102.1),
-                slot_start_in_ms + 1 * report_interval_ms as u128,
+                slot_start_in_ms + report_interval_ms as u128,
             );
         }
 

--- a/apps/sequencer/src/http_handlers/admin.rs
+++ b/apps/sequencer/src/http_handlers/admin.rs
@@ -759,10 +759,10 @@ mod tests {
             let mut recvd_data: AllFeedsConfig =
                 serde_json::from_str(body_str).expect("recvd_data is not valid JSON!");
 
-            assert_eq!(
-                recvd_data.feeds.sort_by(FeedConfig::compare),
-                feeds_config.feeds.sort_by(FeedConfig::compare)
-            );
+            recvd_data.feeds.sort_by(FeedConfig::compare);
+            feeds_config.feeds.sort_by(FeedConfig::compare);
+
+            assert_eq!(recvd_data.feeds, feeds_config.feeds);
         }
 
         {
@@ -905,10 +905,7 @@ mod tests {
 
         {
             let sequencer_config = sequencer_state.sequencer_config.read().await;
-            assert_eq!(
-                true,
-                sequencer_config.providers.get(network).unwrap().is_enabled
-            );
+            assert!(sequencer_config.providers.get(network).unwrap().is_enabled);
         }
 
         let req = test::TestRequest::post()
@@ -920,10 +917,7 @@ mod tests {
         assert_eq!(200, resp.status());
         {
             let sequencer_config = sequencer_state.sequencer_config.read().await;
-            assert_eq!(
-                false,
-                sequencer_config.providers.get(network).unwrap().is_enabled
-            );
+            assert!(!sequencer_config.providers.get(network).unwrap().is_enabled);
         }
     }
 
@@ -952,10 +946,7 @@ mod tests {
         assert_eq!(200, resp.status());
 
         let sequencer_config = sequencer_state.sequencer_config.read().await;
-        assert_eq!(
-            true,
-            sequencer_config.providers.get(network).unwrap().is_enabled
-        );
+        assert!(sequencer_config.providers.get(network).unwrap().is_enabled);
     }
 
     #[actix_web::test]

--- a/apps/sequencer/src/http_handlers/data_feeds.rs
+++ b/apps/sequencer/src/http_handlers/data_feeds.rs
@@ -692,7 +692,7 @@ pub mod tests {
         const HTTP_STATUS_SUCCESS: u16 = 200;
 
         let anvil = Anvil::new().try_spawn().unwrap();
-        let key_path = PathBuf::new().join("/tmp").join("priv_key_test");
+        let key_path = PathBuf::from("/tmp").join("priv_key_test");
         let network = "ETH140";
 
         // Read app config
@@ -1174,12 +1174,12 @@ pub mod tests {
             history.push_next(
                 feed_id,
                 FeedType::Numerical(102754.2f64),
-                end_slot_timestamp + 300_u128 * 0,
+                end_slot_timestamp, /* + 300_u128 * 0*/
             );
             history.push_next(
                 feed_id,
                 FeedType::Numerical(122756.7f64),
-                end_slot_timestamp + 300_u128 * 1,
+                end_slot_timestamp + 300_u128, /* * 1*/
             );
             history.push_next(
                 feed_id,

--- a/apps/sequencer/src/providers/eth_send_utils.rs
+++ b/apps/sequencer/src/providers/eth_send_utils.rs
@@ -810,7 +810,7 @@ mod tests {
         let provider_settings = cfg
             .providers
             .get(&net)
-            .expect(format!("Config for network {net} not found!").as_str())
+            .unwrap_or_else(|| panic!("Config for network {net} not found!"))
             .clone();
         let feeds_config = Arc::new(RwLock::new(HashMap::<u32, FeedConfig>::new()));
 
@@ -940,7 +940,7 @@ mod tests {
         let updates_oneshot = BatchedAggegratesToSend {
             block_height: 0,
             updates: vec![VotedFeedUpdate::new_decode(
-                &"00000003",
+                "00000003",
                 &value1,
                 end_of_timeslot,
                 FeedType::Text("".to_string()),
@@ -1129,7 +1129,7 @@ mod tests {
         let key_path = get_test_private_key_path();
 
         let mut sequencer_config =
-            get_test_config_with_single_provider(network, key_path.as_path(), &url);
+            get_test_config_with_single_provider(network, key_path.as_path(), url);
 
         sequencer_config
             .providers
@@ -1151,14 +1151,14 @@ mod tests {
         };
         let providers = init_shared_rpc_providers(
             &sequencer_config,
-            Some(&"peg_stable_coin_updates_"),
+            Some("peg_stable_coin_updates_"),
             &feeds_config,
         )
         .await;
         let mut prov2 = providers.write().await;
         let mut provider = prov2.get_mut(network).unwrap().lock().await;
 
-        provider.update_history(&vec![VotedFeedUpdate {
+        provider.update_history(&[VotedFeedUpdate {
             feed_id: 0x001_u32,
             value: FeedType::Numerical(1.0f64),
             end_slot_timestamp: 0_u128,
@@ -1184,7 +1184,7 @@ mod tests {
         let key_path = get_test_private_key_path();
 
         let mut sequencer_config =
-            get_test_config_with_single_provider(network, key_path.as_path(), &url);
+            get_test_config_with_single_provider(network, key_path.as_path(), url);
 
         sequencer_config
             .providers
@@ -1205,14 +1205,14 @@ mod tests {
         };
         let providers = init_shared_rpc_providers(
             &sequencer_config,
-            Some(&"peg_stable_coin_updates_disabled"),
+            Some("peg_stable_coin_updates_disabled"),
             &feeds_config,
         )
         .await;
         let mut prov2 = providers.write().await;
         let mut provider = prov2.get_mut(network).unwrap().lock().await;
 
-        provider.update_history(&vec![VotedFeedUpdate {
+        provider.update_history(&[VotedFeedUpdate {
             feed_id: 0x001_u32,
             value: FeedType::Numerical(1.0f64),
             end_slot_timestamp: 0_u128,

--- a/libs/data_feeds/src/feeds_processing.rs
+++ b/libs/data_feeds/src/feeds_processing.rs
@@ -220,70 +220,52 @@ mod tests {
         };
 
         // No history
-        assert_eq!(
-            update.should_skip(&always_publish_criteria, &history),
-            false
-        );
+        assert!(!update.should_skip(&always_publish_criteria, &history));
 
         history.push_next(
             feed_id,
             FeedType::Numerical(1000.0f64),
             end_slot_timestamp - 1000_u128,
         );
-        assert_eq!(
-            update.should_skip(&always_publish_criteria, &history),
-            false
-        );
-        assert_eq!(update.should_skip(&one_percent_threshold, &history), true);
-        assert_eq!(
-            update.should_skip(&always_publish_every_second, &history),
-            false
-        );
+        assert!(!update.should_skip(&always_publish_criteria, &history));
+        assert!(update.should_skip(&one_percent_threshold, &history));
+        assert!(!update.should_skip(&always_publish_every_second, &history));
 
         history.push_next(
             feed_id,
             FeedType::Numerical(1000.0f64),
             end_slot_timestamp - 900_u128,
         );
-        assert_eq!(
-            update.should_skip(&always_publish_criteria, &history),
-            false
-        );
-        assert_eq!(update.should_skip(&one_percent_threshold, &history), true);
-        assert_eq!(
-            update.should_skip(&always_publish_every_second, &history),
-            true
-        ); // only 900 ms since last update, shoud be skipped
+        assert!(!update.should_skip(&always_publish_criteria, &history));
+        assert!(update.should_skip(&one_percent_threshold, &history));
+        assert!(update.should_skip(&always_publish_every_second, &history)); // only 900 ms since last update, shoud be skipped
 
         let update = VotedFeedUpdate {
             feed_id,
             value: FeedType::Numerical(1010.0),
             end_slot_timestamp,
         };
-        assert_eq!(
-            update.should_skip(&always_publish_criteria, &history),
-            false
-        );
+        assert!(!update.should_skip(&always_publish_criteria, &history));
         // If the price is 1000 and it moved to 1010, I'd say it moved by 1%, not by 100/101 %.
-        assert_eq!(update.should_skip(&one_percent_threshold, &history), false);
+        assert!(!update.should_skip(&one_percent_threshold, &history));
         let update = VotedFeedUpdate {
             feed_id,
             value: FeedType::Numerical(1009.999),
             end_slot_timestamp,
         };
-        assert_eq!(update.should_skip(&one_percent_threshold, &history), true);
+        assert!(update.should_skip(&one_percent_threshold, &history));
         let update = VotedFeedUpdate {
             feed_id,
             value: FeedType::Numerical(990.001),
             end_slot_timestamp,
         };
-        assert_eq!(update.should_skip(&one_percent_threshold, &history), true);
+        assert!(update.should_skip(&one_percent_threshold, &history));
         let update = VotedFeedUpdate {
             feed_id,
             value: FeedType::Numerical(990.000),
             end_slot_timestamp,
         };
-        assert_eq!(update.should_skip(&one_percent_threshold, &history), false);
+        assert!(!update.should_skip(&one_percent_threshold, &history));
     }
 
     #[test]

--- a/nix/shells/pkg-sets/pre-commit.nix
+++ b/nix/shells/pkg-sets/pre-commit.nix
@@ -20,6 +20,19 @@
         rustfmt = self'.legacyPackages.rustToolchain;
       };
     };
+    clippy = {
+      enable = true;
+      packageOverrides = {
+        cargo = self'.legacyPackages.cargoWrapped;
+        clippy = self'.legacyPackages.rustToolchain;
+      };
+
+      settings = {
+        denyWarnings = true;
+        allFeatures = true;
+        extraArgs = "--tests";
+      };
+    };
     prettier = {
       enable = true;
       args = [

--- a/nix/shells/pkg-sets/pre-commit.nix
+++ b/nix/shells/pkg-sets/pre-commit.nix
@@ -9,10 +9,6 @@
       excludes = [ "libs/sdk/wit/deps" ];
       enable = true;
     };
-    cargo-check = {
-      enable = true;
-      package = self'.legacyPackages.cargoWrapped;
-    };
     rustfmt = {
       enable = true;
       packageOverrides = {


### PR DESCRIPTION
Fix warnings generated from clippy for unit tests. One warning was causing an assert in `test_get_feeds_config` to not perform the required check. Problem found by @Xearty - thanks for looking into this! 
To run cargo clippy on the unit tests run the following from the main blocksense project folder:
`cargo clippy --tests`