### PR TITLE
[oracles/crypto price feeds] Improve logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3434,6 +3434,7 @@ dependencies = [
  "blocksense-sdk",
  "futures",
  "itertools 0.14.0",
+ "prettytable-rs",
  "serde 1.0.217",
  "serde-this-or-that",
  "serde_derive",
@@ -3905,6 +3906,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
 ]
 
 [[package]]
@@ -7851,6 +7862,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettytable-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
+dependencies = [
+ "csv",
+ "encode_unicode",
+ "is-terminal",
+ "lazy_static 1.5.0",
+ "term",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10640,6 +10665,17 @@ dependencies = [
  "once_cell",
  "rustix 0.38.43",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/apps/oracles/crypto-price-feeds/Cargo.toml
+++ b/apps/oracles/crypto-price-feeds/Cargo.toml
@@ -20,3 +20,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0.210"
 futures = { workspace = true }
 itertools = "0.14.0"
+prettytable-rs = "0.10"


### PR DESCRIPTION
### Before
```
. . .
🕛 All prices fetched in 3.274712744s
missing ids(id-symbol): [(439-SUSHI/ETH),(422-YFI/ETH),(32-wBTC/USD),(671-MLN/USDC),(566-USDtb/USD),(572-JOE/USDC),(567-USDtb/USDT),(339-deUSD/USDT),(338-deUSD/USD),(79-USDe/USDC),(679-PERP/USDC),(78-USDe/USDT),(76-USDe/USD),(34-wBTC/USDC),(33-wBTC/USDT),(683-GHST/USDC),(688-NULS/USDC),(669-MLN/ETH)]
(id-exchange_count): [(468-9),(107-3),(723-10),(526-1),(159-7),(67-8),(659-5),(174-3),(658-2),(672-6),(460-3),(629-5),(490-10),(548-11),(61-8),(166-14),(514-6),(259-7),(408-1),(637-10),(300-3),(114-18),(245-8),(450-5),(513-8),(258-8),(687-4),(200-10),(583-8),(290-5),(375-3),(387-10),(89-4),(364-12),(630-7),(638-7),(184-12),(198-3),(95-6),(100-10),(276-1),(235-4),(72-23),(266-3),(293-7),(398-3),(498-1),(21-10),(241-3),(275-7),(553-7),(467-3),(682-5),(711-5),(712-4),(50-10),(229-1),(416-6),(87-3),(53-11),(447-11),(686-5),(722-3),(528-7),(139-6),(464-2),(371-6),(368-9),(40-14),(648-2),(279-10),(689-4),(584-6),(269-17),(333-6),(646-6),(126-5),(0-25),(645-7),(590-6),(318-6),(613-5),(383-1),(80-5),(315-15),(376-15),(391-1),(502-11),(680-1),(7-7),(152-9),(25-9),(506-6),(549-8),(128-1),(242-9),(575-1),(202-18),(319-4),(36-6),(691-6),(725-5),(557-3),(99-21),(188-5),(370-11),(685-5),(249-2),(726-2),(215-18),(214-1),(503-8),(280-4),(39-8),(335-1),(289-6),(363-1),(445-7),(307-10),(504-2),(609-1),(60-11),(274-4),(491-7),(122-5),(509-7),(456-1),(465-13),(605-6),(706-2),(77-7),(93-3),(91-22),(473-6),(709-2),(501-1),(494-5),(505-9),(220-3),(103-10),(118-7),(472-3),(600-11),(699-6),(149-10),(271-4),(714-10),(45-1),(479-7),(602-3),(62-1),(233-18),(47-10),(436-7),(403-12),(327-10),(203-9),(585-11),(186-16),(701-4),(301-2),(401-6),(105-16),(675-3),(413-6),(130-8),(270-9),(115-3),(37-1),(133-2),(535-1),(326-4),(588-1),(611-5),(185-9),(351-4),(46-17),(182-9),(218-15),(312-16),(647-1),(692-4),(230-20),(347-13),(493-7),(392-15),(538-3),(234-10),(328-6),(316-9),(92-1),(415-8),(673-5),(135-3),(372-1),(410-6),(340-13),(512-5),(581-3),(596-1),(399-7),(623-5),(286-3),(469-7),(306-1),(355-13),(30-9),(444-13),(625-6),(458-13),(263-8),(713-4),(8-2),(165-5),(569-3),(518-2),(644-1),(655-5),(428-1),(607-7),(352-13),(555-11),(253-14),(677-11),(112-9),(649-2),(252-1),(604-10),(231-9),(144-7),(55-21),(209-15),(365-9),(136-20),(595-6),(75-7),(426-3),(485-7),(524-7),(530-8),(43-4),(313-10),(654-1),(155-9),(160-15),(717-4),(407-8),(668-7),(517-4),(267-6),(281-2),(64-10),(563-12),(592-2),(721-5),(48-5),(261-1),(730-1),(337-6),(562-6),(5-12),(85-2),(358-13),(168-4),(385-2),(546-7),(176-8),(475-6),(694-5),(693-5),(13-15),(150-7),(204-5),(1-12),(205-21),(405-3),(129-16),(390-7),(70-7),(420-14),(331-7),(321-8),(346-2),(134-9),(206-1),(295-13),(342-9),(173-3),(511-5),(3-26),(540-6),(97-9),(558-11),(559-7),(499-10),(283-5),(57-7),(213-6),(227-12),(278-1),(4-13),(288-1),(603-3),(617-8),(113-6),(27-11),(66-16),(190-7),(84-8),(302-7),(208-7),(177-4),(58-1),(626-7),(628-6),(441-1),(616-5),(643-5),(163-20),(265-8),(222-9),(461-10),(101-7),(148-21),(369-2),(466-7),(359-9),(599-1),(639-10),(65-8),(104-7),(197-7),(284-16),(304-1),(94-10),(716-2),(380-3),(703-7),(449-8),(698-7),(156-4),(171-9),(389-8),(710-6),(556-6),(382-16),(161-8),(308-6),(334-5),(470-11),(561-7),(580-4),(515-2),(591-2),(63-23),(394-9),(531-6),(539-8),(478-10),(131-4),(554-3),(614-5),(124-8),(291-1),(292-12),(481-13),(547-1),(143-10),(624-7),(652-9),(332-2),(246-2),(187-8),(12-8),(676-1),(255-1),(9-24),(356-8),(404-8),(615-7),(663-5),(366-1),(69-12),(83-1),(108-16),(662-5),(96-18),(665-9),(411-2),(495-1),(23-1),(51-8),(216-10),(145-16),(239-3),(44-2),(273-8),(477-1),(425-12),(484-11),(660-5),(73-1),(353-8),(610-8),(488-8),(212-8),(409-10),(180-5),(299-6),(248-10),(310-8),(454-9),(2-8),(68-5),(151-19),(102-22),(476-5),(497-7),(565-1),(571-5),(192-14),(586-2),(601-7),(191-1),(140-1),(268-4),(325-6),(17-11),(378-4),(31-7),(221-14),(322-3),(487-13),(223-2),(224-13),(167-7),(254-9),(421-1),(10-1),(28-7),(71-3),(350-6),(438-14),(471-7),(324-4),(474-5),(379-4),(510-1),(536-1),(621-1),(622-7),(633-6),(719-3),(141-1),(178-18),(207-10),(298-9),(552-11),(576-13),(523-2),(272-15),(244-14),(598-8),(22-23),(251-4),(402-5),(427-9),(661-6),(423-8),(442-9),(361-7),(451-13),(522-8),(303-6),(568-3),(419-1),(424-1),(653-6),(674-6),(440-9),(718-3),(664-5),(728-5),(533-10),(82-16),(226-3),(700-4),(183-1),(74-11),(210-8),(157-20),(132-16),(720-2),(146-10),(196-14),(446-3),(125-7),(81-2),(116-9),(537-3),(560-2),(573-9),(593-2),(452-7),(597-11),(619-8),(618-6),(219-9),(640-5),(357-3),(285-9),(684-5),(551-4),(417-12),(120-1),(715-6),(729-2),(393-2),(344-9),(651-5),(59-22),(323-6),(430-9),(433-9),(16-25),(459-7),(388-1),(657-2),(453-3),(170-1),(670-4),(142-19),(632-8),(486-1),(516-8),(678-7),(117-4),(262-12),(294-3),(317-1),(320-13),(88-7),(606-2),(690-4),(705-6),(41-10),(256-9),(500-7),(195-1),(147-3),(437-1),(455-7),(35-22),(521-13),(650-6),(362-6),(367-12),(496-10),(127-4),(594-8),(345-5),(642-8),(666-7),(18-9),(681-8),(162-4),(29-18),(211-3),(336-7),(343-1),(287-1),(15-7),(199-18),(377-8),(236-16),(412-9),(542-5),(305-20),(98-5),(26-22),(406-10),(582-2),(587-7),(296-8),(508-11),(667-1),(702-9),(483-3),(631-5),(282-7),(153-5),(6-9),(110-5),(577-8),(86-3),(634-11),(179-9),(123-3),(189-9),(462-8),(330-11),(348-9),(482-8),(431-2),(49-24),(225-8),(297-4),(579-4),(90-2),(397-9),(589-8),(232-6),(14-8),(545-11),(608-5),(695-21),(696-11),(38-10),(386-14),(311-2),(432-12),(193-1),(395-1),(520-7),(707-2),(121-10),(314-3),(656-5),(429-14),(641-1),(154-16),(341-3),(396-16),(570-8),(240-17),(164-10),(448-8),(620-6),(194-9),(492-1),(106-10),(480-1),(636-1),(119-5),(228-9),(418-8),(169-15),(257-1),(612-2),(541-6),(138-10),(374-8),(627-5),(329-1),(277-6),(697-6),(54-8),(42-3),(172-1),(137-4),(247-16),(443-7),(434-2),(463-2),(708-3),(727-1),(52-25),(158-9),(384-10),(544-6),(349-1),(507-1),(574-8),(550-4),(527-12),(525-5),(24-11),(109-8),(360-1),(457-2),(532-1),(578-3),(529-2),(217-3),(543-8),(201-4),(260-4),(519-10),(11-11),(534-7),(381-1),(564-9),(704-7),(111-18),(175-14),(19-12),(489-1),(264-13),(435-12),(724-6),(181-13),(20-1),(237-2),(238-10),(243-3),(56-9),(309-12),(354-2),(373-13),(414-1),(635-9),(250-6),(400-6)]
Final Payload - [DataFeedResult { id: "670", value: Numerical(9.456207212227422) }, DataFeedResult { id: "177", value: Numerical(0.6439393052282203) }, DataFeedResult { id: "154", value: Numerical(0.5247084232483522) }, DataFeedResult { id: "630", value: Numerical(0.04165008898453576) }, DataFeedResult { id: "351", value: Numerical(22.58562435271972) }, DataFeedResult { id: "701", value: Numerical(0.06960499623683092) }, DataFeedResult { id: "132", value: Numerical(0.21565184479621766) }, DataFeedResult { id: "293", value: Numerical(1.1848517925415794) }, DataFeedResult { id: "625", value: Numerical(0.6410814477073852) }, DataFeedResult { id: "684", value: Numerical(0.03561048630185989) }, DataFeedResult { id: "3", value: Numerical(1921.6856908382051) }, DataFeedResult { id: "478", value: Numerical(0.7700564519288029) }, DataFeedResult { id: "1", value: Numerical(84025.4855007759) }, DataFeedResult { id: "229", value: Numerical(0.3962) }, DataFeedResult { id: "268", value: Numerical(0.013359272151014694) }, DataFeedResult { id: "654", value: Numerical(0.03927) }, DataFeedResult { id: "350", value: Numerical(22.58596816283303) }, DataFeedResult { id: "668", value: Numerical(9.45591316616863) }, DataFeedResult { id: "31", value: Numerical(0.22126371327275354) }, DataFeedResult { id: "459", value: Numerical(0.002221981947670013) }, DataFeedResult { id: "716", value: Numerical(0.6950138257467189) }, DataFeedResult { id: "395", value: Numerical(0.2534) }, DataFeedResult { id: "291", value: Numerical(0.4045) }, 
. . .
```

### After

```
. . .
🕛 All prices fetched in 3.273018232s

Missing pairs:
[{ 32: wBTC / USD },{ 688: NULS / USDC },{ 567: USDtb / USDT },{ 566: USDtb / USD },{ 572: JOE / USDC },{ 679: PERP / USDC },{ 78: USDe / USDT },{ 683: GHST / USDC },{ 79: USDe / USDC },{ 669: MLN / ETH },{ 339: deUSD / USDT },{ 439: SUSHI / ETH },{ 671: MLN / USDC },{ 34: wBTC / USDC },{ 33: wBTC / USDT },{ 76: USDe / USD },{ 422: YFI / ETH },{ 338: deUSD / USD },]

Missing prices:
[{ 257: TUSD / ETH, exchanges: ["Binance"] },{ 214: XTZ / BNB, exchanges: ["Binance"] },{ 261: ZEC / USDC, exchanges: ["Binance"] },{ 492: RPL / USDC, exchanges: ["OKX"] },{ 45: USDS / USDC, exchanges: ["Binance"] },{ 419: ANKR / USDC, exchanges: ["Binance"] },{ 727: FTM / USDC, exchanges: ["Binance"] },{ 393: ZRX / ETH, exchanges: ["Binance", "Kraken"] },{ 424: YFI / USDC, exchanges: ["OKX"] },{ 421: YFI / BNB, exchanges: ["Binance"] },{ 592: BUSD / USD, exchanges: ["Binance"] },{ 729: RNDR / USDT, exchanges: ["Binance"] },{ 83: DAI / BNB, exchanges: ["Binance"] },{ 593: BUSD / USDT, exchanges: ["Binance"] },{ 306: APE / ETH, exchanges: ["Binance"] },{ 588: KNC / USDC, exchanges: ["OKX"] },{ 477: BAND / BNB, exchanges: ["Binance"] },{ 680: GHST / ETH, exchanges: ["Binance"] },{ 206: EOS / BNB, exchanges: ["Binance"] },{ 92: UNI / BNB, exchanges: ["Binance"] },{ 730: RNDR / USDC, exchanges: ["Binance"] },{ 596: WIN / USDC, exchanges: ["Binance"] },{ 20: USDC / BNB, exchanges: ["Binance"] },{ 609: BONE / USDC, exchanges: ["OKX"] },]

Results:
+-----+-----------------+----------------+-----------+
| ID  |      Name       |     Value      | Exchanges |
+-----+-----------------+----------------+-----------+
|   0 |       BTC / USD | 84161.55056650 |        12 |
|   1 |      BTC / USDT | 84150.50554963 |        10 |
|   2 |      BTC / USDC | 84173.07117070 |         7 |
. . .
```