### PR TITLE
[ui/docs.ws]: Implement `InfoTip` component

### DIFF
--- a/apps/docs.blocksense.network/public/icons/info.svg
+++ b/apps/docs.blocksense.network/public/icons/info.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-info-icon lucide-info"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>

--- a/libs/ts/ui/assets/icons/info.svg
+++ b/libs/ts/ui/assets/icons/info.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-info-icon lucide-info"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>

--- a/libs/ts/ui/package.json
+++ b/libs/ts/ui/package.json
@@ -31,6 +31,7 @@
     "./Popover": "./src/components/Popover/index.tsx",
     "./TextArea": "./src/components/TextArea/index.tsx",
     "./RadioGroup": "./src/components/RadioGroup/index.tsx",
+    "./InfoTip": "./src/components/InfoTip/index.tsx",
     "./utils": "./src/lib/utils.ts"
   },
   "dependencies": {

--- a/libs/ts/ui/src/components/InfoTip/InfoTip.tsx
+++ b/libs/ts/ui/src/components/InfoTip/InfoTip.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import { Tooltip } from '@blocksense/ui/Tooltip';
+import { TooltipProps } from '../Tooltip/Tooltip';
+import { Icon } from '@blocksense/ui/Icon';
+import { cn } from '@blocksense/ui/utils';
+
+type InfoTipProps = TooltipProps & {
+  iconClassName?: string;
+};
+
+export function InfoTip({
+  children,
+  iconClassName,
+  position,
+  contentClassName,
+}: InfoTipProps) {
+  return (
+    <Tooltip position={position} contentClassName={contentClassName}>
+      <Tooltip.Content>{children}</Tooltip.Content>
+      <Icon
+        icon={{
+          type: 'image',
+          src: '/icons/info.svg',
+        }}
+        ariaLabel="Info icon"
+        size="xs"
+        className={cn('invert', iconClassName)}
+      />
+    </Tooltip>
+  );
+}

--- a/libs/ts/ui/src/components/InfoTip/index.tsx
+++ b/libs/ts/ui/src/components/InfoTip/index.tsx
@@ -1,0 +1,1 @@
+export { InfoTip } from './InfoTip';

--- a/libs/ts/ui/src/components/Tooltip/Tooltip.tsx
+++ b/libs/ts/ui/src/components/Tooltip/Tooltip.tsx
@@ -7,7 +7,7 @@ import React, {
 
 import { cn } from '@blocksense/ui/utils';
 
-type TooltipProps = {
+export type TooltipProps = {
   position?: 'top' | 'right' | 'bottom' | 'left';
   children: ReactNode;
   contentClassName?: string;

--- a/libs/ts/ui/src/index.tsx
+++ b/libs/ts/ui/src/index.tsx
@@ -22,4 +22,5 @@ export * from './components/Table';
 export * from './components/Popover';
 export * from './components/TextArea';
 export * from './components/RadioGroup';
+export * from './components/InfoTip';
 export * from './lib/utils';


### PR DESCRIPTION
Used `Tooltip` & `Icon` components with `info.svg` to implement reusable and simpler component for more information with hover:

![image](https://github.com/user-attachments/assets/4e6541c2-b02e-420d-a94e-bbbf429e6c3f)
