### PR TITLE
[docs.ws]: Add Links to our Contracts on GitHub

### DIFF
--- a/apps/docs.blocksense.network/components/sol-contracts/AbsolutePath.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/AbsolutePath.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+
 import Link from 'next/link';
 
 import { Icon } from '@blocksense/ui/Icon';
-
 import { config } from '@/config';
 import { ghContractFolder } from '@/src/constants';
 
@@ -14,8 +14,9 @@ export const AbsolutePath = ({ absolutePath }: AbsolutePathProps) => {
   return (
     <Link
       className="absolute-path__link font-semibold text-sm flex gap-2 items-center"
-      // href={`${ghContractFolder}${absolutePath}`} //use it after our repo is public on GitHub
-      href={`/coming-soon`}
+      href={`${ghContractFolder}${absolutePath}`}
+      target="_blank"
+      rel="noopener noreferrer"
     >
       <Icon
         className="my-1 dark:invert"

--- a/apps/docs.blocksense.network/components/sol-contracts/ContractsFileTree.tsx
+++ b/apps/docs.blocksense.network/components/sol-contracts/ContractsFileTree.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-// import { FileTree } from '@blocksense/docs-theme';
-// import { ghContractFolder } from '@/src/constants';
+
 import { FileTree } from 'nextra/components';
+import Link from 'next/link';
+
+import { ghContractFolder } from '@/src/constants';
 
 type TreeNode = {
   name: string;
@@ -11,7 +13,8 @@ type TreeNode = {
 };
 
 export const renderTree = ({ name, children, id, path }: TreeNode) => {
-  // const constructedHref = `${ghContractFolder}contracts/${path}`; //use it after our repo is public on GitHub
+  const constructedHref = `${ghContractFolder}contracts/${path}`;
+
   if (children) {
     return (
       <FileTree.Folder name={<span>{name}</span>} key={id} defaultOpen>
@@ -19,7 +22,11 @@ export const renderTree = ({ name, children, id, path }: TreeNode) => {
       </FileTree.Folder>
     );
   } else {
-    return <FileTree.File name={<span>{name}</span>} key={id} />;
+    return (
+      <Link href={constructedHref} target="_blank" rel="noopener noreferrer">
+        <FileTree.File name={<span>{name}</span>} key={id} />
+      </Link>
+    );
   }
 };
 


### PR DESCRIPTION
This PR adds or updates the links to our `contracts`, redirecting users to our `now-public GitHub repository`.

* **Before :**

![Screenshot from 2025-03-26 17-19-06](https://github.com/user-attachments/assets/a57d4d7a-d75f-4777-9e54-cf40a0dfc6d9)

![Screenshot from 2025-03-26 17-22-11](https://github.com/user-attachments/assets/1e3564ed-0d3d-40c6-a304-106949863992)

* **After :**

![Screenshot from 2025-03-26 17-19-40](https://github.com/user-attachments/assets/6fab38cf-bc12-4b51-81d2-6e187f9f8b68)

![Screenshot from 2025-03-26 17-22-24](https://github.com/user-attachments/assets/28d89fdb-9e17-419d-94c0-3ca2a593107a)
