### PR TITLE
[nix/example-setup-01]: Update once again

### DIFF
--- a/nix/modules/sequencer/backends/process-compose.nix
+++ b/nix/modules/sequencer/backends/process-compose.nix
@@ -155,8 +155,8 @@ let
       ];
       shutdown.signal = 9;
       depends_on = {
-        "anvil-impersonate-and-fund-a".condition = "process_completed_successfully";
-        "anvil-impersonate-and-fund-b".condition = "process_completed_successfully";
+        "anvil-impersonate-and-fund-ethereum-sepolia".condition = "process_completed_successfully";
+        "anvil-impersonate-and-fund-ink-sepolia".condition = "process_completed_successfully";
       };
       log_configuration = logsConfig;
       log_location = cfg.logsDir + "/sequencer.log";

--- a/nix/test-environments/example-setup-01.nix
+++ b/nix/test-environments/example-setup-01.nix
@@ -76,6 +76,10 @@ in
             114 # AAVE / USD
             121 # TAO / USD
             347 # 1INCH / USD
+            50000 # USDT / USD Pegged
+            50001 # USDC / USD Pegged
+            100000 # ExSat BTC
+            1000000 # WMON 0.2% / USDT
           ];
           publishing_criteria = [
             {
@@ -89,14 +93,14 @@ in
               always_publish_heartbeat_ms = 360000;
             }
             {
-              feed_id = 7;
+              feed_id = 50000;
               skip_publish_if_less_then_percentage = 0.5;
               always_publish_heartbeat_ms = 360000;
               peg_to_value = 1.00;
               peg_tolerance_percentage = 0.1;
             }
             {
-              feed_id = 19;
+              feed_id = 50001;
               skip_publish_if_less_then_percentage = 0.1;
               always_publish_heartbeat_ms = 360000;
               peg_to_value = 1.00;

--- a/nix/test-environments/example-setup-01.nix
+++ b/nix/test-environments/example-setup-01.nix
@@ -8,12 +8,13 @@ let
   readJson = path: builtins.fromJSON (builtins.readFile path);
 
   testKeysDir = config.devenv.root + "/nix/test-environments/test-keys";
-  deploymentFilePath = config.devenv.root + "/config/evm_contracts_deployment_v1.json";
+  deploymentV1FilePath = config.devenv.root + "/config/evm_contracts_deployment_v1.json";
+  deploymentV2FilePath = config.devenv.root + "/config/evm_contracts_deployment_v2.json";
 
   upgradeableProxyContractAddressSepolia =
-    (readJson deploymentFilePath)."ethereum-sepolia".contracts.coreContracts.UpgradeableProxy.address;
-  upgradeableProxyContractAddressHolesky =
-    (readJson deploymentFilePath)."ethereum-holesky".contracts.coreContracts.UpgradeableProxy.address;
+    (readJson deploymentV1FilePath)."ethereum-sepolia".contracts.coreContracts.UpgradeableProxy.address;
+  upgradeableProxyADFSContractAddressInk =
+    (readJson deploymentV2FilePath)."ink-sepolia".contracts.coreContracts.UpgradeableProxyADFS.address;
 
   impersonationAddress = lib.strings.fileContents "${testKeysDir}/impersonation_address";
 in
@@ -35,7 +36,7 @@ in
       b = {
         port = 8547;
         chain-id = 99999999999;
-        fork-url = "wss://ethereum-holesky-rpc.publicnode.com";
+        fork-url = "wss://ink-sepolia.drpc.org";
       };
     };
 
@@ -110,7 +111,8 @@ in
         };
         b = {
           private_key_path = "${testKeysDir}/sequencer-private-key";
-          contract_address = upgradeableProxyContractAddressHolesky;
+          contract_address = upgradeableProxyADFSContractAddressInk;
+          contract_version = 2;
           transaction_gas_limit = 20000000;
           impersonated_anvil_account = impersonationAddress;
         };

--- a/nix/test-environments/example-setup-01.nix
+++ b/nix/test-environments/example-setup-01.nix
@@ -28,12 +28,12 @@ in
     logsDir = config.devenv.root + "/logs/blocksense";
 
     anvil = {
-      a = {
+      ethereum-sepolia = {
         port = 8546;
         chain-id = 99999999999;
         fork-url = "wss://ethereum-sepolia-rpc.publicnode.com";
       };
-      b = {
+      ink-sepolia = {
         port = 8547;
         chain-id = 99999999999;
         fork-url = "wss://ink-sepolia.drpc.org";
@@ -56,7 +56,7 @@ in
       };
 
       providers = {
-        a = {
+        ethereum-sepolia = {
           # NOTE: this is an example key included directly to make the setup
           # self-contained.
           # In a production environment, use a secret manager like Agenix, to
@@ -109,7 +109,7 @@ in
             }
           ];
         };
-        b = {
+        ink-sepolia = {
           private_key_path = "${testKeysDir}/sequencer-private-key";
           contract_address = upgradeableProxyADFSContractAddressInk;
           contract_version = 2;


### PR DESCRIPTION
## Key changes

#### **Added Some Feeds**
- Introduced `ExSat BTC` and `WMON 0.2% / USDT`.
- Included USDT and USDC pegged feeds.

#### **Forking Ink-Sepolia**
- `anvil-b` now forks `ink-sepolia` instead of `ethereum-holesky`.
- Now we support ADFS contract versions in the local env setup.

#### **Renamed Anvil Instances**
- `anvil-a` → `anvil-ethereum-sepolia`
- `anvil-b` → `anvil-ink-sepolia`
- Updated dependencies in `process-compose.nix` to reflect the new names.

## How to test

To test if all works I start `process-compose` and try to read the on-chain data

### Reading data on `anvil-ethereum-sepolia`

- Read data for `USDT / USD Pegged` with id `50000`
```
cast call 0xee5a4826068c5326a7f06fd6c7cbf816f096846c --data 0x8000c350 --rpc-url http://127.0.0.1:8546 |  cut -c1-50 | cast to-dec
```

-  Read data for `USDC / USD Pegged` with id `50001`
  ```
  cast call 0xee5a4826068c5326a7f06fd6c7cbf816f096846c --data 0x8000c351 --rpc-url http://127.0.0.1:8546 |  cut -c1-50 | cast to-dec
  ```

-  Read data for `ExSat BTC` with id `100000`
  > you may want to edit the value of `interval_ms` for feed id `100000` in `config/feeds_config_v2.json`
  ```
  cast call 0xee5a4826068c5326a7f06fd6c7cbf816f096846c --data 0x800186a0 --rpc-url http://127.0.0.1:8546 |  cut -c1-50 | cast to-dec
```

-  Read data for `WMON 0.2% / USDT` with id `1000000`
  ```
   cast call 0xee5a4826068c5326a7f06fd6c7cbf816f096846c --data 0x800f4240 --rpc-url http://127.0.0.1:8546 |  cut -c1-50 | cast to-dec
  ```

### Reading data on `anvil-ink-sepolia`

-  Read data for `BTC / USD` with id `0`
  ```
  cast call 0xADF5aad6faA8f2bFD388D38434Fc45625Ebd9d3b --data 0x8200000000000000000000000000000000  --rpc-url http://127.0.0.1:8547 |  cut -c1-50 | cast to-dec
  ```
