### PR TITLE
[nix/example-setup-01]: Update `ink-sepolia` fork URL

### DIFF
--- a/nix/test-environments/example-setup-01.nix
+++ b/nix/test-environments/example-setup-01.nix
@@ -36,7 +36,7 @@ in
       ink-sepolia = {
         port = 8547;
         chain-id = 99999999999;
-        fork-url = "wss://ink-sepolia.drpc.org";
+        fork-url = "wss://ws-gel-sepolia.inkonchain.com";
       };
     };
 


### PR DESCRIPTION
While going through `process-compose`, me and @EmilIvanichkovv noticed that ink-sepolia's anvil fork fails to start from time to time. 
With this new url it seems more stable.