### PR TITLE
[docs.ws/ui]: Create `Carousel stories` to our `Storybook`

### DIFF
--- a/apps/docs.blocksense.network/public/icons/chevron-left.svg
+++ b/apps/docs.blocksense.network/public/icons/chevron-left.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-left-icon lucide-chevron-left"><path d="m15 18-6-6 6-6"/></svg>

--- a/libs/ts/ui/src/components/Carousel/Carousel.stories.tsx
+++ b/libs/ts/ui/src/components/Carousel/Carousel.stories.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from './Carousel';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from '../Card';
+
+export default {
+  title: 'Components/Carousel',
+  component: Carousel,
+};
+
+const cards = [
+  {
+    title: 'Card 1',
+    description: 'Card 1 Description',
+    content: 'Card 1 content.',
+  },
+  {
+    title: 'Card 2',
+    description: 'Card 2 Description',
+    content: 'Card 2 content.',
+  },
+  {
+    title: 'Card 3',
+    description: 'Card 3 Description',
+    content: 'Card 3 content.',
+  },
+];
+
+const CarouselCard = ({
+  title,
+  description,
+  content,
+}: {
+  title: string;
+  description: string;
+  content: string;
+}) => (
+  <CarouselItem>
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p>{content}</p>
+      </CardContent>
+    </Card>
+  </CarouselItem>
+);
+
+export const CarouselHorizontal = () => {
+  return (
+    <Carousel>
+      <CarouselContent>
+        {cards.map((card, index) => (
+          <CarouselCard key={index} {...card} />
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  );
+};
+
+export const CarouselVertical = () => {
+  return (
+    <Carousel orientation="vertical">
+      <CarouselContent className="h-[400px]">
+        {cards.map((card, index) => (
+          <CarouselCard key={index} {...card} />
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  );
+};


### PR DESCRIPTION
This PR aims to add `Carousel stories` to our `Storybook`.
The `chevron-left.svg` icon is also deleted, as it is only used in the `ui library` and not in the `docs.ws` workspace.