### PR TITLE
[config]: Add `ExSat BTC`, `USDT / WMON 0.2%` & pegged to 1 `USDC / USD` & `USDT / USD`

### DIFF
--- a/config/feeds_config_v2.json
+++ b/config/feeds_config_v2.json
@@ -53249,6 +53249,68 @@
           "chainlink": "RNDR / USD"
         }
       }
+    },
+    {
+      "id": 100000,
+      "full_name": "ExSat BTC",
+      "description": "Exsat network bitcoin wallet total holdings in satoshi",
+      "type": "price-feed",
+      "oracle_id": "exsat-holdings",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 3600000,
+        "heartbeat_ms": 86400000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "Exsat",
+          "quote": "satoshi"
+        },
+        "decimals": 0,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {}
+      }
+    },
+    {
+      "id": 1000000,
+      "full_name": "WMON 0.2% / USDT",
+      "description": "WMON on monad-testnet pool with contract 0x264e9b75723d75e3c607627d8e21d2c758db4c80",
+      "type": "price-feed",
+      "oracle_id": "gecko-terminal",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "WMON",
+          "quote": "USDT"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "network":"monad-testnet",
+          "pool":"0x264e9b75723d75e3c607627d8e21d2c758db4c80",
+          "reverse": true
+        }
+      }
     }
   ]
 }

--- a/config/feeds_config_v2.json
+++ b/config/feeds_config_v2.json
@@ -53251,6 +53251,116 @@
       }
     },
     {
+      "id": 50000,
+      "full_name": "USDT / USD Pegged",
+      "description": "Tether USD Pegged to 1",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "USDT",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Coinbase": {
+              "id": [
+                "USDT-USD"
+              ]
+            },
+            "CryptoCom": {
+              "instrument_name": [
+                "USDT_USD"
+              ]
+            },
+            "GateIo": {
+              "id": [
+                "USDT_USD"
+              ]
+            },
+            "Gemini": {
+              "symbol": [
+                "USDTUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "USDTZUSD"
+              ],
+              "wsname": [
+                "USDT/USD"
+              ]
+            },
+            "OKX": {
+              "instId": [
+                "USDT-USD"
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": 50001,
+      "full_name": "USDC / USD Pegged",
+      "description": "Circle USD Pegged to 1",
+      "type": "price-feed",
+      "oracle_id": "crypto-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "USDC",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Gemini": {
+              "symbol": [
+                "USDCUSD"
+              ]
+            },
+            "Kraken": {
+              "pair": [
+                "USDCUSD"
+              ],
+              "wsname": [
+                "USDC/USD"
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
       "id": 100000,
       "full_name": "ExSat BTC",
       "description": "Exsat network bitcoin wallet total holdings in satoshi",


### PR DESCRIPTION
To test if all works I start `process-compose` and try to read the on-chain data

#### Read data for `USDT / USD Pegged` with id `50000`
```
cast call 0xee5a4826068c5326a7f06fd6c7cbf816f096846c --data 0x8000c350 --rpc-url http://127.0.0.1:8546 |  cut -c1-50 | cast to-dec
```

#### Read data for `USDC / USD Pegged` with id `50001`
```
cast call 0xee5a4826068c5326a7f06fd6c7cbf816f096846c --data 0x8000c351 --rpc-url http://127.0.0.1:8546 |  cut -c1-50 | cast to-dec
```

#### Read data for `ExSat BTC` with id `100000`
```
cast call 0xee5a4826068c5326a7f06fd6c7cbf816f096846c --data 0x800186a0 --rpc-url http://127.0.0.1:8546 |  cut -c1-50 | cast to-dec
```

#### Read data for `WMON 0.2% / USDT` with id `1000000` 
>  can be tested once https://github.com/blocksense-network/blocksense/pull/1078 is merged 
```
 cast call 0xee5a4826068c5326a7f06fd6c7cbf816f096846c --data 0x800f4240 --rpc-url http://127.0.0.1:8546 |  cut -c1-50 | cast to-dec     
```
