### PR TITLE
[contracts]: Add type declaration for `prettier-plugin-solidity`

### DIFF
--- a/libs/ts/contracts/@types/prettier-plugin-solidity.d.ts
+++ b/libs/ts/contracts/@types/prettier-plugin-solidity.d.ts
@@ -1,0 +1,1 @@
+declare module 'prettier-plugin-solidity';

--- a/libs/ts/contracts/tsconfig.json
+++ b/libs/ts/contracts/tsconfig.json
@@ -16,7 +16,8 @@
   "include": [
     "./scripts",
     "./test",
-    "./typechain"
+    "./typechain",
+    "./@types",
   ],
   "files": [
     "./hardhat.config.ts"


### PR DESCRIPTION
This PR adds a missing type declaration for the `prettier-plugin-solidity` package and updates the `tsconfig.json` in the `contracts` library to include the newly added `@types` directory.

### Changes

- Added a custom module declaration file: `@types/prettier-plugin-solidity.d.ts`
- Updated `tsconfig.json` to include `./@types` in the `include` section to ensure the declaration is picked up by the TypeScript compiler

### Motivation
This should prevent the following errors:
- In the ide  in the file `libs/ts/contracts/templates/encode-packed/index.ts` we see
![image](https://github.com/user-attachments/assets/ea08c62e-2437-494e-96a9-7c29088bf4c7)
- And during build:
![image](https://github.com/user-attachments/assets/34cbfa5b-53ff-4027-b116-89405edb7539)

