### PR TITLE
Adding skip-publishing metrics

### DIFF
--- a/apps/sequencer/src/feeds/feed_slots_processor.rs
+++ b/apps/sequencer/src/feeds/feed_slots_processor.rs
@@ -91,7 +91,7 @@ impl FeedSlotsProcessor {
 
         let mut consumed_reports = ConsumedReports {
             is_quorum_reached: false,
-            skip_publishing: SkipDecision::DoSkip(DoSkipReason::NothingToPost),
+            skip_decision: SkipDecision::DoSkip(DoSkipReason::NothingToPost),
             ad_score: None,
             result_post_to_contract: None,
             end_slot_timestamp,
@@ -156,7 +156,7 @@ impl FeedSlotsProcessor {
             return Ok(());
         }
 
-        let skip_decision = &consumed_reports.skip_publishing;
+        let skip_decision = &consumed_reports.skip_decision;
         if let Some(feed_metrics) = &feed_metrics {
             let feed_id = self.key;
             match skip_decision {

--- a/apps/sequencer/src/providers/eth_send_utils.rs
+++ b/apps/sequencer/src/providers/eth_send_utils.rs
@@ -394,6 +394,8 @@ pub async fn eth_batch_send_to_contract(
             result
         };
 
+        inc_metric!(provider_metrics, net, total_tx_sent);
+
         let tx_result_str = format!("{tx_result:?}");
         debug!("tx_result_str={tx_result_str}");
 
@@ -447,7 +449,6 @@ pub async fn eth_batch_send_to_contract(
         "Recvd transaction receipt that took {}ms from `{}`: {:?}",
         transaction_time, net, receipt
     );
-    inc_metric!(provider_metrics, net, total_tx_sent);
 
     let gas_used_value = receipt.gas_used;
     set_metric!(provider_metrics, net, gas_used, gas_used_value);

--- a/apps/sequencer/src/providers/eth_send_utils.rs
+++ b/apps/sequencer/src/providers/eth_send_utils.rs
@@ -527,7 +527,16 @@ pub async fn eth_batch_send_to_all_contracts(
             let net = net.clone();
 
             if let Some(provider_settings) = providers_config.get(&net) {
-                if !provider_settings.is_enabled {
+                let is_enabled_value = provider_settings.is_enabled;
+                {
+                    debug!("Acquiring a read lock on provider for network {net}");
+                    let p = provider.lock().await;
+                    debug!("Acquired a read lock on provider for network {net}");
+                    let provider_metrics = p.provider_metrics.clone();
+                    set_metric!(provider_metrics, net, is_enabled, is_enabled_value);
+                    debug!("Released a read lock on provider for network {net}");
+                }
+                if !is_enabled_value {
                     warn!("Network `{net}` is not enabled; skipping it during reporting");
                     continue;
                 } else {

--- a/apps/sequencer/src/providers/provider.rs
+++ b/apps/sequencer/src/providers/provider.rs
@@ -308,7 +308,9 @@ impl RpcProvider {
             .filter(|update| {
                 self.publishing_criteria
                     .get(&update.feed_id)
-                    .is_none_or(|criteria| !update.should_skip(criteria, &self.history))
+                    .is_none_or(|criteria| {
+                        !update.should_skip(criteria, &self.history).should_skip()
+                    })
             })
             .cloned()
             .collect::<Vec<VotedFeedUpdate>>();

--- a/libs/data_feeds/src/feeds_processing.rs
+++ b/libs/data_feeds/src/feeds_processing.rs
@@ -26,6 +26,7 @@ pub struct VotedFeedUpdateWithProof {
 pub enum DontSkipReason {
     ThresholdCrossed,
     HeartbeatTimedOut,
+    NoHistory,
     NonNumericalFeed,
     OneShotFeed,
 }
@@ -34,7 +35,6 @@ pub enum DontSkipReason {
 pub enum DoSkipReason {
     TooSimilarTooSoon, // threshold not crossed and heartbeat not timed out
     UnexpectedError(String),
-    NoHistory,
     NothingToPost,
 }
 
@@ -122,7 +122,7 @@ impl VotedFeedUpdate {
                         ))
                     }
                 },
-                None => SkipDecision::DoSkip(DoSkipReason::NoHistory),
+                None => SkipDecision::DontSkip(DontSkipReason::NoHistory),
             };
             res
         } else {

--- a/libs/feeds_processing/src/utils.rs
+++ b/libs/feeds_processing/src/utils.rs
@@ -144,7 +144,7 @@ pub async fn consume_reports(
                     SkipDecision::DontSkip(DontSkipReason::NonNumericalFeed)
                 }
             } else {
-                SkipDecision::DoSkip(DoSkipReason::NoHistory)
+                SkipDecision::DontSkip(DontSkipReason::NoHistory)
             }
         } else {
             SkipDecision::DontSkip(DontSkipReason::OneShotFeed)

--- a/libs/feeds_processing/src/utils.rs
+++ b/libs/feeds_processing/src/utils.rs
@@ -48,7 +48,7 @@ pub fn check_signature(
 #[derive(Debug)]
 pub struct ConsumedReports {
     pub is_quorum_reached: bool,
-    pub skip_publishing: SkipDecision,
+    pub skip_decision: SkipDecision,
     pub ad_score: Option<f64>,
     pub result_post_to_contract: Option<VotedFeedUpdateWithProof>,
     pub end_slot_timestamp: Timestamp,
@@ -76,7 +76,7 @@ pub async fn consume_reports(
         info!("No reports found for feed: {} slot: {}!", name, &slot);
         ConsumedReports {
             is_quorum_reached: false,
-            skip_publishing: SkipDecision::DoSkip(DoSkipReason::NothingToPost),
+            skip_decision: SkipDecision::DoSkip(DoSkipReason::NothingToPost),
             ad_score: None,
             result_post_to_contract: None,
             end_slot_timestamp,
@@ -107,7 +107,7 @@ pub async fn consume_reports(
         let mut ad_score_opt: Option<f64> = None;
 
         // Oneshot feeds have no history, so we cannot perform anomaly detection on them.
-        let skip_publishing = if !is_oneshot {
+        let skip_decision = if !is_oneshot {
             if let Some(history) = history {
                 if let FeedType::Numerical(candidate_value) = result_post_to_contract.value {
                     let ad_score =
@@ -151,7 +151,7 @@ pub async fn consume_reports(
         };
         let res = ConsumedReports {
             is_quorum_reached,
-            skip_publishing,
+            skip_decision,
             ad_score: ad_score_opt,
             result_post_to_contract: Some(VotedFeedUpdateWithProof {
                 update: result_post_to_contract,

--- a/libs/prometheus/src/metrics.rs
+++ b/libs/prometheus/src/metrics.rs
@@ -162,44 +162,44 @@ pub struct ProviderMetrics {
 impl ProviderMetrics {
     pub fn new(prefix: &str) -> Result<ProviderMetrics> {
         Ok(ProviderMetrics {
-        total_tx_sent: register_int_counter_vec!(
-            format!("{}total_tx_sent", prefix),
-            "Total number of tx sent",
-            &["Network"]
-        )?,
-        gas_used: register_int_gauge_vec!(
-            format!("{}gas_used", prefix),
-            "Gas used by each transaction",
-            &["Network"]
-        )?,
-        effective_gas_price: register_int_gauge_vec!(
-            format!("{}effective_gas_price", prefix),
-            // Reference: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gettransactionreceipt.
-            "Sum of the base fee and tip paid per unit of gas",
-            &["Network"]
-        )?,
-        transaction_confirmation_time: register_int_gauge_vec!(
-            format!("{}transaction_confirmation_time", prefix),
-            "Time it took to send a transaction and receive a receipt",
-            &["Network"],
-        )?,
-        gas_price: register_int_gauge_vec!(
-            format!("{}gas_price", prefix),
-            "Current gas price in wei (base fee)",
-            &["Network"]
-        )?,
-        failed_send_tx: register_int_counter_vec!(
-            format!("{}failed_send_tx", prefix),
-            "Total number of failed tx for network",
-            &["Network"]
-        )?,
-        failed_get_receipt: register_int_counter_vec!(
-            format!("{}failed_get_receipt", prefix),
-            "Total number of failed get_receipt req-s for network",
-            &["Network"]
-        )?,
-        failed_get_gas_price: register_int_counter_vec!(
-            format!("{}failed_get_gas_price", prefix),
+            total_tx_sent: register_int_counter_vec!(
+                format!("{}total_tx_sent", prefix),
+                "Total number of tx sent",
+                &["Network"]
+            )?,
+            gas_used: register_int_gauge_vec!(
+                format!("{}gas_used", prefix),
+                "Gas used by each transaction",
+                &["Network"]
+            )?,
+            effective_gas_price: register_int_gauge_vec!(
+                format!("{}effective_gas_price", prefix),
+                // Reference: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gettransactionreceipt.
+                "Sum of the base fee and tip paid per unit of gas",
+                &["Network"]
+            )?,
+            transaction_confirmation_time: register_int_gauge_vec!(
+                format!("{}transaction_confirmation_time", prefix),
+                "Time it took to send a transaction and receive a receipt",
+                &["Network"],
+            )?,
+            gas_price: register_int_gauge_vec!(
+                format!("{}gas_price", prefix),
+                "Current gas price in wei (base fee)",
+                &["Network"]
+            )?,
+            failed_send_tx: register_int_counter_vec!(
+                format!("{}failed_send_tx", prefix),
+                "Total number of failed tx for network",
+                &["Network"]
+            )?,
+            failed_get_receipt: register_int_counter_vec!(
+                format!("{}failed_get_receipt", prefix),
+                "Total number of failed get_receipt req-s for network",
+                &["Network"]
+            )?,
+            failed_get_gas_price: register_int_counter_vec!(
+                format!("{}failed_get_gas_price", prefix),
                 "Total number of failed get_gas_price req-s for network",
                 &["Network"]
             )?,

--- a/libs/prometheus/src/metrics.rs
+++ b/libs/prometheus/src/metrics.rs
@@ -316,6 +316,17 @@ pub struct FeedsMetrics {
     pub quorums_reached: IntCounterVec,
     pub failures_to_reach_quorum: IntCounterVec,
     pub updates_to_networks: IntCounterVec,
+
+    // skip-publishing related metrics
+    pub skipped_too_similar_too_soon: IntCounterVec,
+    pub skipped_unexpected_error: IntCounterVec,
+    pub skipped_nothing_to_post: IntCounterVec,
+
+    pub updated_threshold_crossed: IntCounterVec,
+    pub updated_heartbeat_timed_out: IntCounterVec,
+    pub updated_no_history: IntCounterVec,
+    pub updated_non_numerical_feed: IntCounterVec,
+    pub updated_one_shot_feed: IntCounterVec,
 }
 
 impl FeedsMetrics {
@@ -335,6 +346,48 @@ impl FeedsMetrics {
                 format!("{}updates_to_networks", prefix),
                 "Number of updates for a given feed id per Network",
                 &["FeedId", "Network"]
+            )?,
+
+            skipped_too_similar_too_soon: register_int_counter_vec!(
+                format!("{}skipped_too_similar_too_soon", prefix),
+                "Number of updates skipped for a given feed, because value did not deviate enough quickly enough",
+                &["FeedId"]
+            )?,
+            skipped_unexpected_error: register_int_counter_vec!(
+                format!("{}skipped_unexpected_error", prefix),
+                "Number of updates skipped for a given feed, because an unexpected error occurred",
+                &["FeedId"]
+            )?,
+            skipped_nothing_to_post: register_int_counter_vec!(
+                format!("{}skipped_nothing_to_post", prefix),
+                "Number of updates skipped for a given feed, because there was nothing to post",
+                &["FeedId"]
+            )?,
+
+            updated_threshold_crossed: register_int_counter_vec!(
+                format!("{}updated_threshold_crossed", prefix),
+                "Number of updates performed for a given feed, because deviation threshold was crossed",
+                &["FeedId"]
+            )?,
+            updated_heartbeat_timed_out: register_int_counter_vec!(
+                format!("{}updated_heartbeat_timed_out", prefix),
+                "Number of updates performed for a given feed, because heartbeat timed out",
+                &["FeedId"]
+            )?,
+            updated_no_history: register_int_counter_vec!(
+                format!("{}updated_no_history", prefix),
+                "Number of updates performed for a given feed, because there was no history",
+                &["FeedId"]
+            )?,
+            updated_non_numerical_feed: register_int_counter_vec!(
+                format!("{}updated_non_numerical_feed", prefix),
+                "Number of updates performed for a given feed, because the feed is non numerical",
+                &["FeedId"]
+            )?,
+            updated_one_shot_feed: register_int_counter_vec!(
+                format!("{}updated_one_shot_feed", prefix),
+                "Number of updates performed for a given feed, because the feed is one shot",
+                &["FeedId"]
             )?,
         })
     }

--- a/libs/prometheus/src/metrics.rs
+++ b/libs/prometheus/src/metrics.rs
@@ -156,6 +156,7 @@ pub struct ProviderMetrics {
     pub success_get_max_priority_fee_per_gas: IntCounterVec,
     pub success_get_chain_id: IntCounterVec,
     pub total_timed_out_tx: IntCounterVec,
+    pub is_enabled: IntGaugeVec,
 }
 
 impl ProviderMetrics {
@@ -240,6 +241,11 @@ impl ProviderMetrics {
             total_timed_out_tx: register_int_counter_vec!(
                 format!("{}total_timed_out_tx", prefix),
                 "Total number of tx sent that reached the configured timeout before completion for network",
+                &["Network"]
+            )?,
+            is_enabled: register_int_gauge_vec!(
+                format!("{}is_enabled", prefix),
+                "Whether the network is currently enabled or not",
                 &["Network"]
             )?,
         })


### PR DESCRIPTION
These metrics are only for the per-feed configuration.

We need a separate set for the per-feed + per-network configuration.