### PR TITLE
[oracles/crypto-price-feeds]: `symbol` in fill_results match symbol in exchanges

### DIFF
--- a/apps/oracles/crypto-price-feeds/src/fetch_prices.rs
+++ b/apps/oracles/crypto-price-feeds/src/fetch_prices.rs
@@ -120,7 +120,11 @@ fn fill_results(
         res.symbol = trading_pair.clone();
 
         for quote in quote_variants {
-            let symbol = format!("{}{}", resource.pair.base, quote);
+            let symbol = format!(
+                "{}{}",
+                resource.pair.base.to_uppercase(),
+                quote.to_uppercase()
+            );
             if let Some(price_point) = prices_per_exchange.data.get(&symbol) {
                 res.exchanges_data.insert(
                     format!("{} {} price", prices_per_exchange.name, quote),


### PR DESCRIPTION
Before:
```
Missing pairs:
[{ 32: wBTC / USD },{ 688: NULS / USDC },{ 567: USDtb / USDT },{ 566: USDtb / USD },{ 572: JOE / USDC },{ 679: PERP / USDC },{ 78: USDe / USDT },{ 683: GHST / USDC },{ 79: USDe / USDC },{ 669: MLN / ETH },{ 339: deUSD / USDT },{ 439: SUSHI / ETH },{ 671: MLN / USDC },{ 34: wBTC / USDC },{ 33: wBTC / USDT },{ 76: USDe / USD },{ 422: YFI / ETH },{ 338: deUSD / USD },]
```

After:
```
Missing pairs:
[{ 671: MLN / USDC },{ 683: GHST / USDC },{ 669: MLN / ETH },{ 422: YFI / ETH },{ 572: JOE / USDC },{ 439: SUSHI / ETH },{ 679: PERP / USDC },{ 688: NULS / USDC },]
```
