### PR TITLE
fix(nft.blocksense.network): Update Geist and GeistMono font configuration 

### DIFF
--- a/apps/nft.blocksense.network/src/geist.ts
+++ b/apps/nft.blocksense.network/src/geist.ts
@@ -3,13 +3,13 @@ import localFont from 'next/font/local';
 export const geist = localFont({
   src: '../public/font/Geist-Regular.woff2',
   variable: '--font-geist',
-  fallback: ['system-ui', 'arial'],
-  weight: '100 900',
+  fallback: ['system-ui', 'sans-serif'],
+  display: 'swap',
 });
 
 export const geistMono = localFont({
   src: '../public/font/GeistMono-Regular.woff2',
   variable: '--font-geist-mono',
-  fallback: ['system-ui', 'arial'],
-  weight: '100 900',
+  fallback: ['monospace'],
+  display: 'swap',
 });


### PR DESCRIPTION
This PR contains a quick, fix that refines how Geist and Geist Mono fonts are loaded using next/font/local, without the need of using weight and evaluate it directly from CSS variables, in the way they're defined. 