### PR TITLE
fix(cargo-workspace): Enable `float_roundtrip` feature for `serde_json`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ blocksense-metrics = { path = "libs/metrics" }
 anyhow = "1"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"]}
 url = "2.5"
 log = "0.4"
 rand = "0.8"


### PR DESCRIPTION
This fixes a bug, introduced by [build(cargo-workspace): Get rid of unused dependencies](https://github.com/blocksense-network/blocksense/commit/bea42916774cc1df78c31835e3a678ad35797881) part of  #1205. The linked commit deletes a bunch of unused dependencies, one of which being the `cmc` crate, which in turn disables the `float_roundtrip` feature of `serde_json`, which was present before due to cargo workspace feature unification. The absence of this feature flag caused reporters' vote signatures to sometimes fail to verify due to loss of precision.

[`cmc 0.4.4` `Cargo.toml` ](https://docs.rs/crate/cmc/latest/source/Cargo.toml)
[`serde_json` `float_roundtrip` docs](https://github.com/serde-rs/json/blob/6346bb30037f31ea69b9a4eb029875e23521681c/Cargo.toml#L66)

![image](https://github.com/user-attachments/assets/bb77978c-d0c8-45dc-84e6-19e9c0296607)
