### PR TITLE
ci(gh-actions): Add deployment for Blocksense NFT page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,9 +164,14 @@ jobs:
             path: libs/ts/ui/storybook-static
             project_name: blocksense-ui
             build_command: yarn workspace @blocksense/ui build-storybook
+          - project: nft.blocksense.network
+            path: apps/nft.blocksense.network/out
+            project_name: blocksense-nft
+            build_command: yarn workspace @blocksense/nft.blocksense.network build
     outputs:
       docsDeploymentMessage: ${{ steps.docs-ws-url.outputs.url }}
       uiDeploymentMessage: ${{ steps.ui-ws-url.outputs.url }}
+      nftDeploymentMessage: ${{ steps.nft-ws-url.outputs.url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -219,6 +224,14 @@ jobs:
         run: |
           echo "url=$UI_DEPLOY_URL" >> $GITHUB_OUTPUT
 
+      - name: Collect NFT Deployment URL
+        id: nft-ws-url
+        if: matrix.project == 'nft.blocksense.network'
+        env:
+          NFT_DEPLOY_URL: ${{ steps.deploy-website.outputs.deployment-url }}
+        run: |
+          echo "url=$NFT_DEPLOY_URL" >> $GITHUB_OUTPUT
+
   comment_on_pr:
     needs: [deploy_websites]
     runs-on: self-hosted
@@ -241,3 +254,4 @@ jobs:
             |---------------------|----------|----------------------------------------------------------------------|
             | 🌱 [Documentation](${{ needs.deploy_websites.outputs.docsDeploymentMessage }}) | ${{ steps.datetime.outputs.latest_update }} | ${{ github.sha }} |
             | 📖 [UI Components](${{ needs.deploy_websites.outputs.uiDeploymentMessage }}) | ${{ steps.datetime.outputs.latest_update }} | ${{ github.sha }} |
+            | 🏴‍☠ [NFT website](${{ needs.deploy_websites.outputs.nftDeploymentMessage }}) | ${{ steps.datetime.outputs.latest_update }} | ${{ github.sha }} |

--- a/apps/nft.blocksense.network/next.config.ts
+++ b/apps/nft.blocksense.network/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  output: 'export',
+};
+
+export default nextConfig;


### PR DESCRIPTION
## ci(gh-actions): Add deployment for Blocksense NFT project

Configured GitHub Actions to deploy the Blocksense NFT project. This includes setting the project path to `apps/nft.blocksense.network/out`, naming the project `blocksense-nft`, and using the build command `yarn workspace @blocksense/nft.blocksense.network build`. A deployment output message was also added for visibility in CI logs.

![image](https://github.com/user-attachments/assets/498db0ff-8c6f-472a-ba44-96bfdecfc3a4)


