### PR TITLE
[oracles]: Make `just start-oracle <oracle>` great again

### DIFF
--- a/apps/oracles/crypto-price-feeds/spin.toml
+++ b/apps/oracles/crypto-price-feeds/spin.toml
@@ -7,13 +7,11 @@ authors = ["blocksense-network"]
 
 [application.trigger.settings]
 interval_time_in_seconds = 6
-sequencer = "http://gpu-server-001:8877/post_reports_batch"
-kafka_endpoint = "http://127.0.0.1:9092"
-secret_key = "536d1f9d97166eba5ff0efb8cc8dbeb856fb13d2d126ed1efc761e9955014003"
-second_consensus_secret_key = "536d1f9d97166eba5ff0efb8cc8dbeb856fb13d2d126ed1efc761e9955014003"
 reporter_id = 0
-sequencer = "http://127.0.0.1:9856"
+sequencer = "http://127.0.0.1:8877/post_reports_batch"
 secret_key = "536d1f9d97166eba5ff0efb8cc8dbeb856fb13d2d126ed1efc761e9955014003"
+second_consensus_secret_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+kafka_endpoint = "http://127.0.0.1:9092"
 
 [[trigger.oracle]]
 component = "crypto-price-feeds"
@@ -21,2946 +19,4420 @@ capabilities = []
 
 [[trigger.oracle.data_feeds]]
 id = "0"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BTC","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1,31469,31652,32295,34316],"symbol":["BTC","BTC","BTC","BTC","BTC"]}},"exchanges":{"Binance":{"symbol":["BTCUSDC","BTCUSDT"]},"BinanceTR":{"symbol":["BTC_USDT"]},"BinanceUS":{"symbol":["BTCUSDC","BTCUSDT"]},"Bitfinex":{"symbol":["BTCUSD"]},"Bitget":{"symbol":["BTCUSDC_SPBL","BTCUSDT_SPBL"]},"Bybit":{"symbol":["BTCUSDC","BTCUSDT"]},"Coinbase":{"id":["BTC-USD","BTC-USDC","BTC-USDT"]},"CryptoCom":{"instrument_name":["BTCUSD-250328","BTCUSD-250425","BTCUSD-250530","BTCUSD-250627","BTCUSD-PERP","BTC_USD","BTC_USDT"]},"GateIo":{"id":["BTC_USDC","BTC_USDT"]},"Gemini":{"symbol":["BTCUSD","BTCUSDT"]},"KuCoin":{"symbol":["BTC-USDC","BTC-USDT"]},"MEXC":{"symbol":["BTCUSDC","BTCUSDT"]},"OKX":{"instId":["BTC-USD","BTC-USDC","BTC-USDT"]},"Upbit":{"market":["USDT-BTC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "1"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BTC","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BTCUSDT"]},"BinanceTR":{"symbol":["BTC_USDT"]},"BinanceUS":{"symbol":["BTCUSDT"]},"Bitget":{"symbol":["BTCUSDT_SPBL"]},"Bybit":{"symbol":["BTCUSDT"]},"Coinbase":{"id":["BTC-USDT"]},"CryptoCom":{"instrument_name":["BTC_USDT"]},"GateIo":{"id":["BTC_USDT"]},"Gemini":{"symbol":["BTCUSDT"]},"KuCoin":{"symbol":["BTC-USDT"]},"MEXC":{"symbol":["BTCUSDT"]},"OKX":{"instId":["BTC-USDT"]},"Upbit":{"market":["USDT-BTC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "2"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BTC","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BTCUSDC"]},"BinanceUS":{"symbol":["BTCUSDC"]},"Bitget":{"symbol":["BTCUSDC_SPBL"]},"Bybit":{"symbol":["BTCUSDC"]},"Coinbase":{"id":["BTC-USDC"]},"GateIo":{"id":["BTC_USDC"]},"KuCoin":{"symbol":["BTC-USDC"]},"MEXC":{"symbol":["BTCUSDC"]},"OKX":{"instId":["BTC-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "3"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ETH","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1027,29991,33661],"symbol":["ETH","ETH","ETH"]}},"exchanges":{"Binance":{"symbol":["ETHUSDC","ETHUSDT"]},"BinanceTR":{"symbol":["ETH_USDT"]},"BinanceUS":{"symbol":["ETHUSDC","ETHUSDT"]},"Bitfinex":{"symbol":["ETHUSD"]},"Bitget":{"symbol":["ETHUSDC_SPBL","ETHUSDT_SPBL"]},"Bybit":{"symbol":["ETHUSDC","ETHUSDT"]},"Coinbase":{"id":["ETH-USD","ETH-USDC","ETH-USDT"]},"CryptoCom":{"instrument_name":["ETHUSD-250328","ETHUSD-250425","ETHUSD-250530","ETHUSD-250627","ETHUSD-PERP","ETH_USD","ETH_USDT"]},"GateIo":{"id":["ETH_USDC","ETH_USDT"]},"Gemini":{"symbol":["ETHUSD","ETHUSDT"]},"Kraken":{"pair":["ETHUSDC","ETHUSDT","XETHZUSD"],"wsname":["ETH/USD","ETH/USDC","ETH/USDT"]},"KuCoin":{"symbol":["ETH-USDC","ETH-USDT"]},"MEXC":{"symbol":["ETHUSDC","ETHUSDT"]},"OKX":{"instId":["ETH-USD","ETH-USDC","ETH-USDT"]},"Upbit":{"market":["USDT-ETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "4"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ETH","quote":"BTC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ETHBTC"]},"BinanceUS":{"symbol":["ETHBTC"]},"Bitfinex":{"symbol":["ETHBTC"]},"Bitget":{"symbol":["ETHBTC_SPBL"]},"Bybit":{"symbol":["ETHBTC"]},"Coinbase":{"id":["ETH-BTC"]},"CryptoCom":{"instrument_name":["ETH_BTC"]},"GateIo":{"id":["ETH_BTC"]},"Gemini":{"symbol":["ETHBTC"]},"KuCoin":{"symbol":["ETH-BTC"]},"MEXC":{"symbol":["ETHBTC"]},"OKX":{"instId":["ETH-BTC"]},"Upbit":{"market":["BTC-ETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "5"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ETH","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ETHUSDT"]},"BinanceTR":{"symbol":["ETH_USDT"]},"BinanceUS":{"symbol":["ETHUSDT"]},"Bitget":{"symbol":["ETHUSDT_SPBL"]},"Bybit":{"symbol":["ETHUSDT"]},"Coinbase":{"id":["ETH-USDT"]},"CryptoCom":{"instrument_name":["ETH_USDT"]},"GateIo":{"id":["ETH_USDT"]},"Gemini":{"symbol":["ETHUSDT"]},"Kraken":{"pair":["ETHUSDT"],"wsname":["ETH/USDT"]},"KuCoin":{"symbol":["ETH-USDT"]},"MEXC":{"symbol":["ETHUSDT"]},"OKX":{"instId":["ETH-USDT"]},"Upbit":{"market":["USDT-ETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "6"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ETH","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ETHUSDC"]},"BinanceUS":{"symbol":["ETHUSDC"]},"Bitget":{"symbol":["ETHUSDC_SPBL"]},"Bybit":{"symbol":["ETHUSDC"]},"Coinbase":{"id":["ETH-USDC"]},"GateIo":{"id":["ETH_USDC"]},"Kraken":{"pair":["ETHUSDC"],"wsname":["ETH/USDC"]},"KuCoin":{"symbol":["ETH-USDC"]},"MEXC":{"symbol":["ETHUSDC"]},"OKX":{"instId":["ETH-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "7"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDT","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[825],"symbol":["USDT"]}},"exchanges":{"Coinbase":{"id":["USDT-USD","USDT-USDC"]},"CryptoCom":{"instrument_name":["USDT_USD"]},"GateIo":{"id":["USDT_USD"]},"Gemini":{"symbol":["USDTUSD"]},"Kraken":{"pair":["USDTZUSD"],"wsname":["USDT/USD"]},"KuCoin":{"symbol":["USDT-USDC"]},"OKX":{"instId":["USDT-USD","USDT-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "8"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDT","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Coinbase":{"id":["USDT-USDC"]},"KuCoin":{"symbol":["USDT-USDC"]},"OKX":{"instId":["USDT-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "9"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"XRP","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[27809,52],"symbol":["XRP","XRP"]}},"exchanges":{"Binance":{"symbol":["XRPUSDC","XRPUSDT"]},"BinanceTR":{"symbol":["XRP_USDT"]},"BinanceUS":{"symbol":["XRPUSDT"]},"Bitfinex":{"symbol":["XRPUSD"]},"Bitget":{"symbol":["XRPUSDC_SPBL","XRPUSDT_SPBL"]},"Bybit":{"symbol":["XRPUSDC","XRPUSDT"]},"Coinbase":{"id":["XRP-USD","XRP-USDT"]},"CryptoCom":{"instrument_name":["XRPUSD-PERP","XRP_USD","XRP_USDT"]},"GateIo":{"id":["XRP_USDC","XRP_USDT"]},"Gemini":{"symbol":["XRPUSD"]},"Kraken":{"pair":["XRPUSDC","XRPUSDT","XXRPZUSD"],"wsname":["XRP/USD","XRP/USDC","XRP/USDT"]},"KuCoin":{"symbol":["XRP-USDC","XRP-USDT"]},"MEXC":{"symbol":["XRPUSDC","XRPUSDT"]},"OKX":{"instId":["XRP-USD","XRP-USDC","XRP-USDT"]},"Upbit":{"market":["USDT-XRP"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "10"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"XRP","quote":"BNB"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["XRPBNB"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "11"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"XRP","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["XRPUSDT"]},"BinanceTR":{"symbol":["XRP_USDT"]},"BinanceUS":{"symbol":["XRPUSDT"]},"Bitget":{"symbol":["XRPUSDT_SPBL"]},"Bybit":{"symbol":["XRPUSDT"]},"Coinbase":{"id":["XRP-USDT"]},"CryptoCom":{"instrument_name":["XRP_USDT"]},"GateIo":{"id":["XRP_USDT"]},"Kraken":{"pair":["XRPUSDT"],"wsname":["XRP/USDT"]},"KuCoin":{"symbol":["XRP-USDT"]},"MEXC":{"symbol":["XRPUSDT"]},"OKX":{"instId":["XRP-USDT"]},"Upbit":{"market":["USDT-XRP"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "12"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"XRP","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["XRPUSDC"]},"Bitget":{"symbol":["XRPUSDC_SPBL"]},"Bybit":{"symbol":["XRPUSDC"]},"GateIo":{"id":["XRP_USDC"]},"Kraken":{"pair":["XRPUSDC"],"wsname":["XRP/USDC"]},"KuCoin":{"symbol":["XRP-USDC"]},"MEXC":{"symbol":["XRPUSDC"]},"OKX":{"instId":["XRP-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "13"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BNB","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1839],"symbol":["BNB"]}},"exchanges":{"Binance":{"symbol":["BNBUSDC","BNBUSDT"]},"BinanceTR":{"symbol":["BNB_USDT"]},"BinanceUS":{"symbol":["BNBUSDT"]},"Bitget":{"symbol":["BNBUSDC_SPBL","BNBUSDT_SPBL"]},"Bybit":{"symbol":["BNBUSDC","BNBUSDT"]},"GateIo":{"id":["BNB_USDC","BNB_USDT"]},"KuCoin":{"symbol":["BNB-USDC","BNB-USDT"]},"MEXC":{"symbol":["BNBUSDC","BNBUSDT"]},"OKX":{"instId":["BNB-USDC","BNB-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "14"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BNB","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BNBUSDT"]},"BinanceTR":{"symbol":["BNB_USDT"]},"BinanceUS":{"symbol":["BNBUSDT"]},"Bitget":{"symbol":["BNBUSDT_SPBL"]},"Bybit":{"symbol":["BNBUSDT"]},"GateIo":{"id":["BNB_USDT"]},"KuCoin":{"symbol":["BNB-USDT"]},"MEXC":{"symbol":["BNBUSDT"]},"OKX":{"instId":["BNB-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "15"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BNB","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BNBUSDC"]},"Bitget":{"symbol":["BNBUSDC_SPBL"]},"Bybit":{"symbol":["BNBUSDC"]},"GateIo":{"id":["BNB_USDC"]},"KuCoin":{"symbol":["BNB-USDC"]},"MEXC":{"symbol":["BNBUSDC"]},"OKX":{"instId":["BNB-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "16"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SOL","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[16116,28825,5426],"symbol":["SOL","SOL","SOL"]}},"exchanges":{"Binance":{"symbol":["SOLUSDC","SOLUSDT"]},"BinanceTR":{"symbol":["SOL_USDT"]},"BinanceUS":{"symbol":["SOLUSDC","SOLUSDT"]},"Bitfinex":{"symbol":["SOLUSD"]},"Bitget":{"symbol":["SOLUSDC_SPBL","SOLUSDT_SPBL"]},"Bybit":{"symbol":["SOLUSDC","SOLUSDT"]},"Coinbase":{"id":["SOL-USD","SOL-USDT"]},"CryptoCom":{"instrument_name":["SOLUSD-PERP","SOL_USD","SOL_USDT"]},"GateIo":{"id":["SOL_USDC","SOL_USDT"]},"Gemini":{"symbol":["SOLUSD"]},"Kraken":{"pair":["SOLUSD","SOLUSDC","SOLUSDT"],"wsname":["SOL/USD","SOL/USDC","SOL/USDT"]},"KuCoin":{"symbol":["SOL-USDC","SOL-USDT"]},"MEXC":{"symbol":["SOLUSDC","SOLUSDT"]},"OKX":{"instId":["SOL-USD","SOL-USDC","SOL-USDT"]},"Upbit":{"market":["USDT-SOL"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "17"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SOL","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SOLUSDT"]},"BinanceTR":{"symbol":["SOL_USDT"]},"BinanceUS":{"symbol":["SOLUSDT"]},"Bitget":{"symbol":["SOLUSDT_SPBL"]},"Bybit":{"symbol":["SOLUSDT"]},"Coinbase":{"id":["SOL-USDT"]},"CryptoCom":{"instrument_name":["SOL_USDT"]},"GateIo":{"id":["SOL_USDT"]},"Kraken":{"pair":["SOLUSDT"],"wsname":["SOL/USDT"]},"KuCoin":{"symbol":["SOL-USDT"]},"MEXC":{"symbol":["SOLUSDT"]},"OKX":{"instId":["SOL-USDT"]},"Upbit":{"market":["USDT-SOL"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "18"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SOL","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SOLUSDC"]},"BinanceUS":{"symbol":["SOLUSDC"]},"Bitget":{"symbol":["SOLUSDC_SPBL"]},"Bybit":{"symbol":["SOLUSDC"]},"GateIo":{"id":["SOL_USDC"]},"Kraken":{"pair":["SOLUSDC"],"wsname":["SOL/USDC"]},"KuCoin":{"symbol":["SOL-USDC"]},"MEXC":{"symbol":["SOLUSDC"]},"OKX":{"instId":["SOL-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "19"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDC","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[3408],"symbol":["USDC"]}},"exchanges":{"Binance":{"symbol":["USDCUSDT"]},"BinanceTR":{"symbol":["USDC_USDT"]},"BinanceUS":{"symbol":["USDCUSDT"]},"Bitget":{"symbol":["USDCUSDT_SPBL"]},"Bybit":{"symbol":["USDCUSDT"]},"GateIo":{"id":["USDC_USDT"]},"Gemini":{"symbol":["USDCUSD"]},"Kraken":{"pair":["USDCUSD","USDCUSDT"],"wsname":["USDC/USD","USDC/USDT"]},"KuCoin":{"symbol":["USDC-USDT"]},"MEXC":{"symbol":["USDCUSDT"]},"OKX":{"instId":["USDC-USDT"]},"Upbit":{"market":["USDT-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "20"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"USDC","quote":"BNB"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["USDCBNB"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "21"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDC","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["USDCUSDT"]},"BinanceTR":{"symbol":["USDC_USDT"]},"BinanceUS":{"symbol":["USDCUSDT"]},"Bitget":{"symbol":["USDCUSDT_SPBL"]},"Bybit":{"symbol":["USDCUSDT"]},"GateIo":{"id":["USDC_USDT"]},"Kraken":{"pair":["USDCUSDT"],"wsname":["USDC/USDT"]},"KuCoin":{"symbol":["USDC-USDT"]},"MEXC":{"symbol":["USDCUSDT"]},"OKX":{"instId":["USDC-USDT"]},"Upbit":{"market":["USDT-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "22"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ADA","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[2010],"symbol":["ADA"]}},"exchanges":{"Binance":{"symbol":["ADAUSDC","ADAUSDT"]},"BinanceTR":{"symbol":["ADA_USDT"]},"BinanceUS":{"symbol":["ADAUSDC","ADAUSDT"]},"Bitfinex":{"symbol":["ADAUSD"]},"Bitget":{"symbol":["ADAUSDC_SPBL","ADAUSDT_SPBL"]},"Bybit":{"symbol":["ADAUSDC","ADAUSDT"]},"Coinbase":{"id":["ADA-USD","ADA-USDC","ADA-USDT"]},"CryptoCom":{"instrument_name":["ADAUSD-PERP","ADA_USD","ADA_USDT"]},"GateIo":{"id":["ADA_USDC","ADA_USDT"]},"Kraken":{"pair":["ADAUSD","ADAUSDC","ADAUSDT"],"wsname":["ADA/USD","ADA/USDC","ADA/USDT"]},"KuCoin":{"symbol":["ADA-USDC","ADA-USDT"]},"MEXC":{"symbol":["ADAUSDC","ADAUSDT"]},"OKX":{"instId":["ADA-USDC","ADA-USDT"]},"Upbit":{"market":["USDT-ADA"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "23"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ADA","quote":"BNB"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ADABNB"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "24"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ADA","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ADAUSDT"]},"BinanceTR":{"symbol":["ADA_USDT"]},"BinanceUS":{"symbol":["ADAUSDT"]},"Bitget":{"symbol":["ADAUSDT_SPBL"]},"Bybit":{"symbol":["ADAUSDT"]},"Coinbase":{"id":["ADA-USDT"]},"CryptoCom":{"instrument_name":["ADA_USDT"]},"GateIo":{"id":["ADA_USDT"]},"Kraken":{"pair":["ADAUSDT"],"wsname":["ADA/USDT"]},"KuCoin":{"symbol":["ADA-USDT"]},"MEXC":{"symbol":["ADAUSDT"]},"OKX":{"instId":["ADA-USDT"]},"Upbit":{"market":["USDT-ADA"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "25"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ADA","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ADAUSDC"]},"BinanceUS":{"symbol":["ADAUSDC"]},"Bitget":{"symbol":["ADAUSDC_SPBL"]},"Bybit":{"symbol":["ADAUSDC"]},"Coinbase":{"id":["ADA-USDC"]},"GateIo":{"id":["ADA_USDC"]},"Kraken":{"pair":["ADAUSDC"],"wsname":["ADA/USDC"]},"KuCoin":{"symbol":["ADA-USDC"]},"MEXC":{"symbol":["ADAUSDC"]},"OKX":{"instId":["ADA-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "26"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DOGE","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[27134,28384,28438,28872,29096,29403,30548,30852,31093,32756,32778,33007,33019,33736,34349,74],"symbol":["DOGE","DOGE","DOGE","DOGE","DOGE","DOGE","DOGE","DOGE","DOGE","DOGE","DOGE","DOGE","DOGE","DOGE","DOGE","DOGE"]}},"exchanges":{"Binance":{"symbol":["DOGEUSDC","DOGEUSDT"]},"BinanceTR":{"symbol":["DOGE_USDT"]},"BinanceUS":{"symbol":["DOGEUSDT"]},"Bitfinex":{"symbol":["DOGE:USD"]},"Bitget":{"symbol":["DOGEUSDC_SPBL","DOGEUSDT_SPBL"]},"Bybit":{"symbol":["DOGEUSDC","DOGEUSDT"]},"Coinbase":{"id":["DOGE-USD","DOGE-USDT"]},"CryptoCom":{"instrument_name":["DOGEUSD-PERP","DOGE_USD","DOGE_USDT"]},"GateIo":{"id":["DOGE_USDC","DOGE_USDT"]},"Gemini":{"symbol":["DOGEUSD"]},"KuCoin":{"symbol":["DOGE-USDC","DOGE-USDT"]},"MEXC":{"symbol":["DOGEUSDC","DOGEUSDT"]},"OKX":{"instId":["DOGE-USD","DOGE-USDC","DOGE-USDT"]},"Upbit":{"market":["USDT-DOGE"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "27"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DOGE","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["DOGEUSDT"]},"BinanceTR":{"symbol":["DOGE_USDT"]},"BinanceUS":{"symbol":["DOGEUSDT"]},"Bitget":{"symbol":["DOGEUSDT_SPBL"]},"Bybit":{"symbol":["DOGEUSDT"]},"Coinbase":{"id":["DOGE-USDT"]},"CryptoCom":{"instrument_name":["DOGE_USDT"]},"GateIo":{"id":["DOGE_USDT"]},"KuCoin":{"symbol":["DOGE-USDT"]},"MEXC":{"symbol":["DOGEUSDT"]},"OKX":{"instId":["DOGE-USDT"]},"Upbit":{"market":["USDT-DOGE"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "28"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DOGE","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["DOGEUSDC"]},"Bitget":{"symbol":["DOGEUSDC_SPBL"]},"Bybit":{"symbol":["DOGEUSDC"]},"GateIo":{"id":["DOGE_USDC"]},"KuCoin":{"symbol":["DOGE-USDC"]},"MEXC":{"symbol":["DOGEUSDC"]},"OKX":{"instId":["DOGE-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "29"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"TRX","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1958],"symbol":["TRX"]}},"exchanges":{"Binance":{"symbol":["TRXUSDC","TRXUSDT"]},"BinanceTR":{"symbol":["TRX_USDT"]},"BinanceUS":{"symbol":["TRXUSDT"]},"Bitfinex":{"symbol":["TRXUSD"]},"Bitget":{"symbol":["TRXUSDC_SPBL","TRXUSDT_SPBL"]},"Bybit":{"symbol":["TRXUSDC","TRXUSDT"]},"GateIo":{"id":["TRX_USDC","TRX_USDT"]},"Kraken":{"pair":["TRXUSD"],"wsname":["TRX/USD"]},"KuCoin":{"symbol":["TRX-USDC","TRX-USDT"]},"MEXC":{"symbol":["TRXUSDC","TRXUSDT"]},"OKX":{"instId":["TRX-USDC","TRX-USDT"]},"Upbit":{"market":["USDT-TRX"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "30"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"TRX","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["TRXUSDT"]},"BinanceTR":{"symbol":["TRX_USDT"]},"BinanceUS":{"symbol":["TRXUSDT"]},"Bitget":{"symbol":["TRXUSDT_SPBL"]},"Bybit":{"symbol":["TRXUSDT"]},"GateIo":{"id":["TRX_USDT"]},"KuCoin":{"symbol":["TRX-USDT"]},"MEXC":{"symbol":["TRXUSDT"]},"OKX":{"instId":["TRX-USDT"]},"Upbit":{"market":["USDT-TRX"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "31"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"TRX","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["TRXUSDC"]},"Bitget":{"symbol":["TRXUSDC_SPBL"]},"Bybit":{"symbol":["TRXUSDC"]},"GateIo":{"id":["TRX_USDC"]},"KuCoin":{"symbol":["TRX-USDC"]},"MEXC":{"symbol":["TRXUSDC"]},"OKX":{"instId":["TRX-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "32"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"wBTC","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[3717],"symbol":["WBTC"]}},"exchanges":{"Binance":{"symbol":["WBTCUSDT"]},"Bitget":{"symbol":["WBTCUSDT_SPBL"]},"Bybit":{"symbol":["WBTCUSDT"]},"Coinbase":{"id":["WBTC-USD"]},"CryptoCom":{"instrument_name":["WBTC_USD"]},"GateIo":{"id":["WBTC_USDT"]},"Kraken":{"pair":["WBTCUSD"],"wsname":["WBTC/USD"]},"KuCoin":{"symbol":["WBTC-USDT"]},"MEXC":{"symbol":["WBTCUSDC","WBTCUSDT"]},"OKX":{"instId":["WBTC-USDC","WBTC-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "33"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"wBTC","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["WBTCUSDT"]},"Bitget":{"symbol":["WBTCUSDT_SPBL"]},"Bybit":{"symbol":["WBTCUSDT"]},"GateIo":{"id":["WBTC_USDT"]},"KuCoin":{"symbol":["WBTC-USDT"]},"MEXC":{"symbol":["WBTCUSDT"]},"OKX":{"instId":["WBTC-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "34"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"wBTC","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"MEXC":{"symbol":["WBTCUSDC"]},"OKX":{"instId":["WBTC-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "35"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"LINK","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1975],"symbol":["LINK"]}},"exchanges":{"Binance":{"symbol":["LINKUSDC","LINKUSDT"]},"BinanceTR":{"symbol":["LINK_USDT"]},"BinanceUS":{"symbol":["LINKUSDT"]},"Bitfinex":{"symbol":["LINK:USD"]},"Bitget":{"symbol":["LINKUSDC_SPBL","LINKUSDT_SPBL"]},"Bybit":{"symbol":["LINKUSDC","LINKUSDT"]},"Coinbase":{"id":["LINK-USD","LINK-USDT"]},"CryptoCom":{"instrument_name":["LINKUSD-PERP","LINK_USD","LINK_USDT"]},"GateIo":{"id":["LINK_USDC","LINK_USDT"]},"Gemini":{"symbol":["LINKUSD"]},"Kraken":{"pair":["LINKUSD","LINKUSDC","LINKUSDT"],"wsname":["LINK/USD","LINK/USDC","LINK/USDT"]},"KuCoin":{"symbol":["LINK-USDC","LINK-USDT"]},"MEXC":{"symbol":["LINKUSDC","LINKUSDT"]},"OKX":{"instId":["LINK-USD","LINK-USDC","LINK-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "36"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"LINK","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["LINKETH"]},"Coinbase":{"id":["LINK-ETH"]},"GateIo":{"id":["LINK_ETH"]},"Gemini":{"symbol":["LINKETH"]},"Kraken":{"pair":["LINKETH"],"wsname":["LINK/ETH"]},"MEXC":{"symbol":["LINKETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "37"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"LINK","quote":"BNB"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["LINKBNB"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "38"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"LINK","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["LINKUSDT"]},"BinanceTR":{"symbol":["LINK_USDT"]},"BinanceUS":{"symbol":["LINKUSDT"]},"Bitget":{"symbol":["LINKUSDT_SPBL"]},"Bybit":{"symbol":["LINKUSDT"]},"Coinbase":{"id":["LINK-USDT"]},"CryptoCom":{"instrument_name":["LINK_USDT"]},"GateIo":{"id":["LINK_USDT"]},"Kraken":{"pair":["LINKUSDT"],"wsname":["LINK/USDT"]},"KuCoin":{"symbol":["LINK-USDT"]},"MEXC":{"symbol":["LINKUSDT"]},"OKX":{"instId":["LINK-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "39"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"LINK","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["LINKUSDC"]},"Bitget":{"symbol":["LINKUSDC_SPBL"]},"Bybit":{"symbol":["LINKUSDC"]},"GateIo":{"id":["LINK_USDC"]},"Kraken":{"pair":["LINKUSDC"],"wsname":["LINK/USDC"]},"KuCoin":{"symbol":["LINK-USDC"]},"MEXC":{"symbol":["LINKUSDC"]},"OKX":{"instId":["LINK-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "40"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"HBAR","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[4642],"symbol":["HBAR"]}},"exchanges":{"Binance":{"symbol":["HBARUSDC","HBARUSDT"]},"BinanceUS":{"symbol":["HBARUSDT"]},"Bitget":{"symbol":["HBARUSDT_SPBL"]},"Bybit":{"symbol":["HBARUSDT"]},"Coinbase":{"id":["HBAR-USD","HBAR-USDT"]},"CryptoCom":{"instrument_name":["HBARUSD-PERP","HBAR_USD","HBAR_USDT"]},"GateIo":{"id":["HBAR_USDT"]},"KuCoin":{"symbol":["HBAR-USDT"]},"MEXC":{"symbol":["HBARUSDC","HBARUSDT"]},"OKX":{"instId":["HBAR-USDC","HBAR-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "41"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"HBAR","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["HBARUSDT"]},"BinanceUS":{"symbol":["HBARUSDT"]},"Bitget":{"symbol":["HBARUSDT_SPBL"]},"Bybit":{"symbol":["HBARUSDT"]},"Coinbase":{"id":["HBAR-USDT"]},"CryptoCom":{"instrument_name":["HBAR_USDT"]},"GateIo":{"id":["HBAR_USDT"]},"KuCoin":{"symbol":["HBAR-USDT"]},"MEXC":{"symbol":["HBARUSDT"]},"OKX":{"instId":["HBAR-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "42"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"HBAR","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["HBARUSDC"]},"MEXC":{"symbol":["HBARUSDC"]},"OKX":{"instId":["HBAR-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "43"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDS","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[17285,33039,33452],"symbol":["USDS","USDS","USDs"]}},"exchanges":{"Binance":{"symbol":["USDSUSDC","USDSUSDT"]},"Bitget":{"symbol":["USDSUSDT_SPBL"]},"Kraken":{"pair":["USDSUSD"],"wsname":["USDS/USD"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "44"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDS","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["USDSUSDT"]},"Bitget":{"symbol":["USDSUSDT_SPBL"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "45"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDS","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["USDSUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "46"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"XLM","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[512],"symbol":["XLM"]}},"exchanges":{"Binance":{"symbol":["XLMUSDC","XLMUSDT"]},"BinanceTR":{"symbol":["XLM_USDT"]},"BinanceUS":{"symbol":["XLMUSDT"]},"Bitfinex":{"symbol":["XLMUSD"]},"Bitget":{"symbol":["XLMUSDC_SPBL","XLMUSDT_SPBL"]},"Bybit":{"symbol":["XLMUSDC","XLMUSDT"]},"Coinbase":{"id":["XLM-USD","XLM-USDT"]},"CryptoCom":{"instrument_name":["XLMUSD-PERP","XLM_USD","XLM_USDT"]},"GateIo":{"id":["XLM_USDT"]},"Kraken":{"pair":["XXLMZUSD"],"wsname":["XLM/USD"]},"KuCoin":{"symbol":["XLM-USDT"]},"MEXC":{"symbol":["XLMUSDC","XLMUSDT"]},"OKX":{"instId":["XLM-USDC","XLM-USDT"]},"Upbit":{"market":["USDT-XLM"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "47"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"XLM","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["XLMUSDT"]},"BinanceTR":{"symbol":["XLM_USDT"]},"BinanceUS":{"symbol":["XLMUSDT"]},"Bitget":{"symbol":["XLMUSDT_SPBL"]},"Bybit":{"symbol":["XLMUSDT"]},"Coinbase":{"id":["XLM-USDT"]},"CryptoCom":{"instrument_name":["XLM_USDT"]},"GateIo":{"id":["XLM_USDT"]},"KuCoin":{"symbol":["XLM-USDT"]},"MEXC":{"symbol":["XLMUSDT"]},"OKX":{"instId":["XLM-USDT"]},"Upbit":{"market":["USDT-XLM"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "48"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"XLM","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["XLMUSDC"]},"Bitget":{"symbol":["XLMUSDC_SPBL"]},"Bybit":{"symbol":["XLMUSDC"]},"MEXC":{"symbol":["XLMUSDC"]},"OKX":{"instId":["XLM-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "49"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"AVAX","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[5805],"symbol":["AVAX"]}},"exchanges":{"Binance":{"symbol":["AVAXUSDC","AVAXUSDT"]},"BinanceTR":{"symbol":["AVAX_USDT"]},"BinanceUS":{"symbol":["AVAXUSDT"]},"Bitfinex":{"symbol":["AVAX:USD"]},"Bitget":{"symbol":["AVAXUSDC_SPBL","AVAXUSDT_SPBL"]},"Bybit":{"symbol":["AVAXUSDC","AVAXUSDT"]},"Coinbase":{"id":["AVAX-USD","AVAX-USDT"]},"CryptoCom":{"instrument_name":["AVAXUSD-PERP","AVAX_USD","AVAX_USDT"]},"GateIo":{"id":["AVAX_USDC","AVAX_USDT"]},"Gemini":{"symbol":["AVAXUSD"]},"Kraken":{"pair":["AVAXUSD","AVAXUSDC","AVAXUSDT"],"wsname":["AVAX/USD","AVAX/USDC","AVAX/USDT"]},"KuCoin":{"symbol":["AVAX-USDC","AVAX-USDT"]},"MEXC":{"symbol":["AVAXUSDC","AVAXUSDT"]},"OKX":{"instId":["AVAX-USD","AVAX-USDC","AVAX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "50"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"AVAX","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["AVAXUSDT"]},"BinanceTR":{"symbol":["AVAX_USDT"]},"BinanceUS":{"symbol":["AVAXUSDT"]},"Bitget":{"symbol":["AVAXUSDT_SPBL"]},"Bybit":{"symbol":["AVAXUSDT"]},"Coinbase":{"id":["AVAX-USDT"]},"CryptoCom":{"instrument_name":["AVAX_USDT"]},"GateIo":{"id":["AVAX_USDT"]},"Kraken":{"pair":["AVAXUSDT"],"wsname":["AVAX/USDT"]},"KuCoin":{"symbol":["AVAX-USDT"]},"MEXC":{"symbol":["AVAXUSDT"]},"OKX":{"instId":["AVAX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "51"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"AVAX","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["AVAXUSDC"]},"Bitget":{"symbol":["AVAXUSDC_SPBL"]},"Bybit":{"symbol":["AVAXUSDC"]},"GateIo":{"id":["AVAX_USDC"]},"Kraken":{"pair":["AVAXUSDC"],"wsname":["AVAX/USDC"]},"KuCoin":{"symbol":["AVAX-USDC"]},"MEXC":{"symbol":["AVAXUSDC"]},"OKX":{"instId":["AVAX-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "52"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SHIB","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[29430,30105,31501,33894,34398,5994],"symbol":["SHIB","SHIB","SHIB","SHIB","SHIB","SHIB"]}},"exchanges":{"Binance":{"symbol":["SHIBUSDC","SHIBUSDT"]},"BinanceTR":{"symbol":["SHIB_USDT"]},"BinanceUS":{"symbol":["SHIBUSDT"]},"Bitfinex":{"symbol":["SHIB:USD"]},"Bitget":{"symbol":["SHIBUSDC_SPBL","SHIBUSDT_SPBL"]},"Bybit":{"symbol":["SHIBUSDC","SHIBUSDT"]},"Coinbase":{"id":["SHIB-USD","SHIB-USDT"]},"CryptoCom":{"instrument_name":["SHIBUSD-PERP","SHIB_USD","SHIB_USDT"]},"GateIo":{"id":["SHIB_USDC","SHIB_USDT"]},"Gemini":{"symbol":["SHIBUSD"]},"Kraken":{"pair":["SHIBUSD","SHIBUSDC","SHIBUSDT"],"wsname":["SHIB/USD","SHIB/USDC","SHIB/USDT"]},"KuCoin":{"symbol":["SHIB-USDC","SHIB-USDT"]},"MEXC":{"symbol":["SHIBUSDC","SHIBUSDT"]},"OKX":{"instId":["SHIB-USD","SHIB-USDC","SHIB-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "53"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SHIB","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SHIBUSDT"]},"BinanceTR":{"symbol":["SHIB_USDT"]},"BinanceUS":{"symbol":["SHIBUSDT"]},"Bitget":{"symbol":["SHIBUSDT_SPBL"]},"Bybit":{"symbol":["SHIBUSDT"]},"Coinbase":{"id":["SHIB-USDT"]},"CryptoCom":{"instrument_name":["SHIB_USDT"]},"GateIo":{"id":["SHIB_USDT"]},"Kraken":{"pair":["SHIBUSDT"],"wsname":["SHIB/USDT"]},"KuCoin":{"symbol":["SHIB-USDT"]},"MEXC":{"symbol":["SHIBUSDT"]},"OKX":{"instId":["SHIB-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "54"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SHIB","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SHIBUSDC"]},"Bitget":{"symbol":["SHIBUSDC_SPBL"]},"Bybit":{"symbol":["SHIBUSDC"]},"GateIo":{"id":["SHIB_USDC"]},"Kraken":{"pair":["SHIBUSDC"],"wsname":["SHIB/USDC"]},"KuCoin":{"symbol":["SHIB-USDC"]},"MEXC":{"symbol":["SHIBUSDC"]},"OKX":{"instId":["SHIB-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "55"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SUI","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[20947],"symbol":["SUI"]}},"exchanges":{"Binance":{"symbol":["SUIUSDC","SUIUSDT"]},"BinanceUS":{"symbol":["SUIUSDT"]},"Bitfinex":{"symbol":["SUIUSD"]},"Bitget":{"symbol":["SUIUSDC_SPBL","SUIUSDT_SPBL"]},"Bybit":{"symbol":["SUIUSDC","SUIUSDT"]},"Coinbase":{"id":["SUI-USD"]},"CryptoCom":{"instrument_name":["SUIUSD-PERP","SUI_USD","SUI_USDT"]},"GateIo":{"id":["SUI_USDC","SUI_USDT"]},"Kraken":{"pair":["SUIUSD"],"wsname":["SUI/USD"]},"KuCoin":{"symbol":["SUI-USDC","SUI-USDT"]},"MEXC":{"symbol":["SUIUSDC","SUIUSDT"]},"OKX":{"instId":["SUI-USD","SUI-USDC","SUI-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "56"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SUI","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SUIUSDT"]},"BinanceUS":{"symbol":["SUIUSDT"]},"Bitget":{"symbol":["SUIUSDT_SPBL"]},"Bybit":{"symbol":["SUIUSDT"]},"CryptoCom":{"instrument_name":["SUI_USDT"]},"GateIo":{"id":["SUI_USDT"]},"KuCoin":{"symbol":["SUI-USDT"]},"MEXC":{"symbol":["SUIUSDT"]},"OKX":{"instId":["SUI-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "57"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SUI","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SUIUSDC"]},"Bitget":{"symbol":["SUIUSDC_SPBL"]},"Bybit":{"symbol":["SUIUSDC"]},"GateIo":{"id":["SUI_USDC"]},"KuCoin":{"symbol":["SUI-USDC"]},"MEXC":{"symbol":["SUIUSDC"]},"OKX":{"instId":["SUI-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "58"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BCH","quote":"BNB"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BCHBNB"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "59"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BCH","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1831],"symbol":["BCH"]}},"exchanges":{"Binance":{"symbol":["BCHUSDC","BCHUSDT"]},"BinanceUS":{"symbol":["BCHUSDT"]},"Bitget":{"symbol":["BCHUSDC_SPBL","BCHUSDT_SPBL"]},"Bybit":{"symbol":["BCHUSDC","BCHUSDT"]},"Coinbase":{"id":["BCH-USD"]},"CryptoCom":{"instrument_name":["BCHUSD-PERP","BCH_USD","BCH_USDT"]},"GateIo":{"id":["BCH_USDC","BCH_USDT"]},"Gemini":{"symbol":["BCHUSD"]},"Kraken":{"pair":["BCHUSD","BCHUSDC","BCHUSDT"],"wsname":["BCH/USD","BCH/USDC","BCH/USDT"]},"KuCoin":{"symbol":["BCH-USDC","BCH-USDT"]},"MEXC":{"symbol":["BCHUSDC","BCHUSDT"]},"OKX":{"instId":["BCH-USDC","BCH-USDT"]},"Upbit":{"market":["USDT-BCH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "60"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BCH","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BCHUSDT"]},"BinanceUS":{"symbol":["BCHUSDT"]},"Bitget":{"symbol":["BCHUSDT_SPBL"]},"Bybit":{"symbol":["BCHUSDT"]},"CryptoCom":{"instrument_name":["BCH_USDT"]},"GateIo":{"id":["BCH_USDT"]},"Kraken":{"pair":["BCHUSDT"],"wsname":["BCH/USDT"]},"KuCoin":{"symbol":["BCH-USDT"]},"MEXC":{"symbol":["BCHUSDT"]},"OKX":{"instId":["BCH-USDT"]},"Upbit":{"market":["USDT-BCH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "61"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BCH","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BCHUSDC"]},"Bitget":{"symbol":["BCHUSDC_SPBL"]},"Bybit":{"symbol":["BCHUSDC"]},"GateIo":{"id":["BCH_USDC"]},"Kraken":{"pair":["BCHUSDC"],"wsname":["BCH/USDC"]},"KuCoin":{"symbol":["BCH-USDC"]},"MEXC":{"symbol":["BCHUSDC"]},"OKX":{"instId":["BCH-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "62"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"LTC","quote":"BNB"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["LTCBNB"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "63"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"LTC","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[2],"symbol":["LTC"]}},"exchanges":{"Binance":{"symbol":["LTCUSDC","LTCUSDT"]},"BinanceUS":{"symbol":["LTCUSDT"]},"Bitfinex":{"symbol":["LTCUSD"]},"Bitget":{"symbol":["LTCUSDC_SPBL","LTCUSDT_SPBL"]},"Bybit":{"symbol":["LTCUSDC","LTCUSDT"]},"Coinbase":{"id":["LTC-USD"]},"CryptoCom":{"instrument_name":["LTCUSD-PERP","LTC_USD","LTC_USDT"]},"GateIo":{"id":["LTC_USDC","LTC_USDT"]},"Gemini":{"symbol":["LTCUSD"]},"Kraken":{"pair":["LTCUSDC","LTCUSDT","XLTCZUSD"],"wsname":["LTC/USD","LTC/USDC","LTC/USDT"]},"KuCoin":{"symbol":["LTC-USDC","LTC-USDT"]},"MEXC":{"symbol":["LTCUSDC","LTCUSDT"]},"OKX":{"instId":["LTC-USD","LTC-USDC","LTC-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "64"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"LTC","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["LTCUSDT"]},"BinanceUS":{"symbol":["LTCUSDT"]},"Bitget":{"symbol":["LTCUSDT_SPBL"]},"Bybit":{"symbol":["LTCUSDT"]},"CryptoCom":{"instrument_name":["LTC_USDT"]},"GateIo":{"id":["LTC_USDT"]},"Kraken":{"pair":["LTCUSDT"],"wsname":["LTC/USDT"]},"KuCoin":{"symbol":["LTC-USDT"]},"MEXC":{"symbol":["LTCUSDT"]},"OKX":{"instId":["LTC-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "65"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"LTC","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["LTCUSDC"]},"Bitget":{"symbol":["LTCUSDC_SPBL"]},"Bybit":{"symbol":["LTCUSDC"]},"GateIo":{"id":["LTC_USDC"]},"Kraken":{"pair":["LTCUSDC"],"wsname":["LTC/USDC"]},"KuCoin":{"symbol":["LTC-USDC"]},"MEXC":{"symbol":["LTCUSDC"]},"OKX":{"instId":["LTC-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "66"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TON","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[11419,6890],"symbol":["TON","TON"]}},"exchanges":{"Binance":{"symbol":["TONUSDC","TONUSDT"]},"Bitfinex":{"symbol":["TONUSD"]},"Bybit":{"symbol":["TONUSDC","TONUSDT"]},"CryptoCom":{"instrument_name":["TONUSD-PERP","TON_USD","TON_USDT"]},"GateIo":{"id":["TON_USDT"]},"Kraken":{"pair":["TONUSD","TONUSDC","TONUSDT"],"wsname":["TON/USD","TON/USDC","TON/USDT"]},"KuCoin":{"symbol":["TON-USDT"]},"MEXC":{"symbol":["TONUSDC","TONUSDT"]},"OKX":{"instId":["TON-USDC","TON-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "67"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TON","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["TONUSDT"]},"Bybit":{"symbol":["TONUSDT"]},"CryptoCom":{"instrument_name":["TON_USDT"]},"GateIo":{"id":["TON_USDT"]},"Kraken":{"pair":["TONUSDT"],"wsname":["TON/USDT"]},"KuCoin":{"symbol":["TON-USDT"]},"MEXC":{"symbol":["TONUSDT"]},"OKX":{"instId":["TON-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "68"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TON","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["TONUSDC"]},"Bybit":{"symbol":["TONUSDC"]},"Kraken":{"pair":["TONUSDC"],"wsname":["TON/USDC"]},"MEXC":{"symbol":["TONUSDC"]},"OKX":{"instId":["TON-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "69"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"OM","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[6536],"symbol":["OM"]}},"exchanges":{"Binance":{"symbol":["OMUSDC","OMUSDT"]},"Bitget":{"symbol":["OMUSDC_SPBL","OMUSDT_SPBL"]},"Bybit":{"symbol":["OMUSDT"]},"CryptoCom":{"instrument_name":["OMUSD-PERP","OM_USD"]},"GateIo":{"id":["OM_USDT"]},"Kraken":{"pair":["OMUSD"],"wsname":["OM/USD"]},"KuCoin":{"symbol":["OM-USDT"]},"MEXC":{"symbol":["OMUSDT"]},"OKX":{"instId":["OM-USDC","OM-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "70"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"OM","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["OMUSDT"]},"Bitget":{"symbol":["OMUSDT_SPBL"]},"Bybit":{"symbol":["OMUSDT"]},"GateIo":{"id":["OM_USDT"]},"KuCoin":{"symbol":["OM-USDT"]},"MEXC":{"symbol":["OMUSDT"]},"OKX":{"instId":["OM-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "71"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"OM","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["OMUSDC"]},"Bitget":{"symbol":["OMUSDC_SPBL"]},"OKX":{"instId":["OM-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "72"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DOT","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[6636],"symbol":["DOT"]}},"exchanges":{"Binance":{"symbol":["DOTUSDC","DOTUSDT"]},"BinanceUS":{"symbol":["DOTUSDT"]},"Bitfinex":{"symbol":["DOTUSD"]},"Bitget":{"symbol":["DOTUSDC_SPBL","DOTUSDT_SPBL"]},"Bybit":{"symbol":["DOTUSDC","DOTUSDT"]},"Coinbase":{"id":["DOT-USD","DOT-USDT"]},"CryptoCom":{"instrument_name":["DOTUSD-PERP","DOT_USD","DOT_USDT"]},"GateIo":{"id":["DOT_USDC","DOT_USDT"]},"Gemini":{"symbol":["DOTUSD"]},"Kraken":{"pair":["DOTUSD","DOTUSDC","DOTUSDT"],"wsname":["DOT/USD","DOT/USDC","DOT/USDT"]},"KuCoin":{"symbol":["DOT-USDC","DOT-USDT"]},"MEXC":{"symbol":["DOTUSDT"]},"OKX":{"instId":["DOT-USDC","DOT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "73"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"DOT","quote":"BNB"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["DOTBNB"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "74"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DOT","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["DOTUSDT"]},"BinanceUS":{"symbol":["DOTUSDT"]},"Bitget":{"symbol":["DOTUSDT_SPBL"]},"Bybit":{"symbol":["DOTUSDT"]},"Coinbase":{"id":["DOT-USDT"]},"CryptoCom":{"instrument_name":["DOT_USDT"]},"GateIo":{"id":["DOT_USDT"]},"Kraken":{"pair":["DOTUSDT"],"wsname":["DOT/USDT"]},"KuCoin":{"symbol":["DOT-USDT"]},"MEXC":{"symbol":["DOTUSDT"]},"OKX":{"instId":["DOT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "75"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DOT","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["DOTUSDC"]},"Bitget":{"symbol":["DOTUSDC_SPBL"]},"Bybit":{"symbol":["DOTUSDC"]},"GateIo":{"id":["DOT_USDC"]},"Kraken":{"pair":["DOTUSDC"],"wsname":["DOT/USDC"]},"KuCoin":{"symbol":["DOT-USDC"]},"OKX":{"instId":["DOT-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "76"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"USDe","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[29470],"symbol":["USDe"]}},"exchanges":{"Bitget":{"symbol":["USDEUSDC_SPBL","USDEUSDT_SPBL"]},"Bybit":{"symbol":["USDEUSDC","USDEUSDT"]},"GateIo":{"id":["USDE_USDT"]},"KuCoin":{"symbol":["USDE-USDT"]},"MEXC":{"symbol":["USDEUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "77"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDE","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[29470],"symbol":["USDe"]}},"exchanges":{"Bitget":{"symbol":["USDEUSDC_SPBL","USDEUSDT_SPBL"]},"Bybit":{"symbol":["USDEUSDC","USDEUSDT"]},"GateIo":{"id":["USDE_USDT"]},"KuCoin":{"symbol":["USDE-USDT"]},"MEXC":{"symbol":["USDEUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "78"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"USDe","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["USDEUSDT_SPBL"]},"Bybit":{"symbol":["USDEUSDT"]},"GateIo":{"id":["USDE_USDT"]},"KuCoin":{"symbol":["USDE-USDT"]},"MEXC":{"symbol":["USDEUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "79"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"USDe","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["USDEUSDC_SPBL"]},"Bybit":{"symbol":["USDEUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "80"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDE","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["USDEUSDT_SPBL"]},"Bybit":{"symbol":["USDEUSDT"]},"GateIo":{"id":["USDE_USDT"]},"KuCoin":{"symbol":["USDE-USDT"]},"MEXC":{"symbol":["USDEUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "81"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDE","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["USDEUSDC_SPBL"]},"Bybit":{"symbol":["USDEUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "82"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DAI","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[4943],"symbol":["DAI"]}},"exchanges":{"Binance":{"symbol":["DAIUSDT"]},"BinanceUS":{"symbol":["DAIUSDT"]},"Bitfinex":{"symbol":["DAIUSD"]},"Bitget":{"symbol":["DAIUSDC_SPBL","DAIUSDT_SPBL"]},"Bybit":{"symbol":["DAIUSDT"]},"Coinbase":{"id":["DAI-USD","DAI-USDC"]},"CryptoCom":{"instrument_name":["DAI_USD"]},"GateIo":{"id":["DAI_USDT"]},"Gemini":{"symbol":["DAIUSD"]},"Kraken":{"pair":["DAIUSD","DAIUSDT"],"wsname":["DAI/USD","DAI/USDT"]},"MEXC":{"symbol":["DAIUSDT"]},"OKX":{"instId":["DAI-USD","DAI-USDC","DAI-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "83"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"DAI","quote":"BNB"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["DAIBNB"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "84"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DAI","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["DAIUSDT"]},"BinanceUS":{"symbol":["DAIUSDT"]},"Bitget":{"symbol":["DAIUSDT_SPBL"]},"Bybit":{"symbol":["DAIUSDT"]},"GateIo":{"id":["DAI_USDT"]},"Kraken":{"pair":["DAIUSDT"],"wsname":["DAI/USDT"]},"MEXC":{"symbol":["DAIUSDT"]},"OKX":{"instId":["DAI-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "85"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DAI","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["DAIUSDC_SPBL"]},"Coinbase":{"id":["DAI-USDC"]},"OKX":{"instId":["DAI-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "86"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"HYPE","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[32196],"symbol":["HYPE"]}},"exchanges":{"Bitget":{"symbol":["HYPEUSDT_SPBL"]},"GateIo":{"id":["HYPE_USDT"]},"KuCoin":{"symbol":["HYPE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "87"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"HYPE","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["HYPEUSDT_SPBL"]},"GateIo":{"id":["HYPE_USDT"]},"KuCoin":{"symbol":["HYPE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "88"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"XMR","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[328],"symbol":["XMR"]}},"exchanges":{"Binance":{"symbol":["XMRUSDT"]},"Bitfinex":{"symbol":["XMRUSD"]},"Kraken":{"pair":["XMRUSDC","XMRUSDT","XXMRZUSD"],"wsname":["XMR/USD","XMR/USDC","XMR/USDT"]},"KuCoin":{"symbol":["XMR-USDT"]},"MEXC":{"symbol":["XMRUSDC","XMRUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "89"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"XMR","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["XMRUSDT"]},"Kraken":{"pair":["XMRUSDT"],"wsname":["XMR/USDT"]},"KuCoin":{"symbol":["XMR-USDT"]},"MEXC":{"symbol":["XMRUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "90"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"XMR","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Kraken":{"pair":["XMRUSDC"],"wsname":["XMR/USDC"]},"MEXC":{"symbol":["XMRUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "91"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"UNI","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[33433,4307,7083],"symbol":["UNI","UNI","UNI"]}},"exchanges":{"Binance":{"symbol":["UNIUSDC","UNIUSDT"]},"BinanceUS":{"symbol":["UNIUSDT"]},"Bitfinex":{"symbol":["UNIUSD"]},"Bitget":{"symbol":["UNIUSDC_SPBL","UNIUSDT_SPBL"]},"Bybit":{"symbol":["UNIUSDC","UNIUSDT"]},"Coinbase":{"id":["UNI-USD"]},"CryptoCom":{"instrument_name":["UNIUSD-PERP","UNI_USD","UNI_USDT"]},"GateIo":{"id":["UNI_USDC","UNI_USDT"]},"Gemini":{"symbol":["UNIUSD"]},"Kraken":{"pair":["UNIUSD"],"wsname":["UNI/USD"]},"KuCoin":{"symbol":["UNI-USDT"]},"MEXC":{"symbol":["UNIUSDC","UNIUSDT"]},"OKX":{"instId":["UNI-USD","UNI-USDC","UNI-USDT"]},"Upbit":{"market":["USDT-UNI"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "92"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"UNI","quote":"BNB"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["UNIBNB"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "93"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"UNI","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["UNIETH"]},"Kraken":{"pair":["UNIETH"],"wsname":["UNI/ETH"]},"MEXC":{"symbol":["UNIETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "94"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"UNI","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["UNIUSDT"]},"BinanceUS":{"symbol":["UNIUSDT"]},"Bitget":{"symbol":["UNIUSDT_SPBL"]},"Bybit":{"symbol":["UNIUSDT"]},"CryptoCom":{"instrument_name":["UNI_USDT"]},"GateIo":{"id":["UNI_USDT"]},"KuCoin":{"symbol":["UNI-USDT"]},"MEXC":{"symbol":["UNIUSDT"]},"OKX":{"instId":["UNI-USDT"]},"Upbit":{"market":["USDT-UNI"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "95"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"UNI","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["UNIUSDC"]},"Bitget":{"symbol":["UNIUSDC_SPBL"]},"Bybit":{"symbol":["UNIUSDC"]},"GateIo":{"id":["UNI_USDC"]},"MEXC":{"symbol":["UNIUSDC"]},"OKX":{"instId":["UNI-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "96"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"APT","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[13473,21794],"symbol":["APT","APT"]}},"exchanges":{"Binance":{"symbol":["APTUSDC","APTUSDT"]},"BinanceUS":{"symbol":["APTUSDT"]},"Bitfinex":{"symbol":["APTUSD"]},"Bitget":{"symbol":["APTUSDC_SPBL","APTUSDT_SPBL"]},"Bybit":{"symbol":["APTUSDC","APTUSDT"]},"Coinbase":{"id":["APT-USD","APT-USDT"]},"CryptoCom":{"instrument_name":["APTUSD-PERP","APT_USD","APT_USDT"]},"GateIo":{"id":["APT_USDC","APT_USDT"]},"Kraken":{"pair":["APTUSD"],"wsname":["APT/USD"]},"KuCoin":{"symbol":["APT-USDT"]},"MEXC":{"symbol":["APTUSDT"]},"OKX":{"instId":["APT-USDC","APT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "97"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"APT","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["APTUSDT"]},"BinanceUS":{"symbol":["APTUSDT"]},"Bitget":{"symbol":["APTUSDT_SPBL"]},"Bybit":{"symbol":["APTUSDT"]},"Coinbase":{"id":["APT-USDT"]},"CryptoCom":{"instrument_name":["APT_USDT"]},"GateIo":{"id":["APT_USDT"]},"KuCoin":{"symbol":["APT-USDT"]},"MEXC":{"symbol":["APTUSDT"]},"OKX":{"instId":["APT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "98"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"APT","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["APTUSDC"]},"Bitget":{"symbol":["APTUSDC_SPBL"]},"Bybit":{"symbol":["APTUSDC"]},"GateIo":{"id":["APT_USDC"]},"OKX":{"instId":["APT-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "99"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"NEAR","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[6535],"symbol":["NEAR"]}},"exchanges":{"Binance":{"symbol":["NEARUSDC","NEARUSDT"]},"BinanceUS":{"symbol":["NEARUSDT"]},"Bitfinex":{"symbol":["NEAR:USD"]},"Bitget":{"symbol":["NEARUSDC_SPBL","NEARUSDT_SPBL"]},"Bybit":{"symbol":["NEARUSDC","NEARUSDT"]},"Coinbase":{"id":["NEAR-USD","NEAR-USDT"]},"CryptoCom":{"instrument_name":["NEARUSD-PERP","NEAR_USD","NEAR_USDT"]},"GateIo":{"id":["NEAR_USDC","NEAR_USDT"]},"Kraken":{"pair":["NEARUSD"],"wsname":["NEAR/USD"]},"KuCoin":{"symbol":["NEAR-USDC","NEAR-USDT"]},"MEXC":{"symbol":["NEARUSDC","NEARUSDT"]},"OKX":{"instId":["NEAR-USDC","NEAR-USDT"]},"Upbit":{"market":["USDT-NEAR"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "100"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"NEAR","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["NEARUSDT"]},"BinanceUS":{"symbol":["NEARUSDT"]},"Bitget":{"symbol":["NEARUSDT_SPBL"]},"Bybit":{"symbol":["NEARUSDT"]},"Coinbase":{"id":["NEAR-USDT"]},"CryptoCom":{"instrument_name":["NEAR_USDT"]},"GateIo":{"id":["NEAR_USDT"]},"KuCoin":{"symbol":["NEAR-USDT"]},"MEXC":{"symbol":["NEARUSDT"]},"OKX":{"instId":["NEAR-USDT"]},"Upbit":{"market":["USDT-NEAR"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "101"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"NEAR","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["NEARUSDC"]},"Bitget":{"symbol":["NEARUSDC_SPBL"]},"Bybit":{"symbol":["NEARUSDC"]},"GateIo":{"id":["NEAR_USDC"]},"KuCoin":{"symbol":["NEAR-USDC"]},"MEXC":{"symbol":["NEARUSDC"]},"OKX":{"instId":["NEAR-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "102"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PEPE","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[22454,23450,24478,24549,25289,25359,25912,27928,29084,29783,30341,30890,31147,31587,31616,32527,32643,32982,33050,34519,34702],"symbol":["PEPE","PEPE","PEPE","PEPE","PEPE","PEPE","PEPE","PEPE","PEPE","PEPE","PEPE","PEPE","PEPE","PEPE","PEPE","PEPE","PEPE","PEPE","PEPE","PEPE","PEPE"]}},"exchanges":{"Binance":{"symbol":["PEPEUSDC","PEPEUSDT"]},"BinanceTR":{"symbol":["PEPE_USDT"]},"BinanceUS":{"symbol":["PEPEUSDT"]},"Bitfinex":{"symbol":["PEPE:USD"]},"Bitget":{"symbol":["PEPEUSDC_SPBL","PEPEUSDT_SPBL"]},"Bybit":{"symbol":["PEPEUSDC","PEPEUSDT"]},"Coinbase":{"id":["PEPE-USD"]},"CryptoCom":{"instrument_name":["PEPEUSD-PERP","PEPE_USD","PEPE_USDT"]},"GateIo":{"id":["PEPE_USDC","PEPE_USDT"]},"Gemini":{"symbol":["PEPEUSD"]},"Kraken":{"pair":["PEPEUSD"],"wsname":["PEPE/USD"]},"KuCoin":{"symbol":["PEPE-USDC","PEPE-USDT"]},"MEXC":{"symbol":["PEPEUSDC","PEPEUSDT"]},"OKX":{"instId":["PEPE-USD","PEPE-USDC","PEPE-USDT"]},"Upbit":{"market":["USDT-PEPE"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "103"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PEPE","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["PEPEUSDT"]},"BinanceTR":{"symbol":["PEPE_USDT"]},"BinanceUS":{"symbol":["PEPEUSDT"]},"Bitget":{"symbol":["PEPEUSDT_SPBL"]},"Bybit":{"symbol":["PEPEUSDT"]},"CryptoCom":{"instrument_name":["PEPE_USDT"]},"GateIo":{"id":["PEPE_USDT"]},"KuCoin":{"symbol":["PEPE-USDT"]},"MEXC":{"symbol":["PEPEUSDT"]},"OKX":{"instId":["PEPE-USDT"]},"Upbit":{"market":["USDT-PEPE"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "104"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PEPE","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["PEPEUSDC"]},"Bitget":{"symbol":["PEPEUSDC_SPBL"]},"Bybit":{"symbol":["PEPEUSDC"]},"GateIo":{"id":["PEPE_USDC"]},"KuCoin":{"symbol":["PEPE-USDC"]},"MEXC":{"symbol":["PEPEUSDC"]},"OKX":{"instId":["PEPE-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "105"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ETC","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1321],"symbol":["ETC"]}},"exchanges":{"Binance":{"symbol":["ETCUSDC","ETCUSDT"]},"BinanceUS":{"symbol":["ETCUSDT"]},"Bitfinex":{"symbol":["ETCUSD"]},"Bitget":{"symbol":["ETCUSDT_SPBL"]},"Bybit":{"symbol":["ETCUSDT"]},"Coinbase":{"id":["ETC-USD"]},"CryptoCom":{"instrument_name":["ETCUSD-PERP","ETC_USD","ETC_USDT"]},"GateIo":{"id":["ETC_USDT"]},"Kraken":{"pair":["XETCZUSD"],"wsname":["ETC/USD"]},"KuCoin":{"symbol":["ETC-USDC","ETC-USDT"]},"MEXC":{"symbol":["ETCUSDT"]},"OKX":{"instId":["ETC-USDC","ETC-USDT"]},"Upbit":{"market":["USDT-ETC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "106"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ETC","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ETCUSDT"]},"BinanceUS":{"symbol":["ETCUSDT"]},"Bitget":{"symbol":["ETCUSDT_SPBL"]},"Bybit":{"symbol":["ETCUSDT"]},"CryptoCom":{"instrument_name":["ETC_USDT"]},"GateIo":{"id":["ETC_USDT"]},"KuCoin":{"symbol":["ETC-USDT"]},"MEXC":{"symbol":["ETCUSDT"]},"OKX":{"instId":["ETC-USDT"]},"Upbit":{"market":["USDT-ETC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "107"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ETC","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ETCUSDC"]},"KuCoin":{"symbol":["ETC-USDC"]},"OKX":{"instId":["ETC-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "108"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ONDO","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[21159],"symbol":["ONDO"]}},"exchanges":{"Bitget":{"symbol":["ONDOUSDC_SPBL","ONDOUSDT_SPBL"]},"Bybit":{"symbol":["ONDOUSDC","ONDOUSDT"]},"Coinbase":{"id":["ONDO-USD"]},"CryptoCom":{"instrument_name":["ONDOUSD-PERP","ONDO_USD","ONDO_USDT"]},"GateIo":{"id":["ONDO_USDT"]},"Kraken":{"pair":["ONDOUSD"],"wsname":["ONDO/USD"]},"KuCoin":{"symbol":["ONDO-USDC","ONDO-USDT"]},"MEXC":{"symbol":["ONDOUSDC","ONDOUSDT"]},"OKX":{"instId":["ONDO-USDC","ONDO-USDT"]},"Upbit":{"market":["USDT-ONDO"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "109"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ONDO","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["ONDOUSDT_SPBL"]},"Bybit":{"symbol":["ONDOUSDT"]},"CryptoCom":{"instrument_name":["ONDO_USDT"]},"GateIo":{"id":["ONDO_USDT"]},"KuCoin":{"symbol":["ONDO-USDT"]},"MEXC":{"symbol":["ONDOUSDT"]},"OKX":{"instId":["ONDO-USDT"]},"Upbit":{"market":["USDT-ONDO"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "110"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ONDO","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["ONDOUSDC_SPBL"]},"Bybit":{"symbol":["ONDOUSDC"]},"KuCoin":{"symbol":["ONDO-USDC"]},"MEXC":{"symbol":["ONDOUSDC"]},"OKX":{"instId":["ONDO-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "111"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ICP","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[8916],"symbol":["ICP"]}},"exchanges":{"Binance":{"symbol":["ICPUSDC","ICPUSDT"]},"BinanceUS":{"symbol":["ICPUSDT"]},"Bitfinex":{"symbol":["ICPUSD"]},"Bitget":{"symbol":["ICPUSDC_SPBL","ICPUSDT_SPBL"]},"Bybit":{"symbol":["ICPUSDC","ICPUSDT"]},"Coinbase":{"id":["ICP-USD","ICP-USDT"]},"CryptoCom":{"instrument_name":["ICPUSD-PERP","ICP_USD","ICP_USDT"]},"GateIo":{"id":["ICP_USDC","ICP_USDT"]},"Kraken":{"pair":["ICPUSD"],"wsname":["ICP/USD"]},"KuCoin":{"symbol":["ICP-USDT"]},"MEXC":{"symbol":["ICPUSDC","ICPUSDT"]},"OKX":{"instId":["ICP-USDC","ICP-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "112"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ICP","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ICPUSDT"]},"BinanceUS":{"symbol":["ICPUSDT"]},"Bitget":{"symbol":["ICPUSDT_SPBL"]},"Bybit":{"symbol":["ICPUSDT"]},"Coinbase":{"id":["ICP-USDT"]},"CryptoCom":{"instrument_name":["ICP_USDT"]},"GateIo":{"id":["ICP_USDT"]},"KuCoin":{"symbol":["ICP-USDT"]},"MEXC":{"symbol":["ICPUSDT"]},"OKX":{"instId":["ICP-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "113"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ICP","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ICPUSDC"]},"Bitget":{"symbol":["ICPUSDC_SPBL"]},"Bybit":{"symbol":["ICPUSDC"]},"GateIo":{"id":["ICP_USDC"]},"MEXC":{"symbol":["ICPUSDC"]},"OKX":{"instId":["ICP-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "114"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"AAVE","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[7278],"symbol":["AAVE"]}},"exchanges":{"Binance":{"symbol":["AAVEUSDC","AAVEUSDT"]},"BinanceUS":{"symbol":["AAVEUSDT"]},"Bitfinex":{"symbol":["AAVE:USD"]},"Bitget":{"symbol":["AAVEUSDC_SPBL","AAVEUSDT_SPBL"]},"Bybit":{"symbol":["AAVEUSDT"]},"Coinbase":{"id":["AAVE-USD"]},"CryptoCom":{"instrument_name":["AAVEUSD-PERP","AAVE_USD","AAVE_USDT"]},"GateIo":{"id":["AAVE_USDT"]},"Gemini":{"symbol":["AAVEUSD"]},"Kraken":{"pair":["AAVEUSD"],"wsname":["AAVE/USD"]},"KuCoin":{"symbol":["AAVE-USDT"]},"MEXC":{"symbol":["AAVEUSDC","AAVEUSDT"]},"OKX":{"instId":["AAVE-USD","AAVE-USDC","AAVE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "115"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"AAVE","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["AAVEETH"]},"GateIo":{"id":["AAVE_ETH"]},"Kraken":{"pair":["AAVEETH"],"wsname":["AAVE/ETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "116"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"AAVE","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["AAVEUSDT"]},"BinanceUS":{"symbol":["AAVEUSDT"]},"Bitget":{"symbol":["AAVEUSDT_SPBL"]},"Bybit":{"symbol":["AAVEUSDT"]},"CryptoCom":{"instrument_name":["AAVE_USDT"]},"GateIo":{"id":["AAVE_USDT"]},"KuCoin":{"symbol":["AAVE-USDT"]},"MEXC":{"symbol":["AAVEUSDT"]},"OKX":{"instId":["AAVE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "117"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"AAVE","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["AAVEUSDC"]},"Bitget":{"symbol":["AAVEUSDC_SPBL"]},"MEXC":{"symbol":["AAVEUSDC"]},"OKX":{"instId":["AAVE-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "118"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MNT","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[27075,32856],"symbol":["MNT","MNT"]}},"exchanges":{"Bybit":{"symbol":["MNTUSDC","MNTUSDT"]},"GateIo":{"id":["MNT_USDT"]},"Kraken":{"pair":["MNTUSD"],"wsname":["MNT/USD"]},"KuCoin":{"symbol":["MNT-USDT"]},"MEXC":{"symbol":["MNTUSDT"]},"Upbit":{"market":["USDT-MNT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "119"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MNT","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bybit":{"symbol":["MNTUSDT"]},"GateIo":{"id":["MNT_USDT"]},"KuCoin":{"symbol":["MNT-USDT"]},"MEXC":{"symbol":["MNTUSDT"]},"Upbit":{"market":["USDT-MNT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "120"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MNT","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bybit":{"symbol":["MNTUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "121"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TAO","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[22974],"symbol":["TAO"]}},"exchanges":{"Binance":{"symbol":["TAOUSDC","TAOUSDT"]},"Bitget":{"symbol":["TAOUSDC_SPBL","TAOUSDT_SPBL"]},"Coinbase":{"id":["TAO-USD"]},"CryptoCom":{"instrument_name":["TAOUSD-PERP","TAO_USD"]},"GateIo":{"id":["TAO_USDT"]},"Kraken":{"pair":["TAOUSD"],"wsname":["TAO/USD"]},"KuCoin":{"symbol":["TAO-USDT"]},"MEXC":{"symbol":["TAOUSDC","TAOUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "122"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TAO","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["TAOUSDT"]},"Bitget":{"symbol":["TAOUSDT_SPBL"]},"GateIo":{"id":["TAO_USDT"]},"KuCoin":{"symbol":["TAO-USDT"]},"MEXC":{"symbol":["TAOUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "123"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TAO","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["TAOUSDC"]},"Bitget":{"symbol":["TAOUSDC_SPBL"]},"MEXC":{"symbol":["TAOUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "124"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"VET","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[3077],"symbol":["VET"]}},"exchanges":{"Binance":{"symbol":["VETUSDT"]},"BinanceUS":{"symbol":["VETUSDT"]},"Bitget":{"symbol":["VETUSDT_SPBL"]},"Coinbase":{"id":["VET-USD"]},"CryptoCom":{"instrument_name":["VETUSD-PERP","VET_USD","VET_USDT"]},"GateIo":{"id":["VET_USDT"]},"KuCoin":{"symbol":["VET-USDT"]},"MEXC":{"symbol":["VETUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "125"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"VET","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["VETUSDT"]},"BinanceUS":{"symbol":["VETUSDT"]},"Bitget":{"symbol":["VETUSDT_SPBL"]},"CryptoCom":{"instrument_name":["VET_USDT"]},"GateIo":{"id":["VET_USDT"]},"KuCoin":{"symbol":["VET-USDT"]},"MEXC":{"symbol":["VETUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "126"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FDUSD","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[26081],"symbol":["FDUSD"]}},"exchanges":{"Binance":{"symbol":["FDUSDUSDC","FDUSDUSDT"]},"BinanceTR":{"symbol":["FDUSD_USDC","FDUSD_USDT"]},"Bitget":{"symbol":["FDUSDUSDT_SPBL"]},"GateIo":{"id":["FDUSD_USDT"]},"MEXC":{"symbol":["FDUSDUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "127"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FDUSD","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["FDUSDUSDT"]},"BinanceTR":{"symbol":["FDUSD_USDT"]},"Bitget":{"symbol":["FDUSDUSDT_SPBL"]},"GateIo":{"id":["FDUSD_USDT"]},"MEXC":{"symbol":["FDUSDUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "128"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FDUSD","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["FDUSDUSDC"]},"BinanceTR":{"symbol":["FDUSD_USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "129"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TIA","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[22861],"symbol":["TIA"]}},"exchanges":{"Binance":{"symbol":["TIAUSDC","TIAUSDT"]},"Bitfinex":{"symbol":["TIAUSD"]},"Bitget":{"symbol":["TIAUSDT_SPBL"]},"Bybit":{"symbol":["TIAUSDC","TIAUSDT"]},"Coinbase":{"id":["TIA-USD"]},"CryptoCom":{"instrument_name":["TIAUSD-PERP","TIA_USD","TIA_USDT"]},"GateIo":{"id":["TIA_USDC","TIA_USDT"]},"Kraken":{"pair":["TIAUSD"],"wsname":["TIA/USD"]},"KuCoin":{"symbol":["TIA-USDT"]},"MEXC":{"symbol":["TIAUSDT"]},"OKX":{"instId":["TIA-USDC","TIA-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "130"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TIA","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["TIAUSDT"]},"Bitget":{"symbol":["TIAUSDT_SPBL"]},"Bybit":{"symbol":["TIAUSDT"]},"CryptoCom":{"instrument_name":["TIA_USDT"]},"GateIo":{"id":["TIA_USDT"]},"KuCoin":{"symbol":["TIA-USDT"]},"MEXC":{"symbol":["TIAUSDT"]},"OKX":{"instId":["TIA-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "131"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TIA","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["TIAUSDC"]},"Bybit":{"symbol":["TIAUSDC"]},"GateIo":{"id":["TIA_USDC"]},"OKX":{"instId":["TIA-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "132"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"POL","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28321],"symbol":["POL"]}},"exchanges":{"Binance":{"symbol":["POLUSDC","POLUSDT"]},"BinanceUS":{"symbol":["POLUSDT"]},"Bitfinex":{"symbol":["POLUSD"]},"Bitget":{"symbol":["POLUSDC_SPBL","POLUSDT_SPBL"]},"Bybit":{"symbol":["POLUSDT"]},"Coinbase":{"id":["POL-USD"]},"CryptoCom":{"instrument_name":["POLUSD-PERP","POL_USD","POL_USDT"]},"GateIo":{"id":["POL_USDT"]},"Kraken":{"pair":["POLUSD"],"wsname":["POL/USD"]},"KuCoin":{"symbol":["POL-USDT"]},"MEXC":{"symbol":["POLUSDT"]},"OKX":{"instId":["POL-USDC","POL-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "133"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"POL","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["POLETH"]},"BinanceUS":{"symbol":["POLETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "134"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"POL","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["POLUSDT"]},"BinanceUS":{"symbol":["POLUSDT"]},"Bitget":{"symbol":["POLUSDT_SPBL"]},"Bybit":{"symbol":["POLUSDT"]},"CryptoCom":{"instrument_name":["POL_USDT"]},"GateIo":{"id":["POL_USDT"]},"KuCoin":{"symbol":["POL-USDT"]},"MEXC":{"symbol":["POLUSDT"]},"OKX":{"instId":["POL-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "135"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"POL","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["POLUSDC"]},"Bitget":{"symbol":["POLUSDC_SPBL"]},"OKX":{"instId":["POL-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "136"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FIL","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[2280],"symbol":["FIL"]}},"exchanges":{"Binance":{"symbol":["FILUSDC","FILUSDT"]},"BinanceUS":{"symbol":["FILUSDT"]},"Bitfinex":{"symbol":["FILUSD"]},"Bitget":{"symbol":["FILUSDC_SPBL","FILUSDT_SPBL"]},"Bybit":{"symbol":["FILUSDC","FILUSDT"]},"Coinbase":{"id":["FIL-USD"]},"CryptoCom":{"instrument_name":["FILUSD-PERP","FIL_USD","FIL_USDT"]},"GateIo":{"id":["FIL_USDC","FIL_USDT"]},"Gemini":{"symbol":["FILUSD"]},"Kraken":{"pair":["FILUSD"],"wsname":["FIL/USD"]},"KuCoin":{"symbol":["FIL-USDT"]},"MEXC":{"symbol":["FILUSDC","FILUSDT"]},"OKX":{"instId":["FIL-USDC","FIL-USDT"]},"Upbit":{"market":["USDT-FIL"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "137"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"FIL","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["FILETH"]},"Bitget":{"symbol":["FILETH_SPBL"]},"GateIo":{"id":["FIL_ETH"]},"Kraken":{"pair":["FILETH"],"wsname":["FIL/ETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "138"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FIL","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["FILUSDT"]},"BinanceUS":{"symbol":["FILUSDT"]},"Bitget":{"symbol":["FILUSDT_SPBL"]},"Bybit":{"symbol":["FILUSDT"]},"CryptoCom":{"instrument_name":["FIL_USDT"]},"GateIo":{"id":["FIL_USDT"]},"KuCoin":{"symbol":["FIL-USDT"]},"MEXC":{"symbol":["FILUSDT"]},"OKX":{"instId":["FIL-USDT"]},"Upbit":{"market":["USDT-FIL"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "139"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FIL","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["FILUSDC"]},"Bitget":{"symbol":["FILUSDC_SPBL"]},"Bybit":{"symbol":["FILUSDC"]},"GateIo":{"id":["FIL_USDC"]},"MEXC":{"symbol":["FILUSDC"]},"OKX":{"instId":["FIL-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "140"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"LBTC","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[2335,33652],"symbol":["LBTC","LBTC"]}},"exchanges":{"MEXC":{"symbol":["LBTCUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "141"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"LBTC","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"MEXC":{"symbol":["LBTCUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "142"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ALGO","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[4030],"symbol":["ALGO"]}},"exchanges":{"Binance":{"symbol":["ALGOUSDC","ALGOUSDT"]},"BinanceUS":{"symbol":["ALGOUSDT"]},"Bitget":{"symbol":["ALGOUSDC_SPBL","ALGOUSDT_SPBL"]},"Bybit":{"symbol":["ALGOUSDT"]},"Coinbase":{"id":["ALGO-USD"]},"CryptoCom":{"instrument_name":["ALGOUSD-PERP","ALGO_USD","ALGO_USDT"]},"GateIo":{"id":["ALGO_USDC","ALGO_USDT"]},"Kraken":{"pair":["ALGOUSD","ALGOUSDC","ALGOUSDT"],"wsname":["ALGO/USD","ALGO/USDC","ALGO/USDT"]},"KuCoin":{"symbol":["ALGO-USDC","ALGO-USDT"]},"MEXC":{"symbol":["ALGOUSDC","ALGOUSDT"]},"OKX":{"instId":["ALGO-USDC","ALGO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "143"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ALGO","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ALGOUSDT"]},"BinanceUS":{"symbol":["ALGOUSDT"]},"Bitget":{"symbol":["ALGOUSDT_SPBL"]},"Bybit":{"symbol":["ALGOUSDT"]},"CryptoCom":{"instrument_name":["ALGO_USDT"]},"GateIo":{"id":["ALGO_USDT"]},"Kraken":{"pair":["ALGOUSDT"],"wsname":["ALGO/USDT"]},"KuCoin":{"symbol":["ALGO-USDT"]},"MEXC":{"symbol":["ALGOUSDT"]},"OKX":{"instId":["ALGO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "144"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ALGO","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ALGOUSDC"]},"Bitget":{"symbol":["ALGOUSDC_SPBL"]},"GateIo":{"id":["ALGO_USDC"]},"Kraken":{"pair":["ALGOUSDC"],"wsname":["ALGO/USDC"]},"KuCoin":{"symbol":["ALGO-USDC"]},"MEXC":{"symbol":["ALGOUSDC"]},"OKX":{"instId":["ALGO-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "145"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"RENDER","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[5690],"symbol":["RENDER"]}},"exchanges":{"Binance":{"symbol":["RENDERUSDC","RENDERUSDT"]},"BinanceUS":{"symbol":["RENDERUSDT"]},"Bitget":{"symbol":["RENDERUSDC_SPBL","RENDERUSDT_SPBL"]},"Bybit":{"symbol":["RENDERUSDT"]},"Coinbase":{"id":["RENDER-USD"]},"CryptoCom":{"instrument_name":["RENDERUSD-PERP","RENDER_USD","RENDER_USDT"]},"GateIo":{"id":["RENDER_USDC","RENDER_USDT"]},"Kraken":{"pair":["RENDERUSD"],"wsname":["RENDER/USD"]},"KuCoin":{"symbol":["RENDER-USDT"]},"MEXC":{"symbol":["RENDERUSDT"]},"OKX":{"instId":["RENDER-USD","RENDER-USDT"]},"Upbit":{"market":["USDT-RENDER"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "146"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"RENDER","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["RENDERUSDT"]},"BinanceUS":{"symbol":["RENDERUSDT"]},"Bitget":{"symbol":["RENDERUSDT_SPBL"]},"Bybit":{"symbol":["RENDERUSDT"]},"CryptoCom":{"instrument_name":["RENDER_USDT"]},"GateIo":{"id":["RENDER_USDT"]},"KuCoin":{"symbol":["RENDER-USDT"]},"MEXC":{"symbol":["RENDERUSDT"]},"OKX":{"instId":["RENDER-USDT"]},"Upbit":{"market":["USDT-RENDER"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "147"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"RENDER","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["RENDERUSDC"]},"Bitget":{"symbol":["RENDERUSDC_SPBL"]},"GateIo":{"id":["RENDER_USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "148"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ATOM","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[30019,3794],"symbol":["ATOM","ATOM"]}},"exchanges":{"Binance":{"symbol":["ATOMUSDC","ATOMUSDT"]},"BinanceUS":{"symbol":["ATOMUSDT"]},"Bitget":{"symbol":["ATOMUSDT_SPBL"]},"Bybit":{"symbol":["ATOMUSDC","ATOMUSDT"]},"Coinbase":{"id":["ATOM-USD","ATOM-USDT"]},"CryptoCom":{"instrument_name":["ATOMUSD-PERP","ATOM_USD","ATOM_USDT"]},"GateIo":{"id":["ATOM_USDC","ATOM_USDT"]},"Gemini":{"symbol":["ATOMUSD"]},"Kraken":{"pair":["ATOMUSD","ATOMUSDC","ATOMUSDT"],"wsname":["ATOM/USD","ATOM/USDC","ATOM/USDT"]},"KuCoin":{"symbol":["ATOM-USDC","ATOM-USDT"]},"MEXC":{"symbol":["ATOMUSDC","ATOMUSDT"]},"OKX":{"instId":["ATOM-USDC","ATOM-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "149"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ATOM","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ATOMUSDT"]},"BinanceUS":{"symbol":["ATOMUSDT"]},"Bitget":{"symbol":["ATOMUSDT_SPBL"]},"Bybit":{"symbol":["ATOMUSDT"]},"Coinbase":{"id":["ATOM-USDT"]},"CryptoCom":{"instrument_name":["ATOM_USDT"]},"GateIo":{"id":["ATOM_USDT"]},"Kraken":{"pair":["ATOMUSDT"],"wsname":["ATOM/USDT"]},"KuCoin":{"symbol":["ATOM-USDT"]},"MEXC":{"symbol":["ATOMUSDT"]},"OKX":{"instId":["ATOM-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "150"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ATOM","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ATOMUSDC"]},"Bybit":{"symbol":["ATOMUSDC"]},"GateIo":{"id":["ATOM_USDC"]},"Kraken":{"pair":["ATOMUSDC"],"wsname":["ATOM/USDC"]},"KuCoin":{"symbol":["ATOM-USDC"]},"MEXC":{"symbol":["ATOMUSDC"]},"OKX":{"instId":["ATOM-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "151"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ARB","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[11841,21129,938],"symbol":["ARB","ARB","ARB"]}},"exchanges":{"Binance":{"symbol":["ARBUSDC","ARBUSDT"]},"BinanceTR":{"symbol":["ARB_USDT"]},"BinanceUS":{"symbol":["ARBUSDT"]},"Bitfinex":{"symbol":["ARBUSD"]},"Bitget":{"symbol":["ARBUSDC_SPBL","ARBUSDT_SPBL"]},"Bybit":{"symbol":["ARBUSDC","ARBUSDT"]},"Coinbase":{"id":["ARB-USD"]},"CryptoCom":{"instrument_name":["ARBUSD-PERP","ARB_USD","ARB_USDT"]},"GateIo":{"id":["ARB_USDC","ARB_USDT"]},"Kraken":{"pair":["ARBUSD"],"wsname":["ARB/USD"]},"KuCoin":{"symbol":["ARB-USDT"]},"MEXC":{"symbol":["ARBUSDT"]},"OKX":{"instId":["ARB-USD","ARB-USDC","ARB-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "152"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ARB","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ARBUSDT"]},"BinanceTR":{"symbol":["ARB_USDT"]},"BinanceUS":{"symbol":["ARBUSDT"]},"Bitget":{"symbol":["ARBUSDT_SPBL"]},"Bybit":{"symbol":["ARBUSDT"]},"CryptoCom":{"instrument_name":["ARB_USDT"]},"GateIo":{"id":["ARB_USDT"]},"KuCoin":{"symbol":["ARB-USDT"]},"MEXC":{"symbol":["ARBUSDT"]},"OKX":{"instId":["ARB-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "153"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ARB","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ARBUSDC"]},"Bitget":{"symbol":["ARBUSDC_SPBL"]},"Bybit":{"symbol":["ARBUSDC"]},"GateIo":{"id":["ARB_USDC"]},"OKX":{"instId":["ARB-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "154"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"JUP","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1503,29210],"symbol":["JUP","JUP"]}},"exchanges":{"Binance":{"symbol":["JUPUSDC","JUPUSDT"]},"Bitfinex":{"symbol":["JUPUSD"]},"Bitget":{"symbol":["JUPUSDT_SPBL"]},"Bybit":{"symbol":["JUPUSDT"]},"Coinbase":{"id":["JUP-USD"]},"CryptoCom":{"instrument_name":["JUPUSD-PERP","JUP_USD","JUP_USDT"]},"GateIo":{"id":["JUP_USDC","JUP_USDT"]},"Kraken":{"pair":["JUPUSD"],"wsname":["JUP/USD"]},"KuCoin":{"symbol":["JUP-USDC","JUP-USDT"]},"MEXC":{"symbol":["JUPUSDT"]},"OKX":{"instId":["JUP-USDC","JUP-USDT"]},"Upbit":{"market":["USDT-JUP"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "155"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"JUP","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["JUPUSDT"]},"Bitget":{"symbol":["JUPUSDT_SPBL"]},"Bybit":{"symbol":["JUPUSDT"]},"CryptoCom":{"instrument_name":["JUP_USDT"]},"GateIo":{"id":["JUP_USDT"]},"KuCoin":{"symbol":["JUP-USDT"]},"MEXC":{"symbol":["JUPUSDT"]},"OKX":{"instId":["JUP-USDT"]},"Upbit":{"market":["USDT-JUP"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "156"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"JUP","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["JUPUSDC"]},"GateIo":{"id":["JUP_USDC"]},"KuCoin":{"symbol":["JUP-USDC"]},"OKX":{"instId":["JUP-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "157"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"OP","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[11840],"symbol":["OP"]}},"exchanges":{"Binance":{"symbol":["OPUSDC","OPUSDT"]},"BinanceUS":{"symbol":["OPUSDT"]},"Bitget":{"symbol":["OPUSDC_SPBL","OPUSDT_SPBL"]},"Bybit":{"symbol":["OPUSDC","OPUSDT"]},"Coinbase":{"id":["OP-USD","OP-USDT"]},"CryptoCom":{"instrument_name":["OPUSD-PERP","OP_USD","OP_USDT"]},"GateIo":{"id":["OP_USDC","OP_USDT"]},"Gemini":{"symbol":["OPUSD"]},"Kraken":{"pair":["OPUSD"],"wsname":["OP/USD"]},"KuCoin":{"symbol":["OP-USDC","OP-USDT"]},"MEXC":{"symbol":["OPUSDC","OPUSDT"]},"OKX":{"instId":["OP-USD","OP-USDC","OP-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "158"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"OP","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["OPUSDT"]},"BinanceUS":{"symbol":["OPUSDT"]},"Bitget":{"symbol":["OPUSDT_SPBL"]},"Bybit":{"symbol":["OPUSDT"]},"Coinbase":{"id":["OP-USDT"]},"CryptoCom":{"instrument_name":["OP_USDT"]},"GateIo":{"id":["OP_USDT"]},"KuCoin":{"symbol":["OP-USDT"]},"MEXC":{"symbol":["OPUSDT"]},"OKX":{"instId":["OP-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "159"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"OP","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["OPUSDC"]},"Bitget":{"symbol":["OPUSDC_SPBL"]},"Bybit":{"symbol":["OPUSDC"]},"GateIo":{"id":["OP_USDC"]},"KuCoin":{"symbol":["OP-USDC"]},"MEXC":{"symbol":["OPUSDC"]},"OKX":{"instId":["OP-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "160"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"S","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[32684,33167],"symbol":["S","S"]}},"exchanges":{"Binance":{"symbol":["SUSDC","SUSDT"]},"Bitget":{"symbol":["SUSDT_SPBL"]},"Bybit":{"symbol":["SUSDT"]},"CryptoCom":{"instrument_name":["SUSD-PERP","S_USD"]},"GateIo":{"id":["S_USDT"]},"KuCoin":{"symbol":["S-USDC","S-USDT"]},"MEXC":{"symbol":["SUSDC","SUSDT"]},"OKX":{"instId":["S-USD","S-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "161"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"S","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SUSDT"]},"Bitget":{"symbol":["SUSDT_SPBL"]},"Bybit":{"symbol":["SUSDT"]},"GateIo":{"id":["S_USDT"]},"KuCoin":{"symbol":["S-USDT"]},"MEXC":{"symbol":["SUSDT"]},"OKX":{"instId":["S-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "162"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"S","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SUSDC"]},"KuCoin":{"symbol":["S-USDC"]},"MEXC":{"symbol":["SUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "163"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FET","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[3773],"symbol":["FET"]}},"exchanges":{"Binance":{"symbol":["FETUSDC","FETUSDT"]},"BinanceUS":{"symbol":["FETUSDT"]},"Bitfinex":{"symbol":["FETUSD"]},"Bitget":{"symbol":["FETUSDC_SPBL","FETUSDT_SPBL"]},"Bybit":{"symbol":["FETUSDC","FETUSDT"]},"Coinbase":{"id":["FET-USD","FET-USDT"]},"CryptoCom":{"instrument_name":["FETUSD-PERP","FET_USD","FET_USDT"]},"GateIo":{"id":["FET_USDC","FET_USDT"]},"Gemini":{"symbol":["FETUSD"]},"Kraken":{"pair":["FETUSD"],"wsname":["FET/USD"]},"KuCoin":{"symbol":["FET-USDT"]},"MEXC":{"symbol":["FETUSDC","FETUSDT"]},"OKX":{"instId":["FET-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "164"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FET","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["FETUSDT"]},"BinanceUS":{"symbol":["FETUSDT"]},"Bitget":{"symbol":["FETUSDT_SPBL"]},"Bybit":{"symbol":["FETUSDT"]},"Coinbase":{"id":["FET-USDT"]},"CryptoCom":{"instrument_name":["FET_USDT"]},"GateIo":{"id":["FET_USDT"]},"KuCoin":{"symbol":["FET-USDT"]},"MEXC":{"symbol":["FETUSDT"]},"OKX":{"instId":["FET-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "165"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FET","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["FETUSDC"]},"Bitget":{"symbol":["FETUSDC_SPBL"]},"Bybit":{"symbol":["FETUSDC"]},"GateIo":{"id":["FET_USDC"]},"MEXC":{"symbol":["FETUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "166"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ENA","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[30171],"symbol":["ENA"]}},"exchanges":{"Binance":{"symbol":["ENAUSDC","ENAUSDT"]},"Bitfinex":{"symbol":["ENAUSD"]},"Bitget":{"symbol":["ENAUSDC_SPBL","ENAUSDT_SPBL"]},"Bybit":{"symbol":["ENAUSDT"]},"CryptoCom":{"instrument_name":["ENAUSD-PERP","ENA_USD","ENA_USDT"]},"GateIo":{"id":["ENA_USDC","ENA_USDT"]},"Kraken":{"pair":["ENAUSD"],"wsname":["ENA/USD"]},"KuCoin":{"symbol":["ENA-USDT"]},"MEXC":{"symbol":["ENAUSDC","ENAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "167"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ENA","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ENAUSDT"]},"Bitget":{"symbol":["ENAUSDT_SPBL"]},"Bybit":{"symbol":["ENAUSDT"]},"CryptoCom":{"instrument_name":["ENA_USDT"]},"GateIo":{"id":["ENA_USDT"]},"KuCoin":{"symbol":["ENA-USDT"]},"MEXC":{"symbol":["ENAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "168"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ENA","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ENAUSDC"]},"Bitget":{"symbol":["ENAUSDC_SPBL"]},"GateIo":{"id":["ENA_USDC"]},"MEXC":{"symbol":["ENAUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "169"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MKR","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1518],"symbol":["MKR"]}},"exchanges":{"Binance":{"symbol":["MKRUSDT"]},"BinanceUS":{"symbol":["MKRUSDT"]},"Bitfinex":{"symbol":["MKRUSD"]},"Bitget":{"symbol":["MKRUSDT_SPBL"]},"Bybit":{"symbol":["MKRUSDT"]},"Coinbase":{"id":["MKR-USD"]},"CryptoCom":{"instrument_name":["MKRUSD-PERP","MKR_USD","MKR_USDT"]},"GateIo":{"id":["MKR_USDT"]},"Gemini":{"symbol":["MKRUSD"]},"Kraken":{"pair":["MKRUSD"],"wsname":["MKR/USD"]},"KuCoin":{"symbol":["MKR-USDT"]},"MEXC":{"symbol":["MKRUSDT"]},"OKX":{"instId":["MKR-USD","MKR-USDC","MKR-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "170"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MKR","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"KuCoin":{"symbol":["MKR-ETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "171"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MKR","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["MKRUSDT"]},"BinanceUS":{"symbol":["MKRUSDT"]},"Bitget":{"symbol":["MKRUSDT_SPBL"]},"Bybit":{"symbol":["MKRUSDT"]},"CryptoCom":{"instrument_name":["MKR_USDT"]},"GateIo":{"id":["MKR_USDT"]},"KuCoin":{"symbol":["MKR-USDT"]},"MEXC":{"symbol":["MKRUSDT"]},"OKX":{"instId":["MKR-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "172"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MKR","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["MKR-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "173"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ZBU","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[27765],"symbol":["ZBU"]}},"exchanges":{"Bitget":{"symbol":["ZBUUSDT_SPBL"]},"GateIo":{"id":["ZBU_USDT"]},"MEXC":{"symbol":["ZBUUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "174"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ZBU","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["ZBUUSDT_SPBL"]},"GateIo":{"id":["ZBU_USDT"]},"MEXC":{"symbol":["ZBUUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "175"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"STX","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1861,4847],"symbol":["STX","STX"]}},"exchanges":{"Binance":{"symbol":["STXUSDC","STXUSDT"]},"Bitget":{"symbol":["STXUSDC_SPBL","STXUSDT_SPBL"]},"Bybit":{"symbol":["STXUSDT"]},"Coinbase":{"id":["STX-USD","STX-USDT"]},"CryptoCom":{"instrument_name":["STXUSD-PERP","STX_USD","STX_USDT"]},"GateIo":{"id":["STX_USDC","STX_USDT"]},"Kraken":{"pair":["STXUSD"],"wsname":["STX/USD"]},"KuCoin":{"symbol":["STX-USDT"]},"MEXC":{"symbol":["STXUSDT"]},"OKX":{"instId":["STX-USDC","STX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "176"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"STX","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["STXUSDT"]},"Bitget":{"symbol":["STXUSDT_SPBL"]},"Bybit":{"symbol":["STXUSDT"]},"Coinbase":{"id":["STX-USDT"]},"CryptoCom":{"instrument_name":["STX_USDT"]},"GateIo":{"id":["STX_USDT"]},"KuCoin":{"symbol":["STX-USDT"]},"MEXC":{"symbol":["STXUSDT"]},"OKX":{"instId":["STX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "177"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"STX","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["STXUSDC"]},"Bitget":{"symbol":["STXUSDC_SPBL"]},"GateIo":{"id":["STX_USDC"]},"OKX":{"instId":["STX-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "178"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"INJ","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[7226],"symbol":["INJ"]}},"exchanges":{"Binance":{"symbol":["INJUSDC","INJUSDT"]},"Bitget":{"symbol":["INJUSDC_SPBL","INJUSDT_SPBL"]},"Bybit":{"symbol":["INJUSDC","INJUSDT"]},"Coinbase":{"id":["INJ-USD"]},"CryptoCom":{"instrument_name":["INJUSD-PERP","INJ_USD","INJ_USDT"]},"GateIo":{"id":["INJ_USDC","INJ_USDT"]},"Gemini":{"symbol":["INJUSD"]},"Kraken":{"pair":["INJUSD"],"wsname":["INJ/USD"]},"KuCoin":{"symbol":["INJ-USDT"]},"MEXC":{"symbol":["INJUSDC","INJUSDT"]},"OKX":{"instId":["INJ-USDT"]},"Upbit":{"market":["USDT-INJ"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "179"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"INJ","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["INJUSDT"]},"Bitget":{"symbol":["INJUSDT_SPBL"]},"Bybit":{"symbol":["INJUSDT"]},"CryptoCom":{"instrument_name":["INJ_USDT"]},"GateIo":{"id":["INJ_USDT"]},"KuCoin":{"symbol":["INJ-USDT"]},"MEXC":{"symbol":["INJUSDT"]},"OKX":{"instId":["INJ-USDT"]},"Upbit":{"market":["USDT-INJ"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "180"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"INJ","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["INJUSDC"]},"Bitget":{"symbol":["INJUSDC_SPBL"]},"Bybit":{"symbol":["INJUSDC"]},"GateIo":{"id":["INJ_USDC"]},"MEXC":{"symbol":["INJUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "181"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"IMX","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[10603],"symbol":["IMX"]}},"exchanges":{"Binance":{"symbol":["IMXUSDT"]},"BinanceUS":{"symbol":["IMXUSDT"]},"Bitget":{"symbol":["IMXUSDT_SPBL"]},"Bybit":{"symbol":["IMXUSDT"]},"Coinbase":{"id":["IMX-USD","IMX-USDT"]},"CryptoCom":{"instrument_name":["IMXUSD-PERP","IMX_USD","IMX_USDT"]},"GateIo":{"id":["IMX_USDT"]},"Gemini":{"symbol":["IMXUSD"]},"Kraken":{"pair":["IMXUSD"],"wsname":["IMX/USD"]},"KuCoin":{"symbol":["IMX-USDT"]},"MEXC":{"symbol":["IMXUSDT"]},"OKX":{"instId":["IMX-USDC","IMX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "182"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"IMX","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["IMXUSDT"]},"BinanceUS":{"symbol":["IMXUSDT"]},"Bitget":{"symbol":["IMXUSDT_SPBL"]},"Bybit":{"symbol":["IMXUSDT"]},"Coinbase":{"id":["IMX-USDT"]},"CryptoCom":{"instrument_name":["IMX_USDT"]},"GateIo":{"id":["IMX_USDT"]},"KuCoin":{"symbol":["IMX-USDT"]},"MEXC":{"symbol":["IMXUSDT"]},"OKX":{"instId":["IMX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "183"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"IMX","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["IMX-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "184"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"QNT","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[3155],"symbol":["QNT"]}},"exchanges":{"Binance":{"symbol":["QNTUSDT"]},"BinanceUS":{"symbol":["QNTUSDT"]},"Bitget":{"symbol":["QNTUSDT_SPBL"]},"Bybit":{"symbol":["QNTUSDT"]},"Coinbase":{"id":["QNT-USD","QNT-USDT"]},"CryptoCom":{"instrument_name":["QNTUSD-PERP","QNT_USD","QNT_USDT"]},"GateIo":{"id":["QNT_USDT"]},"Gemini":{"symbol":["QNTUSD"]},"Kraken":{"pair":["QNTUSD"],"wsname":["QNT/USD"]},"KuCoin":{"symbol":["QNT-USDT"]},"MEXC":{"symbol":["QNTUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "185"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"QNT","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["QNTUSDT"]},"BinanceUS":{"symbol":["QNTUSDT"]},"Bitget":{"symbol":["QNTUSDT_SPBL"]},"Bybit":{"symbol":["QNTUSDT"]},"Coinbase":{"id":["QNT-USDT"]},"CryptoCom":{"instrument_name":["QNT_USDT"]},"GateIo":{"id":["QNT_USDT"]},"KuCoin":{"symbol":["QNT-USDT"]},"MEXC":{"symbol":["QNTUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "186"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"WLD","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[13502],"symbol":["WLD"]}},"exchanges":{"Binance":{"symbol":["WLDUSDC","WLDUSDT"]},"Bitget":{"symbol":["WLDUSDC_SPBL","WLDUSDT_SPBL"]},"Bybit":{"symbol":["WLDUSDC","WLDUSDT"]},"CryptoCom":{"instrument_name":["WLDUSD-PERP","WLD_USD","WLD_USDT"]},"GateIo":{"id":["WLD_USDC","WLD_USDT"]},"Kraken":{"pair":["WLDUSD"],"wsname":["WLD/USD"]},"KuCoin":{"symbol":["WLD-USDT"]},"MEXC":{"symbol":["WLDUSDT"]},"OKX":{"instId":["WLD-USD","WLD-USDC","WLD-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "187"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"WLD","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["WLDUSDT"]},"Bitget":{"symbol":["WLDUSDT_SPBL"]},"Bybit":{"symbol":["WLDUSDT"]},"CryptoCom":{"instrument_name":["WLD_USDT"]},"GateIo":{"id":["WLD_USDT"]},"KuCoin":{"symbol":["WLD-USDT"]},"MEXC":{"symbol":["WLDUSDT"]},"OKX":{"instId":["WLD-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "188"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"WLD","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["WLDUSDC"]},"Bitget":{"symbol":["WLDUSDC_SPBL"]},"Bybit":{"symbol":["WLDUSDC"]},"GateIo":{"id":["WLD_USDC"]},"OKX":{"instId":["WLD-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "189"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"THETA","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[2416],"symbol":["THETA"]}},"exchanges":{"Binance":{"symbol":["THETAUSDT"]},"BinanceUS":{"symbol":["THETAUSDT"]},"Bybit":{"symbol":["THETAUSDT"]},"CryptoCom":{"instrument_name":["THETAUSD-PERP","THETA_USD","THETA_USDT"]},"GateIo":{"id":["THETA_USDT"]},"KuCoin":{"symbol":["THETA-USDT"]},"OKX":{"instId":["THETA-USDC","THETA-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "190"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"THETA","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["THETAUSDT"]},"BinanceUS":{"symbol":["THETAUSDT"]},"Bybit":{"symbol":["THETAUSDT"]},"CryptoCom":{"instrument_name":["THETA_USDT"]},"GateIo":{"id":["THETA_USDT"]},"KuCoin":{"symbol":["THETA-USDT"]},"OKX":{"instId":["THETA-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "191"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"THETA","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["THETA-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "192"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"GRT","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[6719],"symbol":["GRT"]}},"exchanges":{"Binance":{"symbol":["GRTUSDT"]},"BinanceUS":{"symbol":["GRTUSDT"]},"Bitfinex":{"symbol":["GRTUSD"]},"Bitget":{"symbol":["GRTUSDT_SPBL"]},"Bybit":{"symbol":["GRTUSDT"]},"Coinbase":{"id":["GRT-USD"]},"CryptoCom":{"instrument_name":["GRTUSD-PERP","GRT_USD","GRT_USDT"]},"GateIo":{"id":["GRT_USDT"]},"Gemini":{"symbol":["GRTUSD"]},"Kraken":{"pair":["GRTUSD"],"wsname":["GRT/USD"]},"KuCoin":{"symbol":["GRT-USDT"]},"MEXC":{"symbol":["GRTUSDT"]},"OKX":{"instId":["GRT-USDC","GRT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "193"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"GRT","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["GRTETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "194"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"GRT","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["GRTUSDT"]},"BinanceUS":{"symbol":["GRTUSDT"]},"Bitget":{"symbol":["GRTUSDT_SPBL"]},"Bybit":{"symbol":["GRTUSDT"]},"CryptoCom":{"instrument_name":["GRT_USDT"]},"GateIo":{"id":["GRT_USDT"]},"KuCoin":{"symbol":["GRT-USDT"]},"MEXC":{"symbol":["GRTUSDT"]},"OKX":{"instId":["GRT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "195"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"GRT","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["GRT-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "196"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SEI","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[23149],"symbol":["SEI"]}},"exchanges":{"Binance":{"symbol":["SEIUSDC","SEIUSDT"]},"Bitfinex":{"symbol":["SEIUSD"]},"Bitget":{"symbol":["SEIUSDT_SPBL"]},"Bybit":{"symbol":["SEIUSDC","SEIUSDT"]},"Coinbase":{"id":["SEI-USD"]},"CryptoCom":{"instrument_name":["SEIUSD-PERP","SEI_USD","SEI_USDT"]},"GateIo":{"id":["SEI_USDC","SEI_USDT"]},"Kraken":{"pair":["SEIUSD"],"wsname":["SEI/USD"]},"KuCoin":{"symbol":["SEI-USDT"]},"MEXC":{"symbol":["SEIUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "197"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SEI","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SEIUSDT"]},"Bitget":{"symbol":["SEIUSDT_SPBL"]},"Bybit":{"symbol":["SEIUSDT"]},"CryptoCom":{"instrument_name":["SEI_USDT"]},"GateIo":{"id":["SEI_USDT"]},"KuCoin":{"symbol":["SEI-USDT"]},"MEXC":{"symbol":["SEIUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "198"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SEI","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SEIUSDC"]},"Bybit":{"symbol":["SEIUSDC"]},"GateIo":{"id":["SEI_USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "199"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BONK","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[23095,29975,30674,31136],"symbol":["BONK","BONK","BONK","BONK"]}},"exchanges":{"Binance":{"symbol":["BONKUSDC","BONKUSDT"]},"BinanceUS":{"symbol":["BONKUSDT"]},"Bitfinex":{"symbol":["BONK:USD"]},"Bitget":{"symbol":["BONKUSDT_SPBL"]},"Bybit":{"symbol":["BONKUSDC","BONKUSDT"]},"Coinbase":{"id":["BONK-USD"]},"CryptoCom":{"instrument_name":["BONKUSD-PERP","BONK_USD","BONK_USDT"]},"GateIo":{"id":["BONK_USDC","BONK_USDT"]},"Gemini":{"symbol":["BONKUSD"]},"Kraken":{"pair":["BONKUSD"],"wsname":["BONK/USD"]},"KuCoin":{"symbol":["BONK-USDT"]},"MEXC":{"symbol":["BONKUSDT"]},"OKX":{"instId":["BONK-USDC","BONK-USDT"]},"Upbit":{"market":["USDT-BONK"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "200"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BONK","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BONKUSDT"]},"BinanceUS":{"symbol":["BONKUSDT"]},"Bitget":{"symbol":["BONKUSDT_SPBL"]},"Bybit":{"symbol":["BONKUSDT"]},"CryptoCom":{"instrument_name":["BONK_USDT"]},"GateIo":{"id":["BONK_USDT"]},"KuCoin":{"symbol":["BONK-USDT"]},"MEXC":{"symbol":["BONKUSDT"]},"OKX":{"instId":["BONK-USDT"]},"Upbit":{"market":["USDT-BONK"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "201"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BONK","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BONKUSDC"]},"Bybit":{"symbol":["BONKUSDC"]},"GateIo":{"id":["BONK_USDC"]},"OKX":{"instId":["BONK-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "202"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"LDO","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[8000],"symbol":["LDO"]}},"exchanges":{"Binance":{"symbol":["LDOUSDC","LDOUSDT"]},"BinanceUS":{"symbol":["LDOUSDT"]},"Bitfinex":{"symbol":["LDOUSD"]},"Bitget":{"symbol":["LDOUSDT_SPBL"]},"Bybit":{"symbol":["LDOUSDC","LDOUSDT"]},"Coinbase":{"id":["LDO-USD"]},"CryptoCom":{"instrument_name":["LDOUSD-PERP","LDO_USD","LDO_USDT"]},"GateIo":{"id":["LDO_USDC","LDO_USDT"]},"Gemini":{"symbol":["LDOUSD"]},"Kraken":{"pair":["LDOUSD"],"wsname":["LDO/USD"]},"KuCoin":{"symbol":["LDO-USDC","LDO-USDT"]},"MEXC":{"symbol":["LDOUSDT"]},"OKX":{"instId":["LDO-USDC","LDO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "203"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"LDO","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["LDOUSDT"]},"BinanceUS":{"symbol":["LDOUSDT"]},"Bitget":{"symbol":["LDOUSDT_SPBL"]},"Bybit":{"symbol":["LDOUSDT"]},"CryptoCom":{"instrument_name":["LDO_USDT"]},"GateIo":{"id":["LDO_USDT"]},"KuCoin":{"symbol":["LDO-USDT"]},"MEXC":{"symbol":["LDOUSDT"]},"OKX":{"instId":["LDO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "204"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"LDO","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["LDOUSDC"]},"Bybit":{"symbol":["LDOUSDC"]},"GateIo":{"id":["LDO_USDC"]},"KuCoin":{"symbol":["LDO-USDC"]},"OKX":{"instId":["LDO-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "205"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"EOS","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1765],"symbol":["EOS"]}},"exchanges":{"Binance":{"symbol":["EOSUSDC","EOSUSDT"]},"BinanceUS":{"symbol":["EOSUSDT"]},"Bitfinex":{"symbol":["EOSUSD"]},"Bitget":{"symbol":["EOSUSDT_SPBL"]},"Bybit":{"symbol":["EOSUSDC","EOSUSDT"]},"Coinbase":{"id":["EOS-USD"]},"CryptoCom":{"instrument_name":["EOSUSD-PERP","EOS_USD","EOS_USDT"]},"GateIo":{"id":["EOS_USDC","EOS_USDT"]},"Kraken":{"pair":["EOSUSD","EOSUSDC","EOSUSDT"],"wsname":["EOS/USD","EOS/USDC","EOS/USDT"]},"KuCoin":{"symbol":["EOS-USDC","EOS-USDT"]},"MEXC":{"symbol":["EOSUSDC","EOSUSDT"]},"OKX":{"instId":["EOS-USDC","EOS-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "206"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"EOS","quote":"BNB"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["EOSBNB"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "207"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"EOS","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["EOSUSDT"]},"BinanceUS":{"symbol":["EOSUSDT"]},"Bitget":{"symbol":["EOSUSDT_SPBL"]},"Bybit":{"symbol":["EOSUSDT"]},"CryptoCom":{"instrument_name":["EOS_USDT"]},"GateIo":{"id":["EOS_USDT"]},"Kraken":{"pair":["EOSUSDT"],"wsname":["EOS/USDT"]},"KuCoin":{"symbol":["EOS-USDT"]},"MEXC":{"symbol":["EOSUSDT"]},"OKX":{"instId":["EOS-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "208"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"EOS","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["EOSUSDC"]},"Bybit":{"symbol":["EOSUSDC"]},"GateIo":{"id":["EOS_USDC"]},"Kraken":{"pair":["EOSUSDC"],"wsname":["EOS/USDC"]},"KuCoin":{"symbol":["EOS-USDC"]},"MEXC":{"symbol":["EOSUSDC"]},"OKX":{"instId":["EOS-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "209"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"GALA","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[7080],"symbol":["GALA"]}},"exchanges":{"Binance":{"symbol":["GALAUSDC","GALAUSDT"]},"BinanceUS":{"symbol":["GALAUSDT"]},"Bitfinex":{"symbol":["GALA:USD"]},"Bitget":{"symbol":["GALAUSDT_SPBL"]},"Bybit":{"symbol":["GALAUSDT"]},"Coinbase":{"id":["GALA-USD","GALA-USDT"]},"CryptoCom":{"instrument_name":["GALAUSD-PERP","GALA_USD","GALA_USDT"]},"GateIo":{"id":["GALA_USDC","GALA_USDT"]},"Gemini":{"symbol":["GALAUSD"]},"Kraken":{"pair":["GALAUSD"],"wsname":["GALA/USD"]},"MEXC":{"symbol":["GALAUSDT"]},"OKX":{"instId":["GALA-USDC","GALA-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "210"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"GALA","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["GALAUSDT"]},"BinanceUS":{"symbol":["GALAUSDT"]},"Bitget":{"symbol":["GALAUSDT_SPBL"]},"Bybit":{"symbol":["GALAUSDT"]},"Coinbase":{"id":["GALA-USDT"]},"CryptoCom":{"instrument_name":["GALA_USDT"]},"GateIo":{"id":["GALA_USDT"]},"MEXC":{"symbol":["GALAUSDT"]},"OKX":{"instId":["GALA-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "211"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"GALA","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["GALAUSDC"]},"GateIo":{"id":["GALA_USDC"]},"OKX":{"instId":["GALA-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "212"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"PYUSD","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[27772],"symbol":["PYUSD"]}},"exchanges":{"Bitget":{"symbol":["PYUSDUSDT_SPBL"]},"Bybit":{"symbol":["PYUSDUSDT"]},"Coinbase":{"id":["PYUSD-USD"]},"CryptoCom":{"instrument_name":["PYUSD_USD","PYUSD_USDT"]},"GateIo":{"id":["PYUSD_USDT"]},"Kraken":{"pair":["PYUSDUSD"],"wsname":["PYUSD/USD"]},"KuCoin":{"symbol":["PYUSD-USDT"]},"OKX":{"instId":["PYUSD-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "213"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"PYUSD","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["PYUSDUSDT_SPBL"]},"Bybit":{"symbol":["PYUSDUSDT"]},"CryptoCom":{"instrument_name":["PYUSD_USDT"]},"GateIo":{"id":["PYUSD_USDT"]},"KuCoin":{"symbol":["PYUSD-USDT"]},"OKX":{"instId":["PYUSD-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "214"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"XTZ","quote":"BNB"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["XTZBNB"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "215"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"XTZ","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[2011],"symbol":["XTZ"]}},"exchanges":{"Binance":{"symbol":["XTZUSDC","XTZUSDT"]},"BinanceTR":{"symbol":["XTZ_USDT"]},"BinanceUS":{"symbol":["XTZUSDT"]},"Bitfinex":{"symbol":["XTZUSD"]},"Bitget":{"symbol":["XTZUSDT_SPBL"]},"Bybit":{"symbol":["XTZUSDT"]},"Coinbase":{"id":["XTZ-USD"]},"CryptoCom":{"instrument_name":["XTZUSD-PERP","XTZ_USD","XTZ_USDT"]},"GateIo":{"id":["XTZ_USDT"]},"Gemini":{"symbol":["XTZUSD"]},"Kraken":{"pair":["XTZUSD","XTZUSDC","XTZUSDT"],"wsname":["XTZ/USD","XTZ/USDC","XTZ/USDT"]},"KuCoin":{"symbol":["XTZ-USDT"]},"MEXC":{"symbol":["XTZUSDT"]},"OKX":{"instId":["XTZ-USDC","XTZ-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "216"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"XTZ","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["XTZUSDT"]},"BinanceTR":{"symbol":["XTZ_USDT"]},"BinanceUS":{"symbol":["XTZUSDT"]},"Bitget":{"symbol":["XTZUSDT_SPBL"]},"Bybit":{"symbol":["XTZUSDT"]},"CryptoCom":{"instrument_name":["XTZ_USDT"]},"GateIo":{"id":["XTZ_USDT"]},"Kraken":{"pair":["XTZUSDT"],"wsname":["XTZ/USDT"]},"KuCoin":{"symbol":["XTZ-USDT"]},"MEXC":{"symbol":["XTZUSDT"]},"OKX":{"instId":["XTZ-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "217"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"XTZ","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["XTZUSDC"]},"Kraken":{"pair":["XTZUSDC"],"wsname":["XTZ/USDC"]},"OKX":{"instId":["XTZ-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "218"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SAND","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[6210],"symbol":["SAND"]}},"exchanges":{"Binance":{"symbol":["SANDUSDC","SANDUSDT"]},"BinanceUS":{"symbol":["SANDUSDT"]},"Bitfinex":{"symbol":["SAND:USD"]},"Bitget":{"symbol":["SANDUSDT_SPBL"]},"Bybit":{"symbol":["SANDUSDC","SANDUSDT"]},"Coinbase":{"id":["SAND-USD","SAND-USDT"]},"CryptoCom":{"instrument_name":["SANDUSD-PERP","SAND_USD","SAND_USDT"]},"GateIo":{"id":["SAND_USDT"]},"Gemini":{"symbol":["SANDUSD"]},"Kraken":{"pair":["SANDUSD"],"wsname":["SAND/USD"]},"KuCoin":{"symbol":["SAND-USDT"]},"MEXC":{"symbol":["SANDUSDT"]},"OKX":{"instId":["SAND-USDC","SAND-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "219"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SAND","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SANDUSDT"]},"BinanceUS":{"symbol":["SANDUSDT"]},"Bitget":{"symbol":["SANDUSDT_SPBL"]},"Bybit":{"symbol":["SANDUSDT"]},"Coinbase":{"id":["SAND-USDT"]},"CryptoCom":{"instrument_name":["SAND_USDT"]},"GateIo":{"id":["SAND_USDT"]},"KuCoin":{"symbol":["SAND-USDT"]},"MEXC":{"symbol":["SANDUSDT"]},"OKX":{"instId":["SAND-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "220"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SAND","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SANDUSDC"]},"Bybit":{"symbol":["SANDUSDC"]},"OKX":{"instId":["SAND-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "221"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BERA","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[24647],"symbol":["BERA"]}},"exchanges":{"Binance":{"symbol":["BERAUSDC","BERAUSDT"]},"Bitget":{"symbol":["BERAUSDT_SPBL"]},"Bybit":{"symbol":["BERAUSDT"]},"Coinbase":{"id":["BERA-USD"]},"CryptoCom":{"instrument_name":["BERAUSD-PERP","BERA_USD"]},"GateIo":{"id":["BERA_USDT"]},"Kraken":{"pair":["BERAUSD","BERAUSDC","BERAUSDT"],"wsname":["BERA/USD","BERA/USDC","BERA/USDT"]},"KuCoin":{"symbol":["BERA-USDT"]},"MEXC":{"symbol":["BERAUSDT"]},"OKX":{"instId":["BERA-USD","BERA-USDT"]},"Upbit":{"market":["USDT-BERA"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "222"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BERA","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BERAUSDT"]},"Bitget":{"symbol":["BERAUSDT_SPBL"]},"Bybit":{"symbol":["BERAUSDT"]},"GateIo":{"id":["BERA_USDT"]},"Kraken":{"pair":["BERAUSDT"],"wsname":["BERA/USDT"]},"KuCoin":{"symbol":["BERA-USDT"]},"MEXC":{"symbol":["BERAUSDT"]},"OKX":{"instId":["BERA-USDT"]},"Upbit":{"market":["USDT-BERA"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "223"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BERA","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BERAUSDC"]},"Kraken":{"pair":["BERAUSDC"],"wsname":["BERA/USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "224"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"JTO","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28541],"symbol":["JTO"]}},"exchanges":{"Binance":{"symbol":["JTOUSDC","JTOUSDT"]},"Bitget":{"symbol":["JTOUSDT_SPBL"]},"Bybit":{"symbol":["JTOUSDT"]},"Coinbase":{"id":["JTO-USD"]},"CryptoCom":{"instrument_name":["JTOUSD-PERP","JTO_USD"]},"GateIo":{"id":["JTO_USDC","JTO_USDT"]},"Kraken":{"pair":["JTOUSD"],"wsname":["JTO/USD"]},"KuCoin":{"symbol":["JTO-USDT"]},"MEXC":{"symbol":["JTOUSDT"]},"OKX":{"instId":["JTO-USDC","JTO-USDT"]},"Upbit":{"market":["USDT-JTO"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "225"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"JTO","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["JTOUSDT"]},"Bitget":{"symbol":["JTOUSDT_SPBL"]},"Bybit":{"symbol":["JTOUSDT"]},"GateIo":{"id":["JTO_USDT"]},"KuCoin":{"symbol":["JTO-USDT"]},"MEXC":{"symbol":["JTOUSDT"]},"OKX":{"instId":["JTO-USDT"]},"Upbit":{"market":["USDT-JTO"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "226"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"JTO","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["JTOUSDC"]},"GateIo":{"id":["JTO_USDC"]},"OKX":{"instId":["JTO-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "227"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"FLOW","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[4558],"symbol":["FLOW"]}},"exchanges":{"Binance":{"symbol":["FLOWUSDT"]},"BinanceUS":{"symbol":["FLOWUSDT"]},"Bitget":{"symbol":["FLOWUSDT_SPBL"]},"Bybit":{"symbol":["FLOWUSDT"]},"Coinbase":{"id":["FLOW-USD","FLOW-USDT"]},"CryptoCom":{"instrument_name":["FLOWUSD-PERP","FLOW_USD","FLOW_USDT"]},"GateIo":{"id":["FLOW_USDT"]},"Kraken":{"pair":["FLOWUSD"],"wsname":["FLOW/USD"]},"KuCoin":{"symbol":["FLOW-USDT"]},"MEXC":{"symbol":["FLOWUSDT"]},"OKX":{"instId":["FLOW-USDC","FLOW-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "228"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"FLOW","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["FLOWUSDT"]},"BinanceUS":{"symbol":["FLOWUSDT"]},"Bitget":{"symbol":["FLOWUSDT_SPBL"]},"Bybit":{"symbol":["FLOWUSDT"]},"Coinbase":{"id":["FLOW-USDT"]},"CryptoCom":{"instrument_name":["FLOW_USDT"]},"GateIo":{"id":["FLOW_USDT"]},"KuCoin":{"symbol":["FLOW-USDT"]},"MEXC":{"symbol":["FLOWUSDT"]},"OKX":{"instId":["FLOW-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "229"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"FLOW","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["FLOW-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "230"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"FLOKI","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[10804,13074,29860,30253],"symbol":["FLOKI","FLOKI","FLOKI","FLOKI"]}},"exchanges":{"Binance":{"symbol":["FLOKIUSDC","FLOKIUSDT"]},"BinanceUS":{"symbol":["FLOKIUSDT"]},"Bitfinex":{"symbol":["FLOKI:USD"]},"Bitget":{"symbol":["FLOKIUSDC_SPBL","FLOKIUSDT_SPBL"]},"Bybit":{"symbol":["FLOKIUSDC","FLOKIUSDT"]},"Coinbase":{"id":["FLOKI-USD"]},"CryptoCom":{"instrument_name":["FLOKIUSD-PERP","FLOKI_USD","FLOKI_USDT"]},"GateIo":{"id":["FLOKI_USDC","FLOKI_USDT"]},"Gemini":{"symbol":["FLOKIUSD"]},"Kraken":{"pair":["FLOKIUSD"],"wsname":["FLOKI/USD"]},"KuCoin":{"symbol":["FLOKI-USDC","FLOKI-USDT"]},"MEXC":{"symbol":["FLOKIUSDT"]},"OKX":{"instId":["FLOKI-USDC","FLOKI-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "231"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"FLOKI","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["FLOKIUSDT"]},"BinanceUS":{"symbol":["FLOKIUSDT"]},"Bitget":{"symbol":["FLOKIUSDT_SPBL"]},"Bybit":{"symbol":["FLOKIUSDT"]},"CryptoCom":{"instrument_name":["FLOKI_USDT"]},"GateIo":{"id":["FLOKI_USDT"]},"KuCoin":{"symbol":["FLOKI-USDT"]},"MEXC":{"symbol":["FLOKIUSDT"]},"OKX":{"instId":["FLOKI-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "232"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"FLOKI","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["FLOKIUSDC"]},"Bitget":{"symbol":["FLOKIUSDC_SPBL"]},"Bybit":{"symbol":["FLOKIUSDC"]},"GateIo":{"id":["FLOKI_USDC"]},"KuCoin":{"symbol":["FLOKI-USDC"]},"OKX":{"instId":["FLOKI-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "233"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ENS","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[13855],"symbol":["ENS"]}},"exchanges":{"Binance":{"symbol":["ENSUSDC","ENSUSDT"]},"BinanceUS":{"symbol":["ENSUSDT"]},"Bitget":{"symbol":["ENSUSDT_SPBL"]},"Bybit":{"symbol":["ENSUSDT"]},"Coinbase":{"id":["ENS-USD","ENS-USDT"]},"CryptoCom":{"instrument_name":["ENSUSD-PERP","ENS_USD","ENS_USDT"]},"GateIo":{"id":["ENS_USDC","ENS_USDT"]},"Gemini":{"symbol":["ENSUSD"]},"Kraken":{"pair":["ENSUSD"],"wsname":["ENS/USD"]},"KuCoin":{"symbol":["ENS-USDT"]},"MEXC":{"symbol":["ENSUSDC","ENSUSDT"]},"OKX":{"instId":["ENS-USD","ENS-USDC","ENS-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "234"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ENS","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ENSUSDT"]},"BinanceUS":{"symbol":["ENSUSDT"]},"Bitget":{"symbol":["ENSUSDT_SPBL"]},"Bybit":{"symbol":["ENSUSDT"]},"Coinbase":{"id":["ENS-USDT"]},"CryptoCom":{"instrument_name":["ENS_USDT"]},"GateIo":{"id":["ENS_USDT"]},"KuCoin":{"symbol":["ENS-USDT"]},"MEXC":{"symbol":["ENSUSDT"]},"OKX":{"instId":["ENS-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "235"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ENS","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ENSUSDC"]},"GateIo":{"id":["ENS_USDC"]},"MEXC":{"symbol":["ENSUSDC"]},"OKX":{"instId":["ENS-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "236"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MANA","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1966],"symbol":["MANA"]}},"exchanges":{"Binance":{"symbol":["MANAUSDT"]},"BinanceTR":{"symbol":["MANA_USDT"]},"BinanceUS":{"symbol":["MANAUSDT"]},"Bitget":{"symbol":["MANAUSDT_SPBL"]},"Bybit":{"symbol":["MANAUSDC","MANAUSDT"]},"Coinbase":{"id":["MANA-USD","MANA-USDC"]},"CryptoCom":{"instrument_name":["MANAUSD-PERP","MANA_USD","MANA_USDT"]},"GateIo":{"id":["MANA_USDT"]},"Gemini":{"symbol":["MANAUSD"]},"Kraken":{"pair":["MANAUSD","MANAUSDC","MANAUSDT"],"wsname":["MANA/USD","MANA/USDC","MANA/USDT"]},"KuCoin":{"symbol":["MANA-USDT"]},"MEXC":{"symbol":["MANAUSDT"]},"OKX":{"instId":["MANA-USDC","MANA-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "237"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MANA","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["MANAETH"]},"Coinbase":{"id":["MANA-ETH"]},"KuCoin":{"symbol":["MANA-ETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "238"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MANA","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["MANAUSDT"]},"BinanceTR":{"symbol":["MANA_USDT"]},"BinanceUS":{"symbol":["MANAUSDT"]},"Bitget":{"symbol":["MANAUSDT_SPBL"]},"Bybit":{"symbol":["MANAUSDT"]},"CryptoCom":{"instrument_name":["MANA_USDT"]},"GateIo":{"id":["MANA_USDT"]},"Kraken":{"pair":["MANAUSDT"],"wsname":["MANA/USDT"]},"KuCoin":{"symbol":["MANA-USDT"]},"MEXC":{"symbol":["MANAUSDT"]},"OKX":{"instId":["MANA-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "239"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MANA","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bybit":{"symbol":["MANAUSDC"]},"Coinbase":{"id":["MANA-USDC"]},"Kraken":{"pair":["MANAUSDC"],"wsname":["MANA/USDC"]},"OKX":{"instId":["MANA-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "240"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CRV","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[6538],"symbol":["CRV"]}},"exchanges":{"Binance":{"symbol":["CRVUSDC","CRVUSDT"]},"BinanceUS":{"symbol":["CRVUSDT"]},"Bitfinex":{"symbol":["CRVUSD"]},"Bitget":{"symbol":["CRVUSDT_SPBL"]},"Bybit":{"symbol":["CRVUSDT"]},"Coinbase":{"id":["CRV-USD"]},"CryptoCom":{"instrument_name":["CRVUSD-PERP","CRV_USD","CRV_USDT"]},"GateIo":{"id":["CRV_USDC","CRV_USDT"]},"Gemini":{"symbol":["CRVUSD"]},"Kraken":{"pair":["CRVUSD"],"wsname":["CRV/USD"]},"KuCoin":{"symbol":["CRV-USDT"]},"MEXC":{"symbol":["CRVUSDT"]},"OKX":{"instId":["CRV-USD","CRV-USDC","CRV-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "241"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"CRV","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["CRVETH"]},"GateIo":{"id":["CRV_ETH"]},"MEXC":{"symbol":["CRVETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "242"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CRV","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["CRVUSDT"]},"BinanceUS":{"symbol":["CRVUSDT"]},"Bitget":{"symbol":["CRVUSDT_SPBL"]},"Bybit":{"symbol":["CRVUSDT"]},"CryptoCom":{"instrument_name":["CRV_USDT"]},"GateIo":{"id":["CRV_USDT"]},"KuCoin":{"symbol":["CRV-USDT"]},"MEXC":{"symbol":["CRVUSDT"]},"OKX":{"instId":["CRV-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "243"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CRV","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["CRVUSDC"]},"GateIo":{"id":["CRV_USDC"]},"OKX":{"instId":["CRV-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "244"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PYTH","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28177],"symbol":["PYTH"]}},"exchanges":{"Binance":{"symbol":["PYTHUSDC","PYTHUSDT"]},"Bitget":{"symbol":["PYTHUSDT_SPBL"]},"Bybit":{"symbol":["PYTHUSDT"]},"Coinbase":{"id":["PYTH-USD"]},"CryptoCom":{"instrument_name":["PYTHUSD-PERP","PYTH_USD","PYTH_USDT"]},"GateIo":{"id":["PYTH_USDT"]},"Gemini":{"symbol":["PYTHUSD"]},"Kraken":{"pair":["PYTHUSD"],"wsname":["PYTH/USD"]},"KuCoin":{"symbol":["PYTH-USDT"]},"MEXC":{"symbol":["PYTHUSDT"]},"OKX":{"instId":["PYTH-USDC","PYTH-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "245"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PYTH","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["PYTHUSDT"]},"Bitget":{"symbol":["PYTHUSDT_SPBL"]},"Bybit":{"symbol":["PYTHUSDT"]},"CryptoCom":{"instrument_name":["PYTH_USDT"]},"GateIo":{"id":["PYTH_USDT"]},"KuCoin":{"symbol":["PYTH-USDT"]},"MEXC":{"symbol":["PYTHUSDT"]},"OKX":{"instId":["PYTH-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "246"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PYTH","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["PYTHUSDC"]},"OKX":{"instId":["PYTH-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "247"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"EGLD","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[6892],"symbol":["EGLD"]}},"exchanges":{"Binance":{"symbol":["EGLDUSDC","EGLDUSDT"]},"BinanceUS":{"symbol":["EGLDUSDT"]},"Bitfinex":{"symbol":["EGLD:USD"]},"Bitget":{"symbol":["EGLDUSDT_SPBL"]},"Bybit":{"symbol":["EGLDUSDT"]},"Coinbase":{"id":["EGLD-USD"]},"CryptoCom":{"instrument_name":["EGLDUSD-PERP","EGLD_USD","EGLD_USDT"]},"GateIo":{"id":["EGLD_USDT"]},"Kraken":{"pair":["EGLDUSD"],"wsname":["EGLD/USD"]},"KuCoin":{"symbol":["EGLD-USDT"]},"MEXC":{"symbol":["EGLDUSDT"]},"OKX":{"instId":["EGLD-USDC","EGLD-USDT"]},"Upbit":{"market":["USDT-EGLD"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "248"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"EGLD","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["EGLDUSDT"]},"BinanceUS":{"symbol":["EGLDUSDT"]},"Bitget":{"symbol":["EGLDUSDT_SPBL"]},"Bybit":{"symbol":["EGLDUSDT"]},"CryptoCom":{"instrument_name":["EGLD_USDT"]},"GateIo":{"id":["EGLD_USDT"]},"KuCoin":{"symbol":["EGLD-USDT"]},"MEXC":{"symbol":["EGLDUSDT"]},"OKX":{"instId":["EGLD-USDT"]},"Upbit":{"market":["USDT-EGLD"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "249"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"EGLD","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["EGLDUSDC"]},"OKX":{"instId":["EGLD-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "250"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RON","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[14101],"symbol":["RON"]}},"exchanges":{"Bitget":{"symbol":["RONUSDT_SPBL"]},"GateIo":{"id":["RON_USDT"]},"MEXC":{"symbol":["RONUSDT"]},"OKX":{"instId":["RON-USDC","RON-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "251"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RON","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["RONUSDT_SPBL"]},"GateIo":{"id":["RON_USDT"]},"MEXC":{"symbol":["RONUSDT"]},"OKX":{"instId":["RON-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "252"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RON","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["RON-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "253"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"AXS","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[6783],"symbol":["AXS"]}},"exchanges":{"Binance":{"symbol":["AXSUSDT"]},"BinanceUS":{"symbol":["AXSUSDT"]},"Bitget":{"symbol":["AXSUSDT_SPBL"]},"Bybit":{"symbol":["AXSUSDT"]},"Coinbase":{"id":["AXS-USD","AXS-USDT"]},"CryptoCom":{"instrument_name":["AXSUSD-PERP","AXS_USD","AXS_USDT"]},"GateIo":{"id":["AXS_USDT"]},"Gemini":{"symbol":["AXSUSD"]},"Kraken":{"pair":["AXSUSD"],"wsname":["AXS/USD"]},"KuCoin":{"symbol":["AXS-USDT"]},"MEXC":{"symbol":["AXSUSDT"]},"OKX":{"instId":["AXS-USDC","AXS-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "254"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"AXS","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["AXSUSDT"]},"BinanceUS":{"symbol":["AXSUSDT"]},"Bitget":{"symbol":["AXSUSDT_SPBL"]},"Bybit":{"symbol":["AXSUSDT"]},"Coinbase":{"id":["AXS-USDT"]},"CryptoCom":{"instrument_name":["AXS_USDT"]},"GateIo":{"id":["AXS_USDT"]},"KuCoin":{"symbol":["AXS-USDT"]},"MEXC":{"symbol":["AXSUSDT"]},"OKX":{"instId":["AXS-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "255"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"AXS","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["AXS-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "256"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"TUSD","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[2563],"symbol":["TUSD"]}},"exchanges":{"Binance":{"symbol":["TUSDUSDT"]},"BinanceTR":{"symbol":["TUSD_USDT"]},"BinanceUS":{"symbol":["TUSDUSDT"]},"Bitget":{"symbol":["TUSDUSDT_SPBL"]},"Bybit":{"symbol":["TUSDUSDT"]},"GateIo":{"id":["TUSD_USDT"]},"Kraken":{"pair":["TUSDUSD"],"wsname":["TUSD/USD"]},"KuCoin":{"symbol":["TUSD-USDT"]},"MEXC":{"symbol":["TUSDUSDT"]},"Upbit":{"market":["USDT-TUSD"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "257"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TUSD","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["TUSDETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "258"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"TUSD","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["TUSDUSDT"]},"BinanceTR":{"symbol":["TUSD_USDT"]},"BinanceUS":{"symbol":["TUSDUSDT"]},"Bitget":{"symbol":["TUSDUSDT_SPBL"]},"Bybit":{"symbol":["TUSDUSDT"]},"GateIo":{"id":["TUSD_USDT"]},"KuCoin":{"symbol":["TUSD-USDT"]},"MEXC":{"symbol":["TUSDUSDT"]},"Upbit":{"market":["USDT-TUSD"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "259"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ZEC","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1437],"symbol":["ZEC"]}},"exchanges":{"Binance":{"symbol":["ZECUSDC","ZECUSDT"]},"BinanceUS":{"symbol":["ZECUSDT"]},"Bitfinex":{"symbol":["ZECUSD"]},"Coinbase":{"id":["ZEC-USD","ZEC-USDC"]},"Gemini":{"symbol":["ZECUSD"]},"Kraken":{"pair":["XZECZUSD"],"wsname":["ZEC/USD"]},"KuCoin":{"symbol":["ZEC-USDT"]},"MEXC":{"symbol":["ZECUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "260"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ZEC","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ZECUSDT"]},"BinanceUS":{"symbol":["ZECUSDT"]},"KuCoin":{"symbol":["ZEC-USDT"]},"MEXC":{"symbol":["ZECUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "261"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ZEC","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ZECUSDC"]},"Coinbase":{"id":["ZEC-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "262"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"KAVA","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[4846],"symbol":["KAVA"]}},"exchanges":{"Binance":{"symbol":["KAVAUSDT"]},"BinanceUS":{"symbol":["KAVAUSDT"]},"Bitfinex":{"symbol":["KAVA:USD"]},"Bitget":{"symbol":["KAVAUSDT_SPBL"]},"Bybit":{"symbol":["KAVAUSDT"]},"Coinbase":{"id":["KAVA-USD"]},"CryptoCom":{"instrument_name":["KAVAUSD-PERP","KAVA_USD","KAVA_USDT"]},"GateIo":{"id":["KAVA_USDT"]},"Kraken":{"pair":["KAVAUSD"],"wsname":["KAVA/USD"]},"KuCoin":{"symbol":["KAVA-USDT"]},"MEXC":{"symbol":["KAVAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "263"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"KAVA","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["KAVAUSDT"]},"BinanceUS":{"symbol":["KAVAUSDT"]},"Bitget":{"symbol":["KAVAUSDT_SPBL"]},"Bybit":{"symbol":["KAVAUSDT"]},"CryptoCom":{"instrument_name":["KAVA_USDT"]},"GateIo":{"id":["KAVA_USDT"]},"KuCoin":{"symbol":["KAVA-USDT"]},"MEXC":{"symbol":["KAVAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "264"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"DYDX","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28324],"symbol":["DYDX"]}},"exchanges":{"Binance":{"symbol":["DYDXUSDC","DYDXUSDT"]},"Bitget":{"symbol":["DYDXUSDC_SPBL","DYDXUSDT_SPBL"]},"Bybit":{"symbol":["DYDXUSDT"]},"CryptoCom":{"instrument_name":["DYDXUSD-PERP","DYDX_USD","DYDX_USDT"]},"GateIo":{"id":["DYDX_USDT"]},"Kraken":{"pair":["DYDXUSD"],"wsname":["DYDX/USD"]},"KuCoin":{"symbol":["DYDX-USDT"]},"MEXC":{"symbol":["DYDXUSDT"]},"OKX":{"instId":["DYDX-USDC","DYDX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "265"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"DYDX","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["DYDXUSDT"]},"Bitget":{"symbol":["DYDXUSDT_SPBL"]},"Bybit":{"symbol":["DYDXUSDT"]},"CryptoCom":{"instrument_name":["DYDX_USDT"]},"GateIo":{"id":["DYDX_USDT"]},"KuCoin":{"symbol":["DYDX-USDT"]},"MEXC":{"symbol":["DYDXUSDT"]},"OKX":{"instId":["DYDX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "266"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"DYDX","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["DYDXUSDC"]},"Bitget":{"symbol":["DYDXUSDC_SPBL"]},"OKX":{"instId":["DYDX-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "267"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"XCN","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[18679,501],"symbol":["XCN","XCN"]}},"exchanges":{"Bitget":{"symbol":["XCNUSDT_SPBL"]},"Coinbase":{"id":["XCN-USD","XCN-USDT"]},"GateIo":{"id":["XCN_USDT"]},"Kraken":{"pair":["XCNUSD"],"wsname":["XCN/USD"]},"KuCoin":{"symbol":["XCN-USDT"]},"MEXC":{"symbol":["XCNUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "268"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"XCN","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["XCNUSDT_SPBL"]},"Coinbase":{"id":["XCN-USDT"]},"GateIo":{"id":["XCN_USDT"]},"KuCoin":{"symbol":["XCN-USDT"]},"MEXC":{"symbol":["XCNUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "269"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"WIF","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28752,30119,31221,31505,31733,31817],"symbol":["WIF","WIF","WIF","WIF","WIF","WIF"]}},"exchanges":{"Binance":{"symbol":["WIFUSDC","WIFUSDT"]},"BinanceUS":{"symbol":["WIFUSDT"]},"Bitfinex":{"symbol":["WIFUSD"]},"Bitget":{"symbol":["WIFUSDT_SPBL"]},"Bybit":{"symbol":["WIFUSDC","WIFUSDT"]},"Coinbase":{"id":["WIF-USD"]},"CryptoCom":{"instrument_name":["WIFUSD-PERP","WIF_USD","WIF_USDT"]},"GateIo":{"id":["WIF_USDC","WIF_USDT"]},"Gemini":{"symbol":["WIFUSD"]},"Kraken":{"pair":["WIFUSD"],"wsname":["WIF/USD"]},"KuCoin":{"symbol":["WIF-USDT"]},"MEXC":{"symbol":["WIFUSDT"]},"OKX":{"instId":["WIF-USDC","WIF-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "270"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"WIF","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["WIFUSDT"]},"BinanceUS":{"symbol":["WIFUSDT"]},"Bitget":{"symbol":["WIFUSDT_SPBL"]},"Bybit":{"symbol":["WIFUSDT"]},"CryptoCom":{"instrument_name":["WIF_USDT"]},"GateIo":{"id":["WIF_USDT"]},"KuCoin":{"symbol":["WIF-USDT"]},"MEXC":{"symbol":["WIFUSDT"]},"OKX":{"instId":["WIF-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "271"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"WIF","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["WIFUSDC"]},"Bybit":{"symbol":["WIFUSDC"]},"GateIo":{"id":["WIF_USDC"]},"OKX":{"instId":["WIF-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "272"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"STRK","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[22691,8911],"symbol":["STRK","STRK"]}},"exchanges":{"Binance":{"symbol":["STRKUSDC","STRKUSDT"]},"Bitfinex":{"symbol":["STRK:USD"]},"Bitget":{"symbol":["STRKUSDT_SPBL"]},"Bybit":{"symbol":["STRKUSDC","STRKUSDT"]},"Coinbase":{"id":["STRK-USD"]},"CryptoCom":{"instrument_name":["STRKUSD-PERP","STRK_USD","STRK_USDT"]},"GateIo":{"id":["STRK_USDC","STRK_USDT"]},"Kraken":{"pair":["STRKUSD"],"wsname":["STRK/USD"]},"KuCoin":{"symbol":["STRK-USDT"]},"MEXC":{"symbol":["STRKUSDT"]},"OKX":{"instId":["STRK-USDC","STRK-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "273"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"STRK","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["STRKUSDT"]},"Bitget":{"symbol":["STRKUSDT_SPBL"]},"Bybit":{"symbol":["STRKUSDT"]},"CryptoCom":{"instrument_name":["STRK_USDT"]},"GateIo":{"id":["STRK_USDT"]},"KuCoin":{"symbol":["STRK-USDT"]},"MEXC":{"symbol":["STRKUSDT"]},"OKX":{"instId":["STRK-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "274"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"STRK","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["STRKUSDC"]},"Bybit":{"symbol":["STRKUSDC"]},"GateIo":{"id":["STRK_USDC"]},"OKX":{"instId":["STRK-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "275"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CAKE","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[7186],"symbol":["CAKE"]}},"exchanges":{"Binance":{"symbol":["CAKEUSDC","CAKEUSDT"]},"BinanceTR":{"symbol":["CAKE_USDT"]},"Bitget":{"symbol":["CAKEUSDT_SPBL"]},"Bybit":{"symbol":["CAKEUSDT"]},"GateIo":{"id":["CAKE_USDT"]},"KuCoin":{"symbol":["CAKE-USDT"]},"MEXC":{"symbol":["CAKEUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "276"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"CAKE","quote":"BNB"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["CAKEBNB"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "277"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CAKE","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["CAKEUSDT"]},"BinanceTR":{"symbol":["CAKE_USDT"]},"Bitget":{"symbol":["CAKEUSDT_SPBL"]},"Bybit":{"symbol":["CAKEUSDT"]},"GateIo":{"id":["CAKE_USDT"]},"KuCoin":{"symbol":["CAKE-USDT"]},"MEXC":{"symbol":["CAKEUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "278"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CAKE","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["CAKEUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "279"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MATIC","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[3890],"symbol":["MATIC"]}},"exchanges":{"Binance":{"symbol":["MATICUSDC","MATICUSDT"]},"BinanceUS":{"symbol":["MATICUSDT"]},"Bitfinex":{"symbol":["MATIC:USD"]},"Coinbase":{"id":["MATIC-USD","MATIC-USDT"]},"Gemini":{"symbol":["MATICUSD"]},"Kraken":{"pair":["MATICUSD","MATICUSDC","MATICUSDT"],"wsname":["MATIC/USD","MATIC/USDC","MATIC/USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "280"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MATIC","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["MATICUSDT"]},"BinanceUS":{"symbol":["MATICUSDT"]},"Coinbase":{"id":["MATIC-USDT"]},"Kraken":{"pair":["MATICUSDT"],"wsname":["MATIC/USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "281"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MATIC","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["MATICUSDC"]},"Kraken":{"pair":["MATICUSDC"],"wsname":["MATIC/USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "282"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"AERO","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[17706,29270],"symbol":["AERO","AERO"]}},"exchanges":{"Bitget":{"symbol":["AEROUSDT_SPBL"]},"Bybit":{"symbol":["AEROUSDT"]},"Coinbase":{"id":["AERO-USD"]},"CryptoCom":{"instrument_name":["AERO_USD"]},"GateIo":{"id":["AERO_USDT"]},"Kraken":{"pair":["AEROUSD"],"wsname":["AERO/USD"]},"KuCoin":{"symbol":["AERO-USDT"]},"MEXC":{"symbol":["AEROUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "283"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"AERO","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["AEROUSDT_SPBL"]},"Bybit":{"symbol":["AEROUSDT"]},"GateIo":{"id":["AERO_USDT"]},"KuCoin":{"symbol":["AERO-USDT"]},"MEXC":{"symbol":["AEROUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "284"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CHZ","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[4066],"symbol":["CHZ"]}},"exchanges":{"Binance":{"symbol":["CHZUSDC","CHZUSDT"]},"BinanceUS":{"symbol":["CHZUSDT"]},"Bitfinex":{"symbol":["CHZUSD"]},"Bitget":{"symbol":["CHZUSDT_SPBL"]},"Bybit":{"symbol":["CHZUSDC","CHZUSDT"]},"Coinbase":{"id":["CHZ-USD","CHZ-USDT"]},"CryptoCom":{"instrument_name":["CHZUSD-PERP","CHZ_USD","CHZ_USDT"]},"GateIo":{"id":["CHZ_USDT"]},"Gemini":{"symbol":["CHZUSD"]},"Kraken":{"pair":["CHZUSD"],"wsname":["CHZ/USD"]},"KuCoin":{"symbol":["CHZ-USDT"]},"MEXC":{"symbol":["CHZUSDT"]},"OKX":{"instId":["CHZ-USDC","CHZ-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "285"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CHZ","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["CHZUSDT"]},"BinanceUS":{"symbol":["CHZUSDT"]},"Bitget":{"symbol":["CHZUSDT_SPBL"]},"Bybit":{"symbol":["CHZUSDT"]},"Coinbase":{"id":["CHZ-USDT"]},"CryptoCom":{"instrument_name":["CHZ_USDT"]},"GateIo":{"id":["CHZ_USDT"]},"KuCoin":{"symbol":["CHZ-USDT"]},"MEXC":{"symbol":["CHZUSDT"]},"OKX":{"instId":["CHZ-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "286"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CHZ","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["CHZUSDC"]},"Bybit":{"symbol":["CHZUSDC"]},"OKX":{"instId":["CHZ-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "287"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FRAX","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[6952],"symbol":["FRAX"]}},"exchanges":{"GateIo":{"id":["FRAX_USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "288"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FRAX","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"GateIo":{"id":["FRAX_USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "289"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CORE","quote":"USD"},"decimals":8,"category":"","market_hours":null,"arguments":{"aggregators":{"CoinMarketCap":{"id":[23254,7242],"symbol":["CORE","CORE"]}},"exchanges":{"Bitget":{"symbol":["COREUSDT_SPBL"]},"Bybit":{"symbol":["COREUSDT"]},"GateIo":{"id":["CORE_USDT"]},"MEXC":{"symbol":["COREUSDT"]},"OKX":{"instId":["CORE-USDC","CORE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "290"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CORE","quote":"USDT"},"decimals":8,"category":"","market_hours":null,"arguments":{"exchanges":{"Bitget":{"symbol":["COREUSDT_SPBL"]},"Bybit":{"symbol":["COREUSDT"]},"GateIo":{"id":["CORE_USDT"]},"MEXC":{"symbol":["COREUSDT"]},"OKX":{"instId":["CORE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "291"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CORE","quote":"USDC"},"decimals":8,"category":"","market_hours":null,"arguments":{"exchanges":{"OKX":{"instId":["CORE-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "292"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RUNE","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[4157,9905],"symbol":["RUNE","RUNE"]}},"exchanges":{"Binance":{"symbol":["RUNEUSDC","RUNEUSDT"]},"Bitget":{"symbol":["RUNEUSDT_SPBL"]},"Bybit":{"symbol":["RUNEUSDT"]},"CryptoCom":{"instrument_name":["RUNEUSD-PERP","RUNE_USD","RUNE_USDT"]},"GateIo":{"id":["RUNE_USDC","RUNE_USDT"]},"Kraken":{"pair":["RUNEUSD"],"wsname":["RUNE/USD"]},"KuCoin":{"symbol":["RUNE-USDC","RUNE-USDT"]},"MEXC":{"symbol":["RUNEUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "293"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RUNE","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["RUNEUSDT"]},"Bitget":{"symbol":["RUNEUSDT_SPBL"]},"Bybit":{"symbol":["RUNEUSDT"]},"CryptoCom":{"instrument_name":["RUNE_USDT"]},"GateIo":{"id":["RUNE_USDT"]},"KuCoin":{"symbol":["RUNE-USDT"]},"MEXC":{"symbol":["RUNEUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "294"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RUNE","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["RUNEUSDC"]},"GateIo":{"id":["RUNE_USDC"]},"KuCoin":{"symbol":["RUNE-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "295"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"AR","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[5632],"symbol":["AR"]}},"exchanges":{"Binance":{"symbol":["ARUSDC","ARUSDT"]},"Bitget":{"symbol":["ARUSDC_SPBL","ARUSDT_SPBL"]},"Bybit":{"symbol":["ARUSDT"]},"CryptoCom":{"instrument_name":["ARUSD-PERP","AR_USD","AR_USDT"]},"GateIo":{"id":["AR_USDC","AR_USDT"]},"KuCoin":{"symbol":["AR-USDT"]},"MEXC":{"symbol":["ARUSDT"]},"OKX":{"instId":["AR-USDC","AR-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "296"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"AR","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ARUSDT"]},"Bitget":{"symbol":["ARUSDT_SPBL"]},"Bybit":{"symbol":["ARUSDT"]},"CryptoCom":{"instrument_name":["AR_USDT"]},"GateIo":{"id":["AR_USDT"]},"KuCoin":{"symbol":["AR-USDT"]},"MEXC":{"symbol":["ARUSDT"]},"OKX":{"instId":["AR-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "297"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"AR","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ARUSDC"]},"Bitget":{"symbol":["ARUSDC_SPBL"]},"GateIo":{"id":["AR_USDC"]},"OKX":{"instId":["AR-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "298"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CFX","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[7334],"symbol":["CFX"]}},"exchanges":{"Binance":{"symbol":["CFXUSDC","CFXUSDT"]},"Bitget":{"symbol":["CFXUSDT_SPBL"]},"CryptoCom":{"instrument_name":["CFXUSD-PERP"]},"GateIo":{"id":["CFX_USDC","CFX_USDT"]},"KuCoin":{"symbol":["CFX-USDT"]},"MEXC":{"symbol":["CFXUSDT"]},"OKX":{"instId":["CFX-USDC","CFX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "299"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CFX","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["CFXUSDT"]},"Bitget":{"symbol":["CFXUSDT_SPBL"]},"GateIo":{"id":["CFX_USDT"]},"KuCoin":{"symbol":["CFX-USDT"]},"MEXC":{"symbol":["CFXUSDT"]},"OKX":{"instId":["CFX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "300"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CFX","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["CFXUSDC"]},"GateIo":{"id":["CFX_USDC"]},"OKX":{"instId":["CFX-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "301"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"FTT","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["FTTETH"]},"GateIo":{"id":["FTT_ETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "302"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FTT","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[4195],"symbol":["FTT"]}},"exchanges":{"Binance":{"symbol":["FTTUSDT"]},"Bitget":{"symbol":["FTTUSDT_SPBL"]},"Bybit":{"symbol":["FTTUSDT"]},"GateIo":{"id":["FTT_USDT"]},"KuCoin":{"symbol":["FTT-USDT"]},"MEXC":{"symbol":["FTTUSDC","FTTUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "303"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FTT","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["FTTUSDT"]},"Bitget":{"symbol":["FTTUSDT_SPBL"]},"Bybit":{"symbol":["FTTUSDT"]},"GateIo":{"id":["FTT_USDT"]},"KuCoin":{"symbol":["FTT-USDT"]},"MEXC":{"symbol":["FTTUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "304"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FTT","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"MEXC":{"symbol":["FTTUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "305"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"APE","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[18876,31434,7257],"symbol":["APE","APE","APE"]}},"exchanges":{"Binance":{"symbol":["APEUSDC","APEUSDT"]},"BinanceUS":{"symbol":["APEUSDT"]},"Bitfinex":{"symbol":["APEUSD"]},"Bitget":{"symbol":["APEUSDT_SPBL"]},"Bybit":{"symbol":["APEUSDC","APEUSDT"]},"Coinbase":{"id":["APE-USD","APE-USDT"]},"CryptoCom":{"instrument_name":["APEUSD-PERP","APE_USD","APE_USDT"]},"GateIo":{"id":["APE_USDT"]},"Gemini":{"symbol":["APEUSD"]},"Kraken":{"pair":["APEUSD","APEUSDC","APEUSDT"],"wsname":["APE/USD","APE/USDC","APE/USDT"]},"KuCoin":{"symbol":["APE-USDC","APE-USDT"]},"MEXC":{"symbol":["APEUSDC","APEUSDT"]},"OKX":{"instId":["APE-USDC","APE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "306"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"APE","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["APEETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "307"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"APE","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["APEUSDT"]},"BinanceUS":{"symbol":["APEUSDT"]},"Bitget":{"symbol":["APEUSDT_SPBL"]},"Bybit":{"symbol":["APEUSDT"]},"Coinbase":{"id":["APE-USDT"]},"CryptoCom":{"instrument_name":["APE_USDT"]},"GateIo":{"id":["APE_USDT"]},"Kraken":{"pair":["APEUSDT"],"wsname":["APE/USDT"]},"KuCoin":{"symbol":["APE-USDT"]},"MEXC":{"symbol":["APEUSDT"]},"OKX":{"instId":["APE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "308"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"APE","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["APEUSDC"]},"Bybit":{"symbol":["APEUSDC"]},"Kraken":{"pair":["APEUSDC"],"wsname":["APE/USDC"]},"KuCoin":{"symbol":["APE-USDC"]},"MEXC":{"symbol":["APEUSDC"]},"OKX":{"instId":["APE-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "309"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"VIRTUAL","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[29420],"symbol":["VIRTUAL"]}},"exchanges":{"Bitget":{"symbol":["VIRTUALUSDT_SPBL"]},"Bybit":{"symbol":["VIRTUALUSDT"]},"CryptoCom":{"instrument_name":["VIRTUALUSD-PERP","VIRTUAL_USD","VIRTUAL_USDT"]},"GateIo":{"id":["VIRTUAL_USDT"]},"Kraken":{"pair":["VIRTUALUSD","VIRTUALUSDC","VIRTUALUSDT"],"wsname":["VIRTUAL/USD","VIRTUAL/USDC","VIRTUAL/USDT"]},"KuCoin":{"symbol":["VIRTUAL-USDT"]},"MEXC":{"symbol":["VIRTUALUSDC","VIRTUALUSDT"]},"Upbit":{"market":["USDT-VIRTUAL"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "310"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"VIRTUAL","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["VIRTUALUSDT_SPBL"]},"Bybit":{"symbol":["VIRTUALUSDT"]},"CryptoCom":{"instrument_name":["VIRTUAL_USDT"]},"GateIo":{"id":["VIRTUAL_USDT"]},"Kraken":{"pair":["VIRTUALUSDT"],"wsname":["VIRTUAL/USDT"]},"KuCoin":{"symbol":["VIRTUAL-USDT"]},"MEXC":{"symbol":["VIRTUALUSDT"]},"Upbit":{"market":["USDT-VIRTUAL"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "311"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"VIRTUAL","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Kraken":{"pair":["VIRTUALUSDC"],"wsname":["VIRTUAL/USDC"]},"MEXC":{"symbol":["VIRTUALUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "312"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PENGU","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[34466],"symbol":["PENGU"]}},"exchanges":{"Binance":{"symbol":["PENGUUSDC","PENGUUSDT"]},"BinanceUS":{"symbol":["PENGUUSDT"]},"Bitget":{"symbol":["PENGUUSDT_SPBL"]},"Bybit":{"symbol":["PENGUUSDT"]},"Coinbase":{"id":["PENGU-USD"]},"CryptoCom":{"instrument_name":["PENGUUSD-PERP","PENGU_USD","PENGU_USDT"]},"GateIo":{"id":["PENGU_USDT"]},"Kraken":{"pair":["PENGUUSD","PENGUUSDC","PENGUUSDT"],"wsname":["PENGU/USD","PENGU/USDC","PENGU/USDT"]},"KuCoin":{"symbol":["PENGU-USDT"]},"MEXC":{"symbol":["PENGUUSDC","PENGUUSDT"]},"OKX":{"instId":["PENGU-USD","PENGU-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "313"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PENGU","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["PENGUUSDT"]},"BinanceUS":{"symbol":["PENGUUSDT"]},"Bitget":{"symbol":["PENGUUSDT_SPBL"]},"Bybit":{"symbol":["PENGUUSDT"]},"CryptoCom":{"instrument_name":["PENGU_USDT"]},"GateIo":{"id":["PENGU_USDT"]},"Kraken":{"pair":["PENGUUSDT"],"wsname":["PENGU/USDT"]},"KuCoin":{"symbol":["PENGU-USDT"]},"MEXC":{"symbol":["PENGUUSDT"]},"OKX":{"instId":["PENGU-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "314"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PENGU","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["PENGUUSDC"]},"Kraken":{"pair":["PENGUUSDC"],"wsname":["PENGU/USDC"]},"MEXC":{"symbol":["PENGUUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "315"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"COMP","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[5692],"symbol":["COMP"]}},"exchanges":{"Binance":{"symbol":["COMPUSDT"]},"BinanceUS":{"symbol":["COMPUSDT"]},"Bitfinex":{"symbol":["COMP:USD"]},"Bitget":{"symbol":["COMPUSDT_SPBL"]},"Bybit":{"symbol":["COMPUSDT"]},"Coinbase":{"id":["COMP-USD"]},"CryptoCom":{"instrument_name":["COMPUSD-PERP","COMP_USD","COMP_USDT"]},"GateIo":{"id":["COMP_USDT"]},"Gemini":{"symbol":["COMPUSD"]},"Kraken":{"pair":["COMPUSD"],"wsname":["COMP/USD"]},"KuCoin":{"symbol":["COMP-USDT"]},"MEXC":{"symbol":["COMPUSDT"]},"OKX":{"instId":["COMP-USD","COMP-USDC","COMP-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "316"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"COMP","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["COMPUSDT"]},"BinanceUS":{"symbol":["COMPUSDT"]},"Bitget":{"symbol":["COMPUSDT_SPBL"]},"Bybit":{"symbol":["COMPUSDT"]},"CryptoCom":{"instrument_name":["COMP_USDT"]},"GateIo":{"id":["COMP_USDT"]},"KuCoin":{"symbol":["COMP-USDT"]},"MEXC":{"symbol":["COMPUSDT"]},"OKX":{"instId":["COMP-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "317"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"COMP","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["COMP-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "318"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"AXL","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[15853,17799],"symbol":["AXL","AXL"]}},"exchanges":{"Binance":{"symbol":["AXLUSDT"]},"BinanceUS":{"symbol":["AXLUSDT"]},"Bybit":{"symbol":["AXLUSDT"]},"Coinbase":{"id":["AXL-USD"]},"CryptoCom":{"instrument_name":["AXLUSD-PERP","AXL_USD","AXL_USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "319"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"AXL","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["AXLUSDT"]},"BinanceUS":{"symbol":["AXLUSDT"]},"Bybit":{"symbol":["AXLUSDT"]},"CryptoCom":{"instrument_name":["AXL_USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "320"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"PENDLE","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[9481],"symbol":["PENDLE"]}},"exchanges":{"Binance":{"symbol":["PENDLEUSDC","PENDLEUSDT"]},"Bitget":{"symbol":["PENDLEUSDT_SPBL"]},"Bybit":{"symbol":["PENDLEUSDT"]},"CryptoCom":{"instrument_name":["PENDLEUSD-PERP","PENDLE_USD","PENDLE_USDT"]},"GateIo":{"id":["PENDLE_USDC","PENDLE_USDT"]},"Kraken":{"pair":["PENDLEUSD"],"wsname":["PENDLE/USD"]},"KuCoin":{"symbol":["PENDLE-USDT"]},"MEXC":{"symbol":["PENDLEUSDT"]},"OKX":{"instId":["PENDLE-USDC","PENDLE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "321"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"PENDLE","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["PENDLEUSDT"]},"Bitget":{"symbol":["PENDLEUSDT_SPBL"]},"Bybit":{"symbol":["PENDLEUSDT"]},"CryptoCom":{"instrument_name":["PENDLE_USDT"]},"GateIo":{"id":["PENDLE_USDT"]},"KuCoin":{"symbol":["PENDLE-USDT"]},"MEXC":{"symbol":["PENDLEUSDT"]},"OKX":{"instId":["PENDLE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "322"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"PENDLE","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["PENDLEUSDC"]},"GateIo":{"id":["PENDLE_USDC"]},"OKX":{"instId":["PENDLE-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "323"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SPX","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28081],"symbol":["SPX"]}},"exchanges":{"Bybit":{"symbol":["SPXUSDT"]},"CryptoCom":{"instrument_name":["SPXUSD-PERP","SPX_USD"]},"GateIo":{"id":["SPX_USDT"]},"Kraken":{"pair":["SPXUSD"],"wsname":["SPX/USD"]},"KuCoin":{"symbol":["SPX-USDT"]},"MEXC":{"symbol":["SPXUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "324"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SPX","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bybit":{"symbol":["SPXUSDT"]},"GateIo":{"id":["SPX_USDT"]},"KuCoin":{"symbol":["SPX-USDT"]},"MEXC":{"symbol":["SPXUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "325"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"GNO","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1659],"symbol":["GNO"]}},"exchanges":{"Binance":{"symbol":["GNOUSDT"]},"Bitget":{"symbol":["GNOUSDT_SPBL"]},"Coinbase":{"id":["GNO-USD","GNO-USDT"]},"CryptoCom":{"instrument_name":["GNO_USD"]},"GateIo":{"id":["GNO_USDT"]},"Kraken":{"pair":["GNOUSD"],"wsname":["GNO/USD"]},"MEXC":{"symbol":["GNOUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "326"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"GNO","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["GNOUSDT"]},"Bitget":{"symbol":["GNOUSDT_SPBL"]},"Coinbase":{"id":["GNO-USDT"]},"GateIo":{"id":["GNO_USDT"]},"MEXC":{"symbol":["GNOUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "327"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MORPHO","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[34104],"symbol":["MORPHO"]}},"exchanges":{"Bitget":{"symbol":["MORPHOUSDT_SPBL"]},"Bybit":{"symbol":["MORPHOUSDT"]},"Coinbase":{"id":["MORPHO-USD"]},"CryptoCom":{"instrument_name":["MORPHOUSD-PERP","MORPHO_USD"]},"GateIo":{"id":["MORPHO_USDT"]},"Kraken":{"pair":["MORPHOUSD"],"wsname":["MORPHO/USD"]},"KuCoin":{"symbol":["MORPHO-USDT"]},"MEXC":{"symbol":["MORPHOUSDT"]},"OKX":{"instId":["MORPHO-USDC","MORPHO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "328"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MORPHO","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["MORPHOUSDT_SPBL"]},"Bybit":{"symbol":["MORPHOUSDT"]},"GateIo":{"id":["MORPHO_USDT"]},"KuCoin":{"symbol":["MORPHO-USDT"]},"MEXC":{"symbol":["MORPHOUSDT"]},"OKX":{"instId":["MORPHO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "329"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MORPHO","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["MORPHO-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "330"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RSR","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[3964],"symbol":["RSR"]}},"exchanges":{"Binance":{"symbol":["RSRUSDC","RSRUSDT"]},"Bitget":{"symbol":["RSRUSDT_SPBL"]},"CryptoCom":{"instrument_name":["RSR_USD","RSR_USDT"]},"GateIo":{"id":["RSR_USDT"]},"Kraken":{"pair":["RSRUSD"],"wsname":["RSR/USD"]},"KuCoin":{"symbol":["RSR-USDT"]},"MEXC":{"symbol":["RSRUSDT"]},"OKX":{"instId":["RSR-USDC","RSR-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "331"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RSR","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["RSRUSDT"]},"Bitget":{"symbol":["RSRUSDT_SPBL"]},"CryptoCom":{"instrument_name":["RSR_USDT"]},"GateIo":{"id":["RSR_USDT"]},"KuCoin":{"symbol":["RSR-USDT"]},"MEXC":{"symbol":["RSRUSDT"]},"OKX":{"instId":["RSR-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "332"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RSR","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["RSRUSDC"]},"OKX":{"instId":["RSR-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "333"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BRETT","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28891,29743,30665,31343,31755,31992,33422],"symbol":["BRETT","BRETT","BRETT","BRETT","BRETT","BRETT","BRETT"]}},"exchanges":{"Bitget":{"symbol":["BRETTUSDT_SPBL"]},"Bybit":{"symbol":["BRETTUSDC","BRETTUSDT"]},"GateIo":{"id":["BRETT_USDT"]},"KuCoin":{"symbol":["BRETT-USDT"]},"Upbit":{"market":["USDT-BRETT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "334"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BRETT","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["BRETTUSDT_SPBL"]},"Bybit":{"symbol":["BRETTUSDT"]},"GateIo":{"id":["BRETT_USDT"]},"KuCoin":{"symbol":["BRETT-USDT"]},"Upbit":{"market":["USDT-BRETT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "335"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BRETT","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bybit":{"symbol":["BRETTUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "336"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BEAM","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28298,3702],"symbol":["BEAM","BEAM"]}},"exchanges":{"Binance":{"symbol":["BEAMUSDT"]},"Bitget":{"symbol":["BEAMUSDT_SPBL"]},"Bybit":{"symbol":["BEAMUSDT"]},"GateIo":{"id":["BEAM_USDT"]},"Kraken":{"pair":["BEAMUSD"],"wsname":["BEAM/USD"]},"MEXC":{"symbol":["BEAMUSDT"]},"Upbit":{"market":["USDT-BEAM"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "337"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BEAM","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BEAMUSDT"]},"Bitget":{"symbol":["BEAMUSDT_SPBL"]},"Bybit":{"symbol":["BEAMUSDT"]},"GateIo":{"id":["BEAM_USDT"]},"MEXC":{"symbol":["BEAMUSDT"]},"Upbit":{"market":["USDT-BEAM"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "338"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"deUSD","quote":"USD"},"decimals":8,"category":"","market_hours":"","arguments":{"aggregators":{"CoinMarketCap":{"id":[31024],"symbol":["DEUSD"]}},"exchanges":{"Bitget":{"symbol":["DEUSDUSDT_SPBL"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "339"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"deUSD","quote":"USDT"},"decimals":8,"category":"","market_hours":"","arguments":{"exchanges":{"Bitget":{"symbol":["DEUSDUSDT_SPBL"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "340"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SNX","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[2586],"symbol":["SNX"]}},"exchanges":{"Binance":{"symbol":["SNXUSDT"]},"BinanceUS":{"symbol":["SNXUSDT"]},"Bitget":{"symbol":["SNXUSDT_SPBL"]},"Bybit":{"symbol":["SNXUSDT"]},"Coinbase":{"id":["SNX-USD"]},"CryptoCom":{"instrument_name":["SNXUSD-PERP","SNX_USD","SNX_USDT"]},"GateIo":{"id":["SNX_USDT"]},"Kraken":{"pair":["SNXUSD"],"wsname":["SNX/USD"]},"KuCoin":{"symbol":["SNX-USDT"]},"MEXC":{"symbol":["SNXUSDT"]},"OKX":{"instId":["SNX-USDC","SNX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "341"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SNX","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SNXETH"]},"KuCoin":{"symbol":["SNX-ETH"]},"MEXC":{"symbol":["SNXETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "342"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SNX","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SNXUSDT"]},"BinanceUS":{"symbol":["SNXUSDT"]},"Bitget":{"symbol":["SNXUSDT_SPBL"]},"Bybit":{"symbol":["SNXUSDT"]},"CryptoCom":{"instrument_name":["SNX_USDT"]},"GateIo":{"id":["SNX_USDT"]},"KuCoin":{"symbol":["SNX-USDT"]},"MEXC":{"symbol":["SNXUSDT"]},"OKX":{"instId":["SNX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "343"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SNX","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["SNX-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "344"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"FARTCOIN","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[33597,34814],"symbol":["FARTCOIN","FARTCOIN"]}},"exchanges":{"Bitget":{"symbol":["FARTCOINUSDT_SPBL"]},"CryptoCom":{"instrument_name":["FARTCOINUSD-PERP","FARTCOIN_USD"]},"GateIo":{"id":["FARTCOIN_USDT"]},"Kraken":{"pair":["FARTCOINUSD","FARTCOINUSDC","FARTCOINUSDT"],"wsname":["FARTCOIN/USD","FARTCOIN/USDC","FARTCOIN/USDT"]},"KuCoin":{"symbol":["FARTCOIN-USDT"]},"MEXC":{"symbol":["FARTCOINUSDC","FARTCOINUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "345"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"FARTCOIN","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["FARTCOINUSDT_SPBL"]},"GateIo":{"id":["FARTCOIN_USDT"]},"Kraken":{"pair":["FARTCOINUSDT"],"wsname":["FARTCOIN/USDT"]},"KuCoin":{"symbol":["FARTCOIN-USDT"]},"MEXC":{"symbol":["FARTCOINUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "346"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"FARTCOIN","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Kraken":{"pair":["FARTCOINUSDC"],"wsname":["FARTCOIN/USDC"]},"MEXC":{"symbol":["FARTCOINUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "347"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"1INCH","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[8104],"symbol":["1INCH"]}},"exchanges":{"Binance":{"symbol":["1INCHUSDT"]},"BinanceUS":{"symbol":["1INCHUSDT"]},"Bitget":{"symbol":["1INCHUSDT_SPBL"]},"Bybit":{"symbol":["1INCHUSDT"]},"Coinbase":{"id":["1INCH-USD"]},"CryptoCom":{"instrument_name":["1INCHUSD-PERP","1INCH_USD","1INCH_USDT"]},"GateIo":{"id":["1INCH_USDT"]},"Kraken":{"pair":["1INCHUSD"],"wsname":["1INCH/USD"]},"KuCoin":{"symbol":["1INCH-USDT"]},"MEXC":{"symbol":["1INCHUSDT"]},"OKX":{"instId":["1INCH-USDC","1INCH-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "348"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"1INCH","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["1INCHUSDT"]},"BinanceUS":{"symbol":["1INCHUSDT"]},"Bitget":{"symbol":["1INCHUSDT_SPBL"]},"Bybit":{"symbol":["1INCHUSDT"]},"CryptoCom":{"instrument_name":["1INCH_USDT"]},"GateIo":{"id":["1INCH_USDT"]},"KuCoin":{"symbol":["1INCH-USDT"]},"MEXC":{"symbol":["1INCHUSDT"]},"OKX":{"instId":["1INCH-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "349"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"1INCH","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["1INCH-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "350"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DASH","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[131],"symbol":["DASH"]}},"exchanges":{"Binance":{"symbol":["DASHUSDT"]},"BinanceUS":{"symbol":["DASHUSDT"]},"Coinbase":{"id":["DASH-USD"]},"Kraken":{"pair":["DASHUSD"],"wsname":["DASH/USD"]},"KuCoin":{"symbol":["DASH-USDT"]},"MEXC":{"symbol":["DASHUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "351"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DASH","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["DASHUSDT"]},"BinanceUS":{"symbol":["DASHUSDT"]},"KuCoin":{"symbol":["DASH-USDT"]},"MEXC":{"symbol":["DASHUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "352"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"EIGEN","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[30494],"symbol":["EIGEN"]}},"exchanges":{"Binance":{"symbol":["EIGENUSDC","EIGENUSDT"]},"BinanceUS":{"symbol":["EIGENUSDT"]},"Bitfinex":{"symbol":["EIGEN:USD"]},"Bitget":{"symbol":["EIGENUSDT_SPBL"]},"Bybit":{"symbol":["EIGENUSDT"]},"Coinbase":{"id":["EIGEN-USD"]},"CryptoCom":{"instrument_name":["EIGENUSD-PERP","EIGEN_USD"]},"GateIo":{"id":["EIGEN_USDT"]},"Kraken":{"pair":["EIGENUSD"],"wsname":["EIGEN/USD"]},"KuCoin":{"symbol":["EIGEN-USDT"]},"MEXC":{"symbol":["EIGENUSDT"]},"OKX":{"instId":["EIGEN-USDC","EIGEN-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "353"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"EIGEN","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["EIGENUSDT"]},"BinanceUS":{"symbol":["EIGENUSDT"]},"Bitget":{"symbol":["EIGENUSDT_SPBL"]},"Bybit":{"symbol":["EIGENUSDT"]},"GateIo":{"id":["EIGEN_USDT"]},"KuCoin":{"symbol":["EIGEN-USDT"]},"MEXC":{"symbol":["EIGENUSDT"]},"OKX":{"instId":["EIGEN-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "354"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"EIGEN","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["EIGENUSDC"]},"OKX":{"instId":["EIGEN-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "355"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ZK","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[24091],"symbol":["ZK"]}},"exchanges":{"Binance":{"symbol":["ZKUSDC","ZKUSDT"]},"Bitget":{"symbol":["ZKUSDT_SPBL"]},"Bybit":{"symbol":["ZKUSDC","ZKUSDT"]},"Coinbase":{"id":["ZK-USD"]},"CryptoCom":{"instrument_name":["ZKUSD-PERP","ZK_USD","ZK_USDT"]},"GateIo":{"id":["ZK_USDT"]},"Kraken":{"pair":["ZKUSD"],"wsname":["ZK/USD"]},"KuCoin":{"symbol":["ZK-USDT"]},"MEXC":{"symbol":["ZKUSDT"]},"OKX":{"instId":["ZK-USDC","ZK-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "356"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ZK","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ZKUSDT"]},"Bitget":{"symbol":["ZKUSDT_SPBL"]},"Bybit":{"symbol":["ZKUSDT"]},"CryptoCom":{"instrument_name":["ZK_USDT"]},"GateIo":{"id":["ZK_USDT"]},"KuCoin":{"symbol":["ZK-USDT"]},"MEXC":{"symbol":["ZKUSDT"]},"OKX":{"instId":["ZK-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "357"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ZK","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ZKUSDC"]},"Bybit":{"symbol":["ZKUSDC"]},"OKX":{"instId":["ZK-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "358"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"KSM","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[5034],"symbol":["KSM"]}},"exchanges":{"Binance":{"symbol":["KSMUSDT"]},"BinanceUS":{"symbol":["KSMUSDT"]},"Bitget":{"symbol":["KSMUSDT_SPBL"]},"Bybit":{"symbol":["KSMUSDT"]},"Coinbase":{"id":["KSM-USD","KSM-USDT"]},"CryptoCom":{"instrument_name":["KSMUSD-PERP","KSM_USD","KSM_USDT"]},"GateIo":{"id":["KSM_USDT"]},"Kraken":{"pair":["KSMUSD"],"wsname":["KSM/USD"]},"KuCoin":{"symbol":["KSM-USDT"]},"MEXC":{"symbol":["KSMUSDT"]},"OKX":{"instId":["KSM-USDC","KSM-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "359"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"KSM","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["KSMUSDT"]},"BinanceUS":{"symbol":["KSMUSDT"]},"Bitget":{"symbol":["KSMUSDT_SPBL"]},"Bybit":{"symbol":["KSMUSDT"]},"Coinbase":{"id":["KSM-USDT"]},"CryptoCom":{"instrument_name":["KSM_USDT"]},"GateIo":{"id":["KSM_USDT"]},"KuCoin":{"symbol":["KSM-USDT"]},"MEXC":{"symbol":["KSMUSDT"]},"OKX":{"instId":["KSM-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "360"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"KSM","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["KSM-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "361"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SATS","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28194,31316],"symbol":["SATS","SATS"]}},"exchanges":{"Bitget":{"symbol":["SATSUSDT_SPBL"]},"Bybit":{"symbol":["SATSUSDT"]},"GateIo":{"id":["SATS_USDT"]},"KuCoin":{"symbol":["SATS-USDT"]},"MEXC":{"symbol":["SATSUSDT"]},"OKX":{"instId":["SATS-USDC","SATS-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "362"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SATS","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["SATSUSDT_SPBL"]},"Bybit":{"symbol":["SATSUSDT"]},"GateIo":{"id":["SATS_USDT"]},"KuCoin":{"symbol":["SATS-USDT"]},"MEXC":{"symbol":["SATSUSDT"]},"OKX":{"instId":["SATS-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "363"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SATS","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["SATS-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "364"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ASTR","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[12885],"symbol":["ASTR"]}},"exchanges":{"Binance":{"symbol":["ASTRUSDT"]},"BinanceUS":{"symbol":["ASTRUSDT"]},"Bitget":{"symbol":["ASTRUSDT_SPBL"]},"CryptoCom":{"instrument_name":["ASTRUSD-PERP","ASTR_USD","ASTR_USDT"]},"GateIo":{"id":["ASTR_USDT"]},"Kraken":{"pair":["ASTRUSD"],"wsname":["ASTR/USD"]},"KuCoin":{"symbol":["ASTR-USDT"]},"MEXC":{"symbol":["ASTRUSDT"]},"OKX":{"instId":["ASTR-USDC","ASTR-USDT"]},"Upbit":{"market":["USDT-ASTR"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "365"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ASTR","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ASTRUSDT"]},"BinanceUS":{"symbol":["ASTRUSDT"]},"Bitget":{"symbol":["ASTRUSDT_SPBL"]},"CryptoCom":{"instrument_name":["ASTR_USDT"]},"GateIo":{"id":["ASTR_USDT"]},"KuCoin":{"symbol":["ASTR-USDT"]},"MEXC":{"symbol":["ASTRUSDT"]},"OKX":{"instId":["ASTR-USDT"]},"Upbit":{"market":["USDT-ASTR"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "366"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ASTR","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["ASTR-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "367"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ZIL","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[2469],"symbol":["ZIL"]}},"exchanges":{"Binance":{"symbol":["ZILUSDT"]},"BinanceUS":{"symbol":["ZILUSDT"]},"Bitget":{"symbol":["ZILUSDT_SPBL"]},"Bybit":{"symbol":["ZILUSDT"]},"CryptoCom":{"instrument_name":["ZIL_USD","ZIL_USDT"]},"GateIo":{"id":["ZIL_USDT"]},"KuCoin":{"symbol":["ZIL-USDC","ZIL-USDT"]},"MEXC":{"symbol":["ZILUSDT"]},"OKX":{"instId":["ZIL-USDC","ZIL-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "368"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ZIL","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ZILUSDT"]},"BinanceUS":{"symbol":["ZILUSDT"]},"Bitget":{"symbol":["ZILUSDT_SPBL"]},"Bybit":{"symbol":["ZILUSDT"]},"CryptoCom":{"instrument_name":["ZIL_USDT"]},"GateIo":{"id":["ZIL_USDT"]},"KuCoin":{"symbol":["ZIL-USDT"]},"MEXC":{"symbol":["ZILUSDT"]},"OKX":{"instId":["ZIL-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "369"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ZIL","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"KuCoin":{"symbol":["ZIL-USDC"]},"OKX":{"instId":["ZIL-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "370"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ATH","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[30083,34278],"symbol":["ATH","ATH"]}},"exchanges":{"Bitfinex":{"symbol":["ATHUSD"]},"Bitget":{"symbol":["ATHUSDT_SPBL"]},"Bybit":{"symbol":["ATHUSDT"]},"CryptoCom":{"instrument_name":["ATH_USD"]},"GateIo":{"id":["ATH_USDT"]},"Kraken":{"pair":["ATHUSD"],"wsname":["ATH/USD"]},"KuCoin":{"symbol":["ATH-USDT"]},"MEXC":{"symbol":["ATHUSDT"]},"OKX":{"instId":["ATH-USD","ATH-USDC","ATH-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "371"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ATH","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["ATHUSDT_SPBL"]},"Bybit":{"symbol":["ATHUSDT"]},"GateIo":{"id":["ATH_USDT"]},"KuCoin":{"symbol":["ATH-USDT"]},"MEXC":{"symbol":["ATHUSDT"]},"OKX":{"instId":["ATH-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "372"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ATH","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["ATH-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "373"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BLUR","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[23121],"symbol":["BLUR"]}},"exchanges":{"Binance":{"symbol":["BLURUSDC","BLURUSDT"]},"BinanceUS":{"symbol":["BLURUSDT"]},"Bitget":{"symbol":["BLURUSDT_SPBL"]},"Bybit":{"symbol":["BLURUSDT"]},"Coinbase":{"id":["BLUR-USD"]},"CryptoCom":{"instrument_name":["BLURUSD-PERP","BLUR_USD"]},"GateIo":{"id":["BLUR_USDC","BLUR_USDT"]},"Kraken":{"pair":["BLURUSD"],"wsname":["BLUR/USD"]},"KuCoin":{"symbol":["BLUR-USDT"]},"MEXC":{"symbol":["BLURUSDT"]},"OKX":{"instId":["BLUR-USDC","BLUR-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "374"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BLUR","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BLURUSDT"]},"BinanceUS":{"symbol":["BLURUSDT"]},"Bitget":{"symbol":["BLURUSDT_SPBL"]},"Bybit":{"symbol":["BLURUSDT"]},"GateIo":{"id":["BLUR_USDT"]},"KuCoin":{"symbol":["BLUR-USDT"]},"MEXC":{"symbol":["BLURUSDT"]},"OKX":{"instId":["BLUR-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "375"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BLUR","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BLURUSDC"]},"GateIo":{"id":["BLUR_USDC"]},"OKX":{"instId":["BLUR-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "376"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"NOT","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28850],"symbol":["NOT"]}},"exchanges":{"Binance":{"symbol":["NOTUSDC","NOTUSDT"]},"Bitfinex":{"symbol":["NOTUSD"]},"Bitget":{"symbol":["NOTUSDT_SPBL"]},"Bybit":{"symbol":["NOTUSDC","NOTUSDT"]},"CryptoCom":{"instrument_name":["NOTUSD-PERP","NOT_USD","NOT_USDT"]},"GateIo":{"id":["NOT_USDC","NOT_USDT"]},"Kraken":{"pair":["NOTUSD"],"wsname":["NOT/USD"]},"KuCoin":{"symbol":["NOT-USDT"]},"MEXC":{"symbol":["NOTUSDT"]},"OKX":{"instId":["NOT-USDC","NOT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "377"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"NOT","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["NOTUSDT"]},"Bitget":{"symbol":["NOTUSDT_SPBL"]},"Bybit":{"symbol":["NOTUSDT"]},"CryptoCom":{"instrument_name":["NOT_USDT"]},"GateIo":{"id":["NOT_USDT"]},"KuCoin":{"symbol":["NOT-USDT"]},"MEXC":{"symbol":["NOTUSDT"]},"OKX":{"instId":["NOT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "378"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"NOT","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["NOTUSDC"]},"Bybit":{"symbol":["NOTUSDC"]},"GateIo":{"id":["NOT_USDC"]},"OKX":{"instId":["NOT-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "379"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDD","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[19891],"symbol":["USDD"]}},"exchanges":{"Bybit":{"symbol":["USDDUSDT"]},"GateIo":{"id":["USDD_USDT"]},"KuCoin":{"symbol":["USDD-USDC","USDD-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "380"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDD","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bybit":{"symbol":["USDDUSDT"]},"GateIo":{"id":["USDD_USDT"]},"KuCoin":{"symbol":["USDD-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "381"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDD","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"KuCoin":{"symbol":["USDD-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "382"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BAT","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1697],"symbol":["BAT"]}},"exchanges":{"Binance":{"symbol":["BATUSDC","BATUSDT"]},"BinanceUS":{"symbol":["BATUSDT"]},"Bitget":{"symbol":["BATUSDT_SPBL"]},"Bybit":{"symbol":["BATUSDT"]},"Coinbase":{"id":["BAT-USD","BAT-USDC"]},"CryptoCom":{"instrument_name":["BATUSD-PERP","BAT_USD","BAT_USDT"]},"GateIo":{"id":["BAT_USDT"]},"Gemini":{"symbol":["BATUSD"]},"Kraken":{"pair":["BATUSD"],"wsname":["BAT/USD"]},"KuCoin":{"symbol":["BAT-USDT"]},"MEXC":{"symbol":["BATUSDT"]},"OKX":{"instId":["BAT-USDC","BAT-USDT"]},"Upbit":{"market":["USDT-BAT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "383"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BAT","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BATETH"]},"Coinbase":{"id":["BAT-ETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "384"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BAT","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BATUSDT"]},"BinanceUS":{"symbol":["BATUSDT"]},"Bitget":{"symbol":["BATUSDT_SPBL"]},"Bybit":{"symbol":["BATUSDT"]},"CryptoCom":{"instrument_name":["BAT_USDT"]},"GateIo":{"id":["BAT_USDT"]},"KuCoin":{"symbol":["BAT-USDT"]},"MEXC":{"symbol":["BATUSDT"]},"OKX":{"instId":["BAT-USDT"]},"Upbit":{"market":["USDT-BAT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "385"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BAT","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BATUSDC"]},"Coinbase":{"id":["BAT-USDC"]},"OKX":{"instId":["BAT-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "386"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MASK","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[8536],"symbol":["MASK"]}},"exchanges":{"Binance":{"symbol":["MASKUSDT"]},"BinanceUS":{"symbol":["MASKUSDT"]},"Bitget":{"symbol":["MASKUSDT_SPBL"]},"Bybit":{"symbol":["MASKUSDT"]},"Coinbase":{"id":["MASK-USD","MASK-USDT"]},"CryptoCom":{"instrument_name":["MASKUSD-PERP","MASK_USD","MASK_USDT"]},"GateIo":{"id":["MASK_USDT"]},"Gemini":{"symbol":["MASKUSD"]},"Kraken":{"pair":["MASKUSD"],"wsname":["MASK/USD"]},"KuCoin":{"symbol":["MASK-USDT"]},"MEXC":{"symbol":["MASKUSDT"]},"OKX":{"instId":["MASK-USDC","MASK-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "387"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MASK","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["MASKUSDT"]},"BinanceUS":{"symbol":["MASKUSDT"]},"Bitget":{"symbol":["MASKUSDT_SPBL"]},"Bybit":{"symbol":["MASKUSDT"]},"Coinbase":{"id":["MASK-USDT"]},"CryptoCom":{"instrument_name":["MASK_USDT"]},"GateIo":{"id":["MASK_USDT"]},"KuCoin":{"symbol":["MASK-USDT"]},"MEXC":{"symbol":["MASKUSDT"]},"OKX":{"instId":["MASK-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "388"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MASK","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["MASK-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "389"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ID","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[21846,8495],"symbol":["ID","ID"]}},"exchanges":{"Binance":{"symbol":["IDUSDT"]},"Bitget":{"symbol":["IDUSDT_SPBL"]},"Bybit":{"symbol":["IDUSDT"]},"GateIo":{"id":["ID_USDT"]},"KuCoin":{"symbol":["ID-USDT"]},"MEXC":{"symbol":["IDUSDT"]},"OKX":{"instId":["ID-USDC","ID-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "390"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ID","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["IDUSDT"]},"Bitget":{"symbol":["IDUSDT_SPBL"]},"Bybit":{"symbol":["IDUSDT"]},"GateIo":{"id":["ID_USDT"]},"KuCoin":{"symbol":["ID-USDT"]},"MEXC":{"symbol":["IDUSDT"]},"OKX":{"instId":["ID-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "391"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ID","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["ID-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "392"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ZRX","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1896],"symbol":["ZRX"]}},"exchanges":{"Binance":{"symbol":["ZRXUSDT"]},"BinanceUS":{"symbol":["ZRXUSDT"]},"Bitfinex":{"symbol":["ZRXUSD"]},"Bitget":{"symbol":["ZRXUSDT_SPBL"]},"Bybit":{"symbol":["ZRXUSDT"]},"Coinbase":{"id":["ZRX-USD"]},"CryptoCom":{"instrument_name":["ZRXUSD-PERP","ZRX_USD"]},"GateIo":{"id":["ZRX_USDT"]},"Gemini":{"symbol":["ZRXUSD"]},"Kraken":{"pair":["ZRXUSD"],"wsname":["ZRX/USD"]},"KuCoin":{"symbol":["ZRX-USDT"]},"MEXC":{"symbol":["ZRXUSDT"]},"OKX":{"instId":["ZRX-USDC","ZRX-USDT"]},"Upbit":{"market":["USDT-ZRX"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "393"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ZRX","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ZRXETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "394"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ZRX","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ZRXUSDT"]},"BinanceUS":{"symbol":["ZRXUSDT"]},"Bitget":{"symbol":["ZRXUSDT_SPBL"]},"Bybit":{"symbol":["ZRXUSDT"]},"GateIo":{"id":["ZRX_USDT"]},"KuCoin":{"symbol":["ZRX-USDT"]},"MEXC":{"symbol":["ZRXUSDT"]},"OKX":{"instId":["ZRX-USDT"]},"Upbit":{"market":["USDT-ZRX"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "395"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ZRX","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["ZRX-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "396"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ZRO","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[26997],"symbol":["ZRO"]}},"exchanges":{"Binance":{"symbol":["ZROUSDC","ZROUSDT"]},"Bitfinex":{"symbol":["ZROUSD"]},"Bitget":{"symbol":["ZROUSDT_SPBL"]},"Bybit":{"symbol":["ZROUSDC","ZROUSDT"]},"Coinbase":{"id":["ZRO-USD"]},"CryptoCom":{"instrument_name":["ZROUSD-PERP","ZRO_USD","ZRO_USDT"]},"GateIo":{"id":["ZRO_USDT"]},"Kraken":{"pair":["ZROUSD"],"wsname":["ZRO/USD"]},"KuCoin":{"symbol":["ZRO-USDT"]},"MEXC":{"symbol":["ZROUSDT"]},"OKX":{"instId":["ZRO-USDC","ZRO-USDT"]},"Upbit":{"market":["USDT-ZRO"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "397"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ZRO","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ZROUSDT"]},"Bitget":{"symbol":["ZROUSDT_SPBL"]},"Bybit":{"symbol":["ZROUSDT"]},"CryptoCom":{"instrument_name":["ZRO_USDT"]},"GateIo":{"id":["ZRO_USDT"]},"KuCoin":{"symbol":["ZRO-USDT"]},"MEXC":{"symbol":["ZROUSDT"]},"OKX":{"instId":["ZRO-USDT"]},"Upbit":{"market":["USDT-ZRO"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "398"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ZRO","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ZROUSDC"]},"Bybit":{"symbol":["ZROUSDC"]},"OKX":{"instId":["ZRO-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "399"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"HOT","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[20493,2430,2682],"symbol":["HOT","HOT","HOT"]}},"exchanges":{"Binance":{"symbol":["HOTUSDT"]},"Bitget":{"symbol":["HOTUSDT_SPBL"]},"Bybit":{"symbol":["HOTUSDT"]},"CryptoCom":{"instrument_name":["HOT_USD","HOT_USDT"]},"GateIo":{"id":["HOT_USDT"]},"MEXC":{"symbol":["HOTUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "400"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"HOT","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["HOTUSDT"]},"Bitget":{"symbol":["HOTUSDT_SPBL"]},"Bybit":{"symbol":["HOTUSDT"]},"CryptoCom":{"instrument_name":["HOT_USDT"]},"GateIo":{"id":["HOT_USDT"]},"MEXC":{"symbol":["HOTUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "401"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"WEMIX","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[7548],"symbol":["WEMIX"]}},"exchanges":{"Bitget":{"symbol":["WEMIXUSDT_SPBL"]},"Bybit":{"symbol":["WEMIXUSDT"]},"CryptoCom":{"instrument_name":["WEMIX_USD"]},"GateIo":{"id":["WEMIX_USDT"]},"KuCoin":{"symbol":["WEMIX-USDT"]},"MEXC":{"symbol":["WEMIXUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "402"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"WEMIX","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["WEMIXUSDT_SPBL"]},"Bybit":{"symbol":["WEMIXUSDT"]},"GateIo":{"id":["WEMIX_USDT"]},"KuCoin":{"symbol":["WEMIX-USDT"]},"MEXC":{"symbol":["WEMIXUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "403"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ORDI","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[25028],"symbol":["ORDI"]}},"exchanges":{"Binance":{"symbol":["ORDIUSDC","ORDIUSDT"]},"Bitget":{"symbol":["ORDIUSDT_SPBL"]},"Bybit":{"symbol":["ORDIUSDT"]},"CryptoCom":{"instrument_name":["ORDIUSD-PERP","ORDI_USD","ORDI_USDT"]},"GateIo":{"id":["ORDI_USDC","ORDI_USDT"]},"KuCoin":{"symbol":["ORDI-USDT"]},"MEXC":{"symbol":["ORDIUSDT"]},"OKX":{"instId":["ORDI-USDC","ORDI-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "404"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ORDI","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ORDIUSDT"]},"Bitget":{"symbol":["ORDIUSDT_SPBL"]},"Bybit":{"symbol":["ORDIUSDT"]},"CryptoCom":{"instrument_name":["ORDI_USDT"]},"GateIo":{"id":["ORDI_USDT"]},"KuCoin":{"symbol":["ORDI-USDT"]},"MEXC":{"symbol":["ORDIUSDT"]},"OKX":{"instId":["ORDI-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "405"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ORDI","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ORDIUSDC"]},"GateIo":{"id":["ORDI_USDC"]},"OKX":{"instId":["ORDI-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "406"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CELO","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[5567],"symbol":["CELO"]}},"exchanges":{"Binance":{"symbol":["CELOUSDT"]},"BinanceUS":{"symbol":["CELOUSDT"]},"Bitfinex":{"symbol":["CELO:USD"]},"Bitget":{"symbol":["CELOUSDT_SPBL"]},"Bybit":{"symbol":["CELOUSDT"]},"CryptoCom":{"instrument_name":["CELOUSD-PERP"]},"GateIo":{"id":["CELO_USDT"]},"KuCoin":{"symbol":["CELO-USDT"]},"MEXC":{"symbol":["CELOUSDT"]},"OKX":{"instId":["CELO-USDC","CELO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "407"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CELO","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["CELOUSDT"]},"BinanceUS":{"symbol":["CELOUSDT"]},"Bitget":{"symbol":["CELOUSDT_SPBL"]},"Bybit":{"symbol":["CELOUSDT"]},"GateIo":{"id":["CELO_USDT"]},"KuCoin":{"symbol":["CELO-USDT"]},"MEXC":{"symbol":["CELOUSDT"]},"OKX":{"instId":["CELO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "408"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CELO","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["CELO-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "409"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"AI16Z","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[34026],"symbol":["AI16Z"]}},"exchanges":{"Bitget":{"symbol":["AI16ZUSDT_SPBL"]},"Bybit":{"symbol":["AI16ZUSDT"]},"CryptoCom":{"instrument_name":["AI16ZUSD-PERP","AI16Z_USD"]},"GateIo":{"id":["AI16Z_USDT"]},"Kraken":{"pair":["AI16ZUSD","AI16ZUSDC","AI16ZUSDT"],"wsname":["AI16Z/USD","AI16Z/USDC","AI16Z/USDT"]},"KuCoin":{"symbol":["AI16Z-USDT"]},"MEXC":{"symbol":["AI16ZUSDC","AI16ZUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "410"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"AI16Z","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["AI16ZUSDT_SPBL"]},"Bybit":{"symbol":["AI16ZUSDT"]},"GateIo":{"id":["AI16Z_USDT"]},"Kraken":{"pair":["AI16ZUSDT"],"wsname":["AI16Z/USDT"]},"KuCoin":{"symbol":["AI16Z-USDT"]},"MEXC":{"symbol":["AI16ZUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "411"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"AI16Z","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Kraken":{"pair":["AI16ZUSDC"],"wsname":["AI16Z/USDC"]},"MEXC":{"symbol":["AI16ZUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "412"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CVX","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[9903],"symbol":["CVX"]}},"exchanges":{"Binance":{"symbol":["CVXUSDT"]},"Bitget":{"symbol":["CVXUSDT_SPBL"]},"Coinbase":{"id":["CVX-USD"]},"CryptoCom":{"instrument_name":["CVX_USD"]},"GateIo":{"id":["CVX_USDT"]},"Kraken":{"pair":["CVXUSD"],"wsname":["CVX/USD"]},"KuCoin":{"symbol":["CVX-USDT"]},"MEXC":{"symbol":["CVXUSDT"]},"OKX":{"instId":["CVX-USDC","CVX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "413"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CVX","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["CVXUSDT"]},"Bitget":{"symbol":["CVXUSDT_SPBL"]},"GateIo":{"id":["CVX_USDT"]},"KuCoin":{"symbol":["CVX-USDT"]},"MEXC":{"symbol":["CVXUSDT"]},"OKX":{"instId":["CVX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "414"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CVX","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["CVX-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "415"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MOG","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[27659,33033,34170],"symbol":["MOG","MOG","MOG"]}},"exchanges":{"Bitget":{"symbol":["MOGUSDT_SPBL"]},"Bybit":{"symbol":["MOGUSDT"]},"Coinbase":{"id":["MOG-USD"]},"CryptoCom":{"instrument_name":["MOGUSD-PERP","MOG_USD","MOG_USDT"]},"GateIo":{"id":["MOG_USDT"]},"Kraken":{"pair":["MOGUSD"],"wsname":["MOG/USD"]},"KuCoin":{"symbol":["MOG-USDT"]},"MEXC":{"symbol":["MOGUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "416"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MOG","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["MOGUSDT_SPBL"]},"Bybit":{"symbol":["MOGUSDT"]},"CryptoCom":{"instrument_name":["MOG_USDT"]},"GateIo":{"id":["MOG_USDT"]},"KuCoin":{"symbol":["MOG-USDT"]},"MEXC":{"symbol":["MOGUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "417"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ANKR","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[3783],"symbol":["ANKR"]}},"exchanges":{"Binance":{"symbol":["ANKRUSDC","ANKRUSDT"]},"BinanceUS":{"symbol":["ANKRUSDT"]},"Bitget":{"symbol":["ANKRUSDT_SPBL"]},"Bybit":{"symbol":["ANKRUSDT"]},"Coinbase":{"id":["ANKR-USD"]},"CryptoCom":{"instrument_name":["ANKRUSD-PERP","ANKR_USD","ANKR_USDT"]},"GateIo":{"id":["ANKR_USDT"]},"Gemini":{"symbol":["ANKRUSD"]},"Kraken":{"pair":["ANKRUSD"],"wsname":["ANKR/USD"]},"KuCoin":{"symbol":["ANKR-USDT"]},"MEXC":{"symbol":["ANKRUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "418"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ANKR","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ANKRUSDT"]},"BinanceUS":{"symbol":["ANKRUSDT"]},"Bitget":{"symbol":["ANKRUSDT_SPBL"]},"Bybit":{"symbol":["ANKRUSDT"]},"CryptoCom":{"instrument_name":["ANKR_USDT"]},"GateIo":{"id":["ANKR_USDT"]},"KuCoin":{"symbol":["ANKR-USDT"]},"MEXC":{"symbol":["ANKRUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "419"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ANKR","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ANKRUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "420"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"YFI","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[5864],"symbol":["YFI"]}},"exchanges":{"Binance":{"symbol":["YFIUSDT"]},"BinanceUS":{"symbol":["YFIUSDT"]},"Bitfinex":{"symbol":["YFIUSD"]},"Bitget":{"symbol":["YFIUSDT_SPBL"]},"Bybit":{"symbol":["YFIUSDT"]},"Coinbase":{"id":["YFI-USD"]},"CryptoCom":{"instrument_name":["YFIUSD-PERP","YFI_USD"]},"GateIo":{"id":["YFI_USDT"]},"Gemini":{"symbol":["YFIUSD"]},"Kraken":{"pair":["YFIUSD"],"wsname":["YFI/USD"]},"KuCoin":{"symbol":["YFI-USDT"]},"MEXC":{"symbol":["YFIUSDT"]},"OKX":{"instId":["YFI-USDC","YFI-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "421"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"YFI","quote":"BNB"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["YFIBNB"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "422"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"YFI","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"MEXC":{"symbol":["YFIETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "423"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"YFI","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["YFIUSDT"]},"BinanceUS":{"symbol":["YFIUSDT"]},"Bitget":{"symbol":["YFIUSDT_SPBL"]},"Bybit":{"symbol":["YFIUSDT"]},"GateIo":{"id":["YFI_USDT"]},"KuCoin":{"symbol":["YFI-USDT"]},"MEXC":{"symbol":["YFIUSDT"]},"OKX":{"instId":["YFI-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "424"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"YFI","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["YFI-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "425"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ENJ","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[2130],"symbol":["ENJ"]}},"exchanges":{"Binance":{"symbol":["ENJUSDT"]},"BinanceUS":{"symbol":["ENJUSDT"]},"Bitget":{"symbol":["ENJUSDT_SPBL"]},"Bybit":{"symbol":["ENJUSDT"]},"Coinbase":{"id":["ENJ-USD","ENJ-USDT"]},"CryptoCom":{"instrument_name":["ENJUSD-PERP","ENJ_USD","ENJ_USDT"]},"GateIo":{"id":["ENJ_USDT"]},"Kraken":{"pair":["ENJUSD"],"wsname":["ENJ/USD"]},"KuCoin":{"symbol":["ENJ-USDT"]},"MEXC":{"symbol":["ENJUSDT"]},"OKX":{"instId":["ENJ-USDC","ENJ-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "426"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ENJ","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ENJETH"]},"KuCoin":{"symbol":["ENJ-ETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "427"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ENJ","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ENJUSDT"]},"BinanceUS":{"symbol":["ENJUSDT"]},"Bitget":{"symbol":["ENJUSDT_SPBL"]},"Bybit":{"symbol":["ENJUSDT"]},"Coinbase":{"id":["ENJ-USDT"]},"CryptoCom":{"instrument_name":["ENJ_USDT"]},"GateIo":{"id":["ENJ_USDT"]},"KuCoin":{"symbol":["ENJ-USDT"]},"MEXC":{"symbol":["ENJUSDT"]},"OKX":{"instId":["ENJ-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "428"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ENJ","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["ENJ-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "429"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PNUT","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[33788,33789,33940,34210],"symbol":["PNUT","PNUT","PNUT","PNUT"]}},"exchanges":{"Binance":{"symbol":["PNUTUSDC","PNUTUSDT"]},"BinanceUS":{"symbol":["PNUTUSDT"]},"Bitget":{"symbol":["PNUTUSDT_SPBL"]},"Bybit":{"symbol":["PNUTUSDT"]},"Coinbase":{"id":["PNUT-USD"]},"CryptoCom":{"instrument_name":["PNUTUSD-PERP","PNUT_USD","PNUT_USDT"]},"GateIo":{"id":["PNUT_USDT"]},"Gemini":{"symbol":["PNUTUSD"]},"Kraken":{"pair":["PNUTUSD"],"wsname":["PNUT/USD"]},"KuCoin":{"symbol":["PNUT-USDT"]},"MEXC":{"symbol":["PNUTUSDT"]},"OKX":{"instId":["PNUT-USDC","PNUT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "430"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PNUT","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["PNUTUSDT"]},"BinanceUS":{"symbol":["PNUTUSDT"]},"Bitget":{"symbol":["PNUTUSDT_SPBL"]},"Bybit":{"symbol":["PNUTUSDT"]},"CryptoCom":{"instrument_name":["PNUT_USDT"]},"GateIo":{"id":["PNUT_USDT"]},"KuCoin":{"symbol":["PNUT-USDT"]},"MEXC":{"symbol":["PNUTUSDT"]},"OKX":{"instId":["PNUT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "431"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PNUT","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["PNUTUSDC"]},"OKX":{"instId":["PNUT-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "432"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ONE","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[2324,24085,3945],"symbol":["ONE","ONE","ONE"]}},"exchanges":{"Binance":{"symbol":["ONEUSDC","ONEUSDT"]},"BinanceUS":{"symbol":["ONEUSDT"]},"Bitget":{"symbol":["ONEUSDT_SPBL"]},"Bybit":{"symbol":["ONEUSDT"]},"CryptoCom":{"instrument_name":["ONEUSD-PERP","ONE_USD","ONE_USDT"]},"GateIo":{"id":["ONE_USDT"]},"KuCoin":{"symbol":["ONE-USDT"]},"MEXC":{"symbol":["ONEUSDT"]},"OKX":{"instId":["ONE-USDC","ONE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "433"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ONE","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ONEUSDT"]},"BinanceUS":{"symbol":["ONEUSDT"]},"Bitget":{"symbol":["ONEUSDT_SPBL"]},"Bybit":{"symbol":["ONEUSDT"]},"CryptoCom":{"instrument_name":["ONE_USDT"]},"GateIo":{"id":["ONE_USDT"]},"KuCoin":{"symbol":["ONE-USDT"]},"MEXC":{"symbol":["ONEUSDT"]},"OKX":{"instId":["ONE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "434"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ONE","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ONEUSDC"]},"OKX":{"instId":["ONE-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "435"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MEW","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[30126],"symbol":["MEW"]}},"exchanges":{"Bitfinex":{"symbol":["MEWUSD"]},"Bitget":{"symbol":["MEWUSDT_SPBL"]},"Bybit":{"symbol":["MEWUSDC","MEWUSDT"]},"GateIo":{"id":["MEW_USDT"]},"Gemini":{"symbol":["MEWUSD"]},"Kraken":{"pair":["MEWUSD"],"wsname":["MEW/USD"]},"KuCoin":{"symbol":["MEW-USDT"]},"MEXC":{"symbol":["MEWUSDT"]},"OKX":{"instId":["MEW-USD","MEW-USDT"]},"Upbit":{"market":["USDT-MEW"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "436"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MEW","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["MEWUSDT_SPBL"]},"Bybit":{"symbol":["MEWUSDT"]},"GateIo":{"id":["MEW_USDT"]},"KuCoin":{"symbol":["MEW-USDT"]},"MEXC":{"symbol":["MEWUSDT"]},"OKX":{"instId":["MEW-USDT"]},"Upbit":{"market":["USDT-MEW"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "437"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MEW","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bybit":{"symbol":["MEWUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "438"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SUSHI","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[6758],"symbol":["SUSHI"]}},"exchanges":{"Binance":{"symbol":["SUSHIUSDT"]},"BinanceUS":{"symbol":["SUSHIUSDT"]},"Bitfinex":{"symbol":["SUSHI:USD"]},"Bitget":{"symbol":["SUSHIUSDT_SPBL"]},"Bybit":{"symbol":["SUSHIUSDT"]},"Coinbase":{"id":["SUSHI-USD"]},"CryptoCom":{"instrument_name":["SUSHIUSD-PERP","SUSHI_USD","SUSHI_USDT"]},"GateIo":{"id":["SUSHI_USDT"]},"Gemini":{"symbol":["SUSHIUSD"]},"Kraken":{"pair":["SUSHIUSD"],"wsname":["SUSHI/USD"]},"KuCoin":{"symbol":["SUSHI-USDT"]},"MEXC":{"symbol":["SUSHIUSDT"]},"OKX":{"instId":["SUSHI-USDC","SUSHI-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "439"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SUSHI","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Coinbase":{"id":["SUSHI-ETH"]},"MEXC":{"symbol":["SUSHIETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "440"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SUSHI","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SUSHIUSDT"]},"BinanceUS":{"symbol":["SUSHIUSDT"]},"Bitget":{"symbol":["SUSHIUSDT_SPBL"]},"Bybit":{"symbol":["SUSHIUSDT"]},"CryptoCom":{"instrument_name":["SUSHI_USDT"]},"GateIo":{"id":["SUSHI_USDT"]},"KuCoin":{"symbol":["SUSHI-USDT"]},"MEXC":{"symbol":["SUSHIUSDT"]},"OKX":{"instId":["SUSHI-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "441"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SUSHI","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["SUSHI-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "442"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"IOTX","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[2777],"symbol":["IOTX"]}},"exchanges":{"Binance":{"symbol":["IOTXUSDT"]},"BinanceUS":{"symbol":["IOTXUSDT"]},"Bitget":{"symbol":["IOTXUSDT_SPBL"]},"Coinbase":{"id":["IOTX-USD"]},"CryptoCom":{"instrument_name":["IOTXUSD-PERP","IOTX_USD","IOTX_USDT"]},"GateIo":{"id":["IOTX_USDT"]},"Gemini":{"symbol":["IOTXUSD"]},"KuCoin":{"symbol":["IOTX-USDT"]},"MEXC":{"symbol":["IOTXUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "443"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"IOTX","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["IOTXUSDT"]},"BinanceUS":{"symbol":["IOTXUSDT"]},"Bitget":{"symbol":["IOTXUSDT_SPBL"]},"CryptoCom":{"instrument_name":["IOTX_USDT"]},"GateIo":{"id":["IOTX_USDT"]},"KuCoin":{"symbol":["IOTX-USDT"]},"MEXC":{"symbol":["IOTXUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "444"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ETHFI","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[29814],"symbol":["ETHFI"]}},"exchanges":{"Binance":{"symbol":["ETHFIUSDC","ETHFIUSDT"]},"Bitget":{"symbol":["ETHFIUSDT_SPBL"]},"Bybit":{"symbol":["ETHFIUSDT"]},"Coinbase":{"id":["ETHFI-USD"]},"CryptoCom":{"instrument_name":["ETHFIUSD-PERP","ETHFI_USD"]},"GateIo":{"id":["ETHFI_USDC","ETHFI_USDT"]},"Kraken":{"pair":["ETHFIUSD"],"wsname":["ETHFI/USD"]},"KuCoin":{"symbol":["ETHFI-USDT"]},"MEXC":{"symbol":["ETHFIUSDT"]},"OKX":{"instId":["ETHFI-USD","ETHFI-USDC","ETHFI-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "445"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ETHFI","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ETHFIUSDT"]},"Bitget":{"symbol":["ETHFIUSDT_SPBL"]},"Bybit":{"symbol":["ETHFIUSDT"]},"GateIo":{"id":["ETHFI_USDT"]},"KuCoin":{"symbol":["ETHFI-USDT"]},"MEXC":{"symbol":["ETHFIUSDT"]},"OKX":{"instId":["ETHFI-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "446"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ETHFI","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ETHFIUSDC"]},"GateIo":{"id":["ETHFI_USDC"]},"OKX":{"instId":["ETHFI-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "447"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"WOO","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[7501],"symbol":["WOO"]}},"exchanges":{"Binance":{"symbol":["WOOUSDT"]},"Bitfinex":{"symbol":["WOOUSD"]},"Bitget":{"symbol":["WOOUSDT_SPBL"]},"Bybit":{"symbol":["WOOUSDT"]},"CryptoCom":{"instrument_name":["WOOUSD-PERP","WOO_USD","WOO_USDT"]},"GateIo":{"id":["WOO_USDT"]},"Kraken":{"pair":["WOOUSD"],"wsname":["WOO/USD"]},"KuCoin":{"symbol":["WOO-USDT"]},"MEXC":{"symbol":["WOOUSDT"]},"OKX":{"instId":["WOO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "448"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"WOO","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["WOOUSDT"]},"Bitget":{"symbol":["WOOUSDT_SPBL"]},"Bybit":{"symbol":["WOOUSDT"]},"CryptoCom":{"instrument_name":["WOO_USDT"]},"GateIo":{"id":["WOO_USDT"]},"KuCoin":{"symbol":["WOO-USDT"]},"MEXC":{"symbol":["WOOUSDT"]},"OKX":{"instId":["WOO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "449"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"POPCAT","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28782,33470],"symbol":["POPCAT","POPCAT"]}},"exchanges":{"Bybit":{"symbol":["POPCATUSDT"]},"Coinbase":{"id":["POPCAT-USD"]},"CryptoCom":{"instrument_name":["POPCATUSD-PERP","POPCAT_USD","POPCAT_USDT"]},"GateIo":{"id":["POPCAT_USDT"]},"Gemini":{"symbol":["POPCATUSD"]},"Kraken":{"pair":["POPCATUSD"],"wsname":["POPCAT/USD"]},"KuCoin":{"symbol":["POPCAT-USDT"]},"MEXC":{"symbol":["POPCATUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "450"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"POPCAT","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bybit":{"symbol":["POPCATUSDT"]},"CryptoCom":{"instrument_name":["POPCAT_USDT"]},"GateIo":{"id":["POPCAT_USDT"]},"KuCoin":{"symbol":["POPCAT-USDT"]},"MEXC":{"symbol":["POPCATUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "451"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TURBO","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[24911,33724,34733],"symbol":["TURBO","TURBO","TURBO"]}},"exchanges":{"Binance":{"symbol":["TURBOUSDC","TURBOUSDT"]},"Bitfinex":{"symbol":["TURBO:USD"]},"Bitget":{"symbol":["TURBOUSDT_SPBL"]},"Coinbase":{"id":["TURBO-USD"]},"CryptoCom":{"instrument_name":["TURBOUSD-PERP","TURBO_USD","TURBO_USDT"]},"GateIo":{"id":["TURBO_USDT"]},"Kraken":{"pair":["TURBOUSD"],"wsname":["TURBO/USD"]},"KuCoin":{"symbol":["TURBO-USDT"]},"MEXC":{"symbol":["TURBOUSDC","TURBOUSDT"]},"OKX":{"instId":["TURBO-USDC","TURBO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "452"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TURBO","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["TURBOUSDT"]},"Bitget":{"symbol":["TURBOUSDT_SPBL"]},"CryptoCom":{"instrument_name":["TURBO_USDT"]},"GateIo":{"id":["TURBO_USDT"]},"KuCoin":{"symbol":["TURBO-USDT"]},"MEXC":{"symbol":["TURBOUSDT"]},"OKX":{"instId":["TURBO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "453"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TURBO","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["TURBOUSDC"]},"MEXC":{"symbol":["TURBOUSDC"]},"OKX":{"instId":["TURBO-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "454"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DGB","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[109],"symbol":["DGB"]}},"exchanges":{"Binance":{"symbol":["DGBUSDT"]},"BinanceUS":{"symbol":["DGBUSDT"]},"Bybit":{"symbol":["DGBUSDT"]},"CryptoCom":{"instrument_name":["DGB_USD"]},"GateIo":{"id":["DGB_USDT"]},"KuCoin":{"symbol":["DGB-USDT"]},"OKX":{"instId":["DGB-USDC","DGB-USDT"]},"Upbit":{"market":["USDT-DGB"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "455"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DGB","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["DGBUSDT"]},"BinanceUS":{"symbol":["DGBUSDT"]},"Bybit":{"symbol":["DGBUSDT"]},"GateIo":{"id":["DGB_USDT"]},"KuCoin":{"symbol":["DGB-USDT"]},"OKX":{"instId":["DGB-USDT"]},"Upbit":{"market":["USDT-DGB"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "456"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DGB","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["DGB-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "457"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"LRC","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["LRCETH"]},"KuCoin":{"symbol":["LRC-ETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "458"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"HMSTR","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[32195],"symbol":["HMSTR"]}},"exchanges":{"Binance":{"symbol":["HMSTRUSDC","HMSTRUSDT"]},"Bitfinex":{"symbol":["HMSTR:USD"]},"Bitget":{"symbol":["HMSTRUSDT_SPBL"]},"Bybit":{"symbol":["HMSTRUSDC","HMSTRUSDT"]},"CryptoCom":{"instrument_name":["HMSTRUSD-PERP","HMSTR_USD"]},"GateIo":{"id":["HMSTR_USDT"]},"KuCoin":{"symbol":["HMSTR-USDT"]},"MEXC":{"symbol":["HMSTRUSDT"]},"OKX":{"instId":["HMSTR-USDC","HMSTR-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "459"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"HMSTR","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["HMSTRUSDT"]},"Bitget":{"symbol":["HMSTRUSDT_SPBL"]},"Bybit":{"symbol":["HMSTRUSDT"]},"GateIo":{"id":["HMSTR_USDT"]},"KuCoin":{"symbol":["HMSTR-USDT"]},"MEXC":{"symbol":["HMSTRUSDT"]},"OKX":{"instId":["HMSTR-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "460"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"HMSTR","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["HMSTRUSDC"]},"Bybit":{"symbol":["HMSTRUSDC"]},"OKX":{"instId":["HMSTR-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "461"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"GMX","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[11857],"symbol":["GMX"]}},"exchanges":{"Binance":{"symbol":["GMXUSDT"]},"Bitget":{"symbol":["GMXUSDT_SPBL"]},"Bybit":{"symbol":["GMXUSDT"]},"CryptoCom":{"instrument_name":["GMX_USD","GMX_USDT"]},"GateIo":{"id":["GMX_USDT"]},"Kraken":{"pair":["GMXUSD"],"wsname":["GMX/USD"]},"KuCoin":{"symbol":["GMX-USDT"]},"MEXC":{"symbol":["GMXUSDT"]},"OKX":{"instId":["GMX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "462"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"GMX","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["GMXUSDT"]},"Bitget":{"symbol":["GMXUSDT_SPBL"]},"Bybit":{"symbol":["GMXUSDT"]},"CryptoCom":{"instrument_name":["GMX_USDT"]},"GateIo":{"id":["GMX_USDT"]},"KuCoin":{"symbol":["GMX-USDT"]},"MEXC":{"symbol":["GMXUSDT"]},"OKX":{"instId":["GMX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "463"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"EURC","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[20641,33923],"symbol":["EURC","EURC"]}},"exchanges":{"Coinbase":{"id":["EURC-USD","EURC-USDC"]},"OKX":{"instId":["EURC-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "464"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"EURC","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Coinbase":{"id":["EURC-USDC"]},"OKX":{"instId":["EURC-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "465"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"GMT","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[18069],"symbol":["GMT"]}},"exchanges":{"Binance":{"symbol":["GMTUSDT"]},"Bitget":{"symbol":["GMTUSDT_SPBL"]},"Bybit":{"symbol":["GMTUSDC","GMTUSDT"]},"Coinbase":{"id":["GMT-USD","GMT-USDT"]},"CryptoCom":{"instrument_name":["GMTUSD-PERP","GMT_USD"]},"GateIo":{"id":["GMT_USDT"]},"Gemini":{"symbol":["GMTUSD"]},"Kraken":{"pair":["GMTUSD"],"wsname":["GMT/USD"]},"KuCoin":{"symbol":["GMT-USDC","GMT-USDT"]},"OKX":{"instId":["GMT-USDC","GMT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "466"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"GMT","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["GMTUSDT"]},"Bitget":{"symbol":["GMTUSDT_SPBL"]},"Bybit":{"symbol":["GMTUSDT"]},"Coinbase":{"id":["GMT-USDT"]},"GateIo":{"id":["GMT_USDT"]},"KuCoin":{"symbol":["GMT-USDT"]},"OKX":{"instId":["GMT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "467"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"GMT","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bybit":{"symbol":["GMTUSDC"]},"KuCoin":{"symbol":["GMT-USDC"]},"OKX":{"instId":["GMT-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "468"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FXS","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[6953],"symbol":["FXS"]}},"exchanges":{"Binance":{"symbol":["FXSUSDT"]},"Bitget":{"symbol":["FXSUSDT_SPBL"]},"Bybit":{"symbol":["FXSUSDT"]},"CryptoCom":{"instrument_name":["FXSUSD-PERP","FXS_USD"]},"GateIo":{"id":["FXS_USDT"]},"Kraken":{"pair":["FXSUSD"],"wsname":["FXS/USD"]},"KuCoin":{"symbol":["FXS-USDT"]},"MEXC":{"symbol":["FXSUSDT"]},"OKX":{"instId":["FXS-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "469"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FXS","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["FXSUSDT"]},"Bitget":{"symbol":["FXSUSDT_SPBL"]},"Bybit":{"symbol":["FXSUSDT"]},"GateIo":{"id":["FXS_USDT"]},"KuCoin":{"symbol":["FXS-USDT"]},"MEXC":{"symbol":["FXSUSDT"]},"OKX":{"instId":["FXS-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "470"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ONT","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[2566],"symbol":["ONT"]}},"exchanges":{"Binance":{"symbol":["ONTUSDC","ONTUSDT"]},"BinanceUS":{"symbol":["ONTUSDT"]},"Bitget":{"symbol":["ONTUSDT_SPBL"]},"CryptoCom":{"instrument_name":["ONT_USD"]},"GateIo":{"id":["ONT_USDC","ONT_USDT"]},"KuCoin":{"symbol":["ONT-USDT"]},"MEXC":{"symbol":["ONTUSDT"]},"OKX":{"instId":["ONT-USDC","ONT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "471"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ONT","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ONTUSDT"]},"BinanceUS":{"symbol":["ONTUSDT"]},"Bitget":{"symbol":["ONTUSDT_SPBL"]},"GateIo":{"id":["ONT_USDT"]},"KuCoin":{"symbol":["ONT-USDT"]},"MEXC":{"symbol":["ONTUSDT"]},"OKX":{"instId":["ONT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "472"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ONT","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ONTUSDC"]},"GateIo":{"id":["ONT_USDC"]},"OKX":{"instId":["ONT-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "473"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SXP","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[4279],"symbol":["SXP"]}},"exchanges":{"Binance":{"symbol":["SXPUSDT"]},"BinanceTR":{"symbol":["SXP_USDT"]},"Bitget":{"symbol":["SXPUSDT_SPBL"]},"GateIo":{"id":["SXP_USDT"]},"KuCoin":{"symbol":["SXP-USDT"]},"MEXC":{"symbol":["SXPUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "474"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SXP","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SXPUSDT"]},"BinanceTR":{"symbol":["SXP_USDT"]},"Bitget":{"symbol":["SXPUSDT_SPBL"]},"GateIo":{"id":["SXP_USDT"]},"KuCoin":{"symbol":["SXP-USDT"]},"MEXC":{"symbol":["SXPUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "475"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"POLYX","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[20362],"symbol":["POLYX"]}},"exchanges":{"Binance":{"symbol":["POLYXUSDT"]},"BinanceUS":{"symbol":["POLYXUSDT"]},"Bitget":{"symbol":["POLYXUSDT_SPBL"]},"CryptoCom":{"instrument_name":["POLYXUSD-PERP","POLYX_USD"]},"GateIo":{"id":["POLYX_USDT"]},"KuCoin":{"symbol":["POLYX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "476"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"POLYX","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["POLYXUSDT"]},"BinanceUS":{"symbol":["POLYXUSDT"]},"Bitget":{"symbol":["POLYXUSDT_SPBL"]},"GateIo":{"id":["POLYX_USDT"]},"KuCoin":{"symbol":["POLYX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "477"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BAND","quote":"BNB"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BANDBNB"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "478"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BAND","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[4679],"symbol":["BAND"]}},"exchanges":{"Binance":{"symbol":["BANDUSDT"]},"BinanceUS":{"symbol":["BANDUSDT"]},"Bitget":{"symbol":["BANDUSDT_SPBL"]},"Coinbase":{"id":["BAND-USD"]},"CryptoCom":{"instrument_name":["BANDUSD-PERP","BAND_USD","BAND_USDT"]},"GateIo":{"id":["BAND_USDT"]},"Kraken":{"pair":["BANDUSD"],"wsname":["BAND/USD"]},"KuCoin":{"symbol":["BAND-USDT"]},"OKX":{"instId":["BAND-USDC","BAND-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "479"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BAND","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BANDUSDT"]},"BinanceUS":{"symbol":["BANDUSDT"]},"Bitget":{"symbol":["BANDUSDT_SPBL"]},"CryptoCom":{"instrument_name":["BAND_USDT"]},"GateIo":{"id":["BAND_USDT"]},"KuCoin":{"symbol":["BAND-USDT"]},"OKX":{"instId":["BAND-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "480"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BAND","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["BAND-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "481"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ARKM","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[27565],"symbol":["ARKM"]}},"exchanges":{"Binance":{"symbol":["ARKMUSDC","ARKMUSDT"]},"Bitget":{"symbol":["ARKMUSDT_SPBL"]},"Bybit":{"symbol":["ARKMUSDT"]},"Coinbase":{"id":["ARKM-USD"]},"CryptoCom":{"instrument_name":["ARKMUSD-PERP","ARKM_USD"]},"GateIo":{"id":["ARKM_USDC","ARKM_USDT"]},"Kraken":{"pair":["ARKMUSD"],"wsname":["ARKM/USD"]},"KuCoin":{"symbol":["ARKM-USDT"]},"MEXC":{"symbol":["ARKMUSDT"]},"OKX":{"instId":["ARKM-USDC","ARKM-USDT"]},"Upbit":{"market":["USDT-ARKM"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "482"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ARKM","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ARKMUSDT"]},"Bitget":{"symbol":["ARKMUSDT_SPBL"]},"Bybit":{"symbol":["ARKMUSDT"]},"GateIo":{"id":["ARKM_USDT"]},"KuCoin":{"symbol":["ARKM-USDT"]},"MEXC":{"symbol":["ARKMUSDT"]},"OKX":{"instId":["ARKM-USDT"]},"Upbit":{"market":["USDT-ARKM"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "483"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ARKM","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ARKMUSDC"]},"GateIo":{"id":["ARKM_USDC"]},"OKX":{"instId":["ARKM-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "484"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"IO","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[29835],"symbol":["IO"]}},"exchanges":{"Binance":{"symbol":["IOUSDC","IOUSDT"]},"Bitget":{"symbol":["IOUSDT_SPBL"]},"Bybit":{"symbol":["IOUSDT"]},"Coinbase":{"id":["IO-USD"]},"CryptoCom":{"instrument_name":["IOUSD-PERP","IO_USD","IO_USDT"]},"GateIo":{"id":["IO_USDT"]},"KuCoin":{"symbol":["IO-USDT"]},"MEXC":{"symbol":["IOUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "485"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"IO","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["IOUSDT"]},"Bitget":{"symbol":["IOUSDT_SPBL"]},"Bybit":{"symbol":["IOUSDT"]},"CryptoCom":{"instrument_name":["IO_USDT"]},"GateIo":{"id":["IO_USDT"]},"KuCoin":{"symbol":["IO-USDT"]},"MEXC":{"symbol":["IOUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "486"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"IO","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["IOUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "487"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"STORJ","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1772],"symbol":["STORJ"]}},"exchanges":{"Binance":{"symbol":["STORJUSDT"]},"BinanceUS":{"symbol":["STORJUSDT"]},"Bitget":{"symbol":["STORJUSDT_SPBL"]},"Coinbase":{"id":["STORJ-USD"]},"CryptoCom":{"instrument_name":["STORJUSD-PERP","STORJ_USD","STORJ_USDT"]},"GateIo":{"id":["STORJ_USDT"]},"Gemini":{"symbol":["STORJUSD"]},"Kraken":{"pair":["STORJUSD"],"wsname":["STORJ/USD"]},"KuCoin":{"symbol":["STORJ-USDT"]},"MEXC":{"symbol":["STORJUSDT"]},"OKX":{"instId":["STORJ-USDC","STORJ-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "488"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"STORJ","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["STORJUSDT"]},"BinanceUS":{"symbol":["STORJUSDT"]},"Bitget":{"symbol":["STORJUSDT_SPBL"]},"CryptoCom":{"instrument_name":["STORJ_USDT"]},"GateIo":{"id":["STORJ_USDT"]},"KuCoin":{"symbol":["STORJ-USDT"]},"MEXC":{"symbol":["STORJUSDT"]},"OKX":{"instId":["STORJ-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "489"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"STORJ","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["STORJ-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "490"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RPL","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[2943],"symbol":["RPL"]}},"exchanges":{"Binance":{"symbol":["RPLUSDT"]},"Bitget":{"symbol":["RPLUSDT_SPBL"]},"Bybit":{"symbol":["RPLUSDT"]},"Coinbase":{"id":["RPL-USD"]},"CryptoCom":{"instrument_name":["RPL_USD"]},"GateIo":{"id":["RPL_USDT"]},"Kraken":{"pair":["RPLUSD"],"wsname":["RPL/USD"]},"KuCoin":{"symbol":["RPL-USDT"]},"MEXC":{"symbol":["RPLUSDT"]},"OKX":{"instId":["RPL-USDC","RPL-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "491"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RPL","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["RPLUSDT"]},"Bitget":{"symbol":["RPLUSDT_SPBL"]},"Bybit":{"symbol":["RPLUSDT"]},"GateIo":{"id":["RPL_USDT"]},"KuCoin":{"symbol":["RPL-USDT"]},"MEXC":{"symbol":["RPLUSDT"]},"OKX":{"instId":["RPL-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "492"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RPL","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["RPL-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "493"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"USUAL","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[33979],"symbol":["USUAL"]}},"exchanges":{"Binance":{"symbol":["USUALUSDC","USUALUSDT"]},"Bitget":{"symbol":["USUALUSDT_SPBL"]},"GateIo":{"id":["USUAL_USDT"]},"Kraken":{"pair":["USUALUSD"],"wsname":["USUAL/USD"]},"KuCoin":{"symbol":["USUAL-USDT"]},"MEXC":{"symbol":["USUALUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "494"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"USUAL","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["USUALUSDT"]},"Bitget":{"symbol":["USUALUSDT_SPBL"]},"GateIo":{"id":["USUAL_USDT"]},"KuCoin":{"symbol":["USUAL-USDT"]},"MEXC":{"symbol":["USUALUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "495"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"USUAL","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["USUALUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "496"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"AEVO","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[29676],"symbol":["AEVO"]}},"exchanges":{"Binance":{"symbol":["AEVOUSDT"]},"Bitget":{"symbol":["AEVOUSDT_SPBL"]},"Bybit":{"symbol":["AEVOUSDT"]},"CryptoCom":{"instrument_name":["AEVO_USD"]},"GateIo":{"id":["AEVO_USDT"]},"Kraken":{"pair":["AEVOUSD"],"wsname":["AEVO/USD"]},"KuCoin":{"symbol":["AEVO-USDT"]},"MEXC":{"symbol":["AEVOUSDT"]},"OKX":{"instId":["AEVO-USDC","AEVO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "497"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"AEVO","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["AEVOUSDT"]},"Bitget":{"symbol":["AEVOUSDT_SPBL"]},"Bybit":{"symbol":["AEVOUSDT"]},"GateIo":{"id":["AEVO_USDT"]},"KuCoin":{"symbol":["AEVO-USDT"]},"MEXC":{"symbol":["AEVOUSDT"]},"OKX":{"instId":["AEVO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "498"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"AEVO","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["AEVO-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "499"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"METIS","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[9640],"symbol":["METIS"]}},"exchanges":{"Binance":{"symbol":["METISUSDT"]},"Bitget":{"symbol":["METISUSDT_SPBL"]},"Coinbase":{"id":["METIS-USD","METIS-USDT"]},"CryptoCom":{"instrument_name":["METISUSD-PERP","METIS_USD","METIS_USDT"]},"GateIo":{"id":["METIS_USDT"]},"KuCoin":{"symbol":["METIS-USDT"]},"MEXC":{"symbol":["METISUSDT"]},"OKX":{"instId":["METIS-USDC","METIS-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "500"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"METIS","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["METISUSDT"]},"Bitget":{"symbol":["METISUSDT_SPBL"]},"Coinbase":{"id":["METIS-USDT"]},"CryptoCom":{"instrument_name":["METIS_USDT"]},"GateIo":{"id":["METIS_USDT"]},"KuCoin":{"symbol":["METIS-USDT"]},"MEXC":{"symbol":["METISUSDT"]},"OKX":{"instId":["METIS-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "501"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"METIS","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["METIS-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "502"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"NEIRO","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[32461,32463,32464,32521,32653,32985,33138,33184,33238],"symbol":["NEIRO","NEIRO","NEIRO","NEIRO","NEIRO","NEIRO","NEIRO","NEIRO","NEIRO"]}},"exchanges":{"Binance":{"symbol":["NEIROUSDC","NEIROUSDT"]},"BinanceUS":{"symbol":["NEIROUSDT"]},"Bitget":{"symbol":["NEIROUSDT_SPBL"]},"Bybit":{"symbol":["NEIROUSDT"]},"GateIo":{"id":["NEIRO_USDT"]},"Kraken":{"pair":["NEIROUSD"],"wsname":["NEIRO/USD"]},"KuCoin":{"symbol":["NEIRO-USDT"]},"MEXC":{"symbol":["NEIROUSDT"]},"OKX":{"instId":["NEIRO-USDC","NEIRO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "503"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"NEIRO","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["NEIROUSDT"]},"BinanceUS":{"symbol":["NEIROUSDT"]},"Bitget":{"symbol":["NEIROUSDT_SPBL"]},"Bybit":{"symbol":["NEIROUSDT"]},"GateIo":{"id":["NEIRO_USDT"]},"KuCoin":{"symbol":["NEIRO-USDT"]},"MEXC":{"symbol":["NEIROUSDT"]},"OKX":{"instId":["NEIRO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "504"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"NEIRO","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["NEIROUSDC"]},"OKX":{"instId":["NEIRO-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "505"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MEME","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1191,18938,23258,25159,28111,28301,33368],"symbol":["MEME","MEME","MEME","MEME","MEME","MEME","MEME"]}},"exchanges":{"Binance":{"symbol":["MEMEUSDC","MEMEUSDT"]},"Bybit":{"symbol":["MEMEUSDT"]},"GateIo":{"id":["MEME_USDT"]},"Kraken":{"pair":["MEMEUSD"],"wsname":["MEME/USD"]},"KuCoin":{"symbol":["MEME-USDT"]},"MEXC":{"symbol":["MEMEUSDT"]},"OKX":{"instId":["MEME-USD","MEME-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "506"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MEME","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["MEMEUSDT"]},"Bybit":{"symbol":["MEMEUSDT"]},"GateIo":{"id":["MEME_USDT"]},"KuCoin":{"symbol":["MEME-USDT"]},"MEXC":{"symbol":["MEMEUSDT"]},"OKX":{"instId":["MEME-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "507"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MEME","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["MEMEUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "508"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"UMA","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[5617],"symbol":["UMA"]}},"exchanges":{"Binance":{"symbol":["UMAUSDT"]},"Bitget":{"symbol":["UMAUSDT_SPBL"]},"Bybit":{"symbol":["UMAUSDT"]},"Coinbase":{"id":["UMA-USD"]},"CryptoCom":{"instrument_name":["UMA_USD"]},"GateIo":{"id":["UMA_USDT"]},"Gemini":{"symbol":["UMAUSD"]},"Kraken":{"pair":["UMAUSD"],"wsname":["UMA/USD"]},"KuCoin":{"symbol":["UMA-USDT"]},"MEXC":{"symbol":["UMAUSDT"]},"OKX":{"instId":["UMA-USDC","UMA-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "509"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"UMA","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["UMAUSDT"]},"Bitget":{"symbol":["UMAUSDT_SPBL"]},"Bybit":{"symbol":["UMAUSDT"]},"GateIo":{"id":["UMA_USDT"]},"KuCoin":{"symbol":["UMA-USDT"]},"MEXC":{"symbol":["UMAUSDT"]},"OKX":{"instId":["UMA-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "510"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"UMA","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["UMA-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "511"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"AVAIL","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[32376],"symbol":["AVAIL"]}},"exchanges":{"Bitget":{"symbol":["AVAILUSDT_SPBL"]},"Bybit":{"symbol":["AVAILUSDT"]},"GateIo":{"id":["AVAIL_USDT"]},"KuCoin":{"symbol":["AVAIL-USDT"]},"MEXC":{"symbol":["AVAILUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "512"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"AVAIL","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["AVAILUSDT_SPBL"]},"Bybit":{"symbol":["AVAILUSDT"]},"GateIo":{"id":["AVAIL_USDT"]},"KuCoin":{"symbol":["AVAIL-USDT"]},"MEXC":{"symbol":["AVAILUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "513"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MANTA","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[13631],"symbol":["MANTA"]}},"exchanges":{"Binance":{"symbol":["MANTAUSDC","MANTAUSDT"]},"Bitget":{"symbol":["MANTAUSDT_SPBL"]},"Bybit":{"symbol":["MANTAUSDT"]},"GateIo":{"id":["MANTA_USDC","MANTA_USDT"]},"KuCoin":{"symbol":["MANTA-USDT"]},"MEXC":{"symbol":["MANTAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "514"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MANTA","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["MANTAUSDT"]},"Bitget":{"symbol":["MANTAUSDT_SPBL"]},"Bybit":{"symbol":["MANTAUSDT"]},"GateIo":{"id":["MANTA_USDT"]},"KuCoin":{"symbol":["MANTA-USDT"]},"MEXC":{"symbol":["MANTAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "515"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MANTA","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["MANTAUSDC"]},"GateIo":{"id":["MANTA_USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "516"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ALT","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[10897,22065,29073],"symbol":["ALT","ALT","ALT"]}},"exchanges":{"Binance":{"symbol":["ALTUSDC","ALTUSDT"]},"Bybit":{"symbol":["ALTUSDT"]},"CryptoCom":{"instrument_name":["ALT_USD"]},"GateIo":{"id":["ALT_USDC","ALT_USDT"]},"Kraken":{"pair":["ALTUSD"],"wsname":["ALT/USD"]},"MEXC":{"symbol":["ALTUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "517"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ALT","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ALTUSDT"]},"Bybit":{"symbol":["ALTUSDT"]},"GateIo":{"id":["ALT_USDT"]},"MEXC":{"symbol":["ALTUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "518"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ALT","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ALTUSDC"]},"GateIo":{"id":["ALT_USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "519"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SPELL","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[11289],"symbol":["SPELL"]}},"exchanges":{"Binance":{"symbol":["SPELLUSDT"]},"BinanceUS":{"symbol":["SPELLUSDT"]},"Bitfinex":{"symbol":["SPELL:USD"]},"Bitget":{"symbol":["SPELLUSDT_SPBL"]},"Bybit":{"symbol":["SPELLUSDT"]},"Coinbase":{"id":["SPELL-USD","SPELL-USDT"]},"CryptoCom":{"instrument_name":["SPELL_USD","SPELL_USDT"]},"GateIo":{"id":["SPELL_USDT"]},"Kraken":{"pair":["SPELLUSD"],"wsname":["SPELL/USD"]},"MEXC":{"symbol":["SPELLUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "520"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SPELL","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SPELLUSDT"]},"BinanceUS":{"symbol":["SPELLUSDT"]},"Bitget":{"symbol":["SPELLUSDT_SPBL"]},"Bybit":{"symbol":["SPELLUSDT"]},"Coinbase":{"id":["SPELL-USDT"]},"CryptoCom":{"instrument_name":["SPELL_USDT"]},"GateIo":{"id":["SPELL_USDT"]},"MEXC":{"symbol":["SPELLUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "521"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BOME","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[29870,33369,33774],"symbol":["BOME","BOME","BOME"]}},"exchanges":{"Binance":{"symbol":["BOMEUSDC","BOMEUSDT"]},"Bitget":{"symbol":["BOMEUSDT_SPBL"]},"Bybit":{"symbol":["BOMEUSDT"]},"CryptoCom":{"instrument_name":["BOMEUSD-PERP","BOME_USD","BOME_USDT"]},"GateIo":{"id":["BOME_USDC","BOME_USDT"]},"Gemini":{"symbol":["BOMEUSD"]},"KuCoin":{"symbol":["BOME-USDT"]},"MEXC":{"symbol":["BOMEUSDT"]},"OKX":{"instId":["BOME-USD","BOME-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "522"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BOME","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BOMEUSDT"]},"Bitget":{"symbol":["BOMEUSDT_SPBL"]},"Bybit":{"symbol":["BOMEUSDT"]},"CryptoCom":{"instrument_name":["BOME_USDT"]},"GateIo":{"id":["BOME_USDT"]},"KuCoin":{"symbol":["BOME-USDT"]},"MEXC":{"symbol":["BOMEUSDT"]},"OKX":{"instId":["BOME-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "523"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BOME","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BOMEUSDC"]},"GateIo":{"id":["BOME_USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "524"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"IQ","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[2930],"symbol":["IQ"]}},"exchanges":{"Binance":{"symbol":["IQUSDT"]},"Bitget":{"symbol":["IQUSDT_SPBL"]},"CryptoCom":{"instrument_name":["IQ_USD"]},"GateIo":{"id":["IQ_USDT"]},"MEXC":{"symbol":["IQUSDT"]},"OKX":{"instId":["IQ-USDC","IQ-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "525"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"IQ","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["IQUSDT"]},"Bitget":{"symbol":["IQUSDT_SPBL"]},"GateIo":{"id":["IQ_USDT"]},"MEXC":{"symbol":["IQUSDT"]},"OKX":{"instId":["IQ-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "526"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"IQ","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["IQ-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "527"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"AIXBT","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[34103],"symbol":["AIXBT"]}},"exchanges":{"Binance":{"symbol":["AIXBTUSDC","AIXBTUSDT"]},"Bitget":{"symbol":["AIXBTUSDT_SPBL"]},"Bybit":{"symbol":["AIXBTUSDT"]},"CryptoCom":{"instrument_name":["AIXBTUSD-PERP","AIXBT_USD"]},"GateIo":{"id":["AIXBT_USDT"]},"Kraken":{"pair":["AIXBTUSD"],"wsname":["AIXBT/USD"]},"KuCoin":{"symbol":["AIXBT-USDT"]},"MEXC":{"symbol":["AIXBTUSDC","AIXBTUSDT"]},"OKX":{"instId":["AIXBT-USD","AIXBT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "528"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"AIXBT","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["AIXBTUSDT"]},"Bitget":{"symbol":["AIXBTUSDT_SPBL"]},"Bybit":{"symbol":["AIXBTUSDT"]},"GateIo":{"id":["AIXBT_USDT"]},"KuCoin":{"symbol":["AIXBT-USDT"]},"MEXC":{"symbol":["AIXBTUSDT"]},"OKX":{"instId":["AIXBT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "529"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"AIXBT","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["AIXBTUSDC"]},"MEXC":{"symbol":["AIXBTUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "530"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"VELO","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[20435,7127],"symbol":["VELO","VELO"]}},"exchanges":{"Bitget":{"symbol":["VELOUSDT_SPBL"]},"Bybit":{"symbol":["VELOUSDT"]},"Coinbase":{"id":["VELO-USD"]},"CryptoCom":{"instrument_name":["VELO_USD"]},"GateIo":{"id":["VELO_USDT"]},"KuCoin":{"symbol":["VELO-USDT"]},"MEXC":{"symbol":["VELOUSDT"]},"OKX":{"instId":["VELO-USDC","VELO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "531"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"VELO","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["VELOUSDT_SPBL"]},"Bybit":{"symbol":["VELOUSDT"]},"GateIo":{"id":["VELO_USDT"]},"KuCoin":{"symbol":["VELO-USDT"]},"MEXC":{"symbol":["VELOUSDT"]},"OKX":{"instId":["VELO-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "532"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"VELO","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["VELO-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "533"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BAL","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[5728],"symbol":["BAL"]}},"exchanges":{"Binance":{"symbol":["BALUSDT"]},"BinanceUS":{"symbol":["BALUSDT"]},"Bitget":{"symbol":["BALUSDT_SPBL"]},"Coinbase":{"id":["BAL-USD"]},"CryptoCom":{"instrument_name":["BALUSD-PERP","BAL_USD"]},"GateIo":{"id":["BAL_USDT"]},"Kraken":{"pair":["BALUSD"],"wsname":["BAL/USD"]},"KuCoin":{"symbol":["BAL-USDT"]},"MEXC":{"symbol":["BALUSDT"]},"OKX":{"instId":["BAL-USDC","BAL-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "534"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BAL","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BALUSDT"]},"BinanceUS":{"symbol":["BALUSDT"]},"Bitget":{"symbol":["BALUSDT_SPBL"]},"GateIo":{"id":["BAL_USDT"]},"KuCoin":{"symbol":["BAL-USDT"]},"MEXC":{"symbol":["BALUSDT"]},"OKX":{"instId":["BAL-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "535"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BAL","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["BAL-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "536"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"XVS","quote":"BNB"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["XVSBNB"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "537"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"XVS","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[7288],"symbol":["XVS"]}},"exchanges":{"Binance":{"symbol":["XVSUSDT"]},"GateIo":{"id":["XVS_USDT"]},"MEXC":{"symbol":["XVSUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "538"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"XVS","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["XVSUSDT"]},"GateIo":{"id":["XVS_USDT"]},"MEXC":{"symbol":["XVSUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "539"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CHR","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[24158,3978],"symbol":["CHR","CHR"]}},"exchanges":{"Binance":{"symbol":["CHRUSDT"]},"Bitget":{"symbol":["CHRUSDT_SPBL"]},"CryptoCom":{"instrument_name":["CHRUSD-PERP","CHR_USD","CHR_USDT"]},"GateIo":{"id":["CHR_USDT"]},"Kraken":{"pair":["CHRUSD"],"wsname":["CHR/USD"]},"KuCoin":{"symbol":["CHR-USDT"]},"MEXC":{"symbol":["CHRUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "540"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CHR","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["CHRUSDT"]},"Bitget":{"symbol":["CHRUSDT_SPBL"]},"CryptoCom":{"instrument_name":["CHR_USDT"]},"GateIo":{"id":["CHR_USDT"]},"KuCoin":{"symbol":["CHR-USDT"]},"MEXC":{"symbol":["CHRUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "541"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ONG","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[3217],"symbol":["ONG"]}},"exchanges":{"Binance":{"symbol":["ONGUSDT"]},"BinanceUS":{"symbol":["ONGUSDT"]},"Bitget":{"symbol":["ONGUSDT_SPBL"]},"CryptoCom":{"instrument_name":["ONG_USD"]},"GateIo":{"id":["ONG_USDT"]},"MEXC":{"symbol":["ONGUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "542"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ONG","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ONGUSDT"]},"BinanceUS":{"symbol":["ONGUSDT"]},"Bitget":{"symbol":["ONGUSDT_SPBL"]},"GateIo":{"id":["ONG_USDT"]},"MEXC":{"symbol":["ONGUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "543"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BLAST","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28480,9967],"symbol":["BLAST","BLAST"]}},"exchanges":{"Bitfinex":{"symbol":["BLAST:USD"]},"Bitget":{"symbol":["BLASTUSDT_SPBL"]},"Bybit":{"symbol":["BLASTUSDT"]},"Coinbase":{"id":["BLAST-USD"]},"CryptoCom":{"instrument_name":["BLASTUSD-PERP","BLAST_USD"]},"GateIo":{"id":["BLAST_USDT"]},"KuCoin":{"symbol":["BLAST-USDT"]},"MEXC":{"symbol":["BLASTUSDT"]},"Upbit":{"market":["USDT-BLAST"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "544"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BLAST","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["BLASTUSDT_SPBL"]},"Bybit":{"symbol":["BLASTUSDT"]},"GateIo":{"id":["BLAST_USDT"]},"KuCoin":{"symbol":["BLAST-USDT"]},"MEXC":{"symbol":["BLASTUSDT"]},"Upbit":{"market":["USDT-BLAST"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "545"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BIGTIME","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28230],"symbol":["BIGTIME"]}},"exchanges":{"Bitget":{"symbol":["BIGTIMEUSDT_SPBL"]},"Coinbase":{"id":["BIGTIME-USD"]},"CryptoCom":{"instrument_name":["BIGTIMEUSD-PERP","BIGTIME_USD","BIGTIME_USDT"]},"GateIo":{"id":["BIGTIME_USDT"]},"Kraken":{"pair":["BIGTIMEUSD"],"wsname":["BIGTIME/USD"]},"KuCoin":{"symbol":["BIGTIME-USDT"]},"MEXC":{"symbol":["BIGTIMEUSDT"]},"OKX":{"instId":["BIGTIME-USDC","BIGTIME-USDT"]},"Upbit":{"market":["USDT-BIGTIME"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "546"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BIGTIME","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["BIGTIMEUSDT_SPBL"]},"CryptoCom":{"instrument_name":["BIGTIME_USDT"]},"GateIo":{"id":["BIGTIME_USDT"]},"KuCoin":{"symbol":["BIGTIME-USDT"]},"MEXC":{"symbol":["BIGTIMEUSDT"]},"OKX":{"instId":["BIGTIME-USDT"]},"Upbit":{"market":["USDT-BIGTIME"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "547"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BIGTIME","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["BIGTIME-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "548"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ILV","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[8719],"symbol":["ILV"]}},"exchanges":{"Binance":{"symbol":["ILVUSDT"]},"BinanceUS":{"symbol":["ILVUSDT"]},"Bitget":{"symbol":["ILVUSDT_SPBL"]},"Coinbase":{"id":["ILV-USD"]},"CryptoCom":{"instrument_name":["ILV_USD","ILV_USDT"]},"GateIo":{"id":["ILV_USDT"]},"KuCoin":{"symbol":["ILV-USDT"]},"MEXC":{"symbol":["ILVUSDT"]},"OKX":{"instId":["ILV-USD","ILV-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "549"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ILV","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ILVUSDT"]},"BinanceUS":{"symbol":["ILVUSDT"]},"Bitget":{"symbol":["ILVUSDT_SPBL"]},"CryptoCom":{"instrument_name":["ILV_USDT"]},"GateIo":{"id":["ILV_USDT"]},"KuCoin":{"symbol":["ILV-USDT"]},"MEXC":{"symbol":["ILVUSDT"]},"OKX":{"instId":["ILV-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "550"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDP","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[3330,8886],"symbol":["USDP","USDP"]}},"exchanges":{"Binance":{"symbol":["USDPUSDT"]},"GateIo":{"id":["USDP_USDT"]},"KuCoin":{"symbol":["USDP-USDT"]},"MEXC":{"symbol":["USDPUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "551"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDP","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["USDPUSDT"]},"GateIo":{"id":["USDP_USDT"]},"KuCoin":{"symbol":["USDP-USDT"]},"MEXC":{"symbol":["USDPUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "552"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PEOPLE","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[14806,32079],"symbol":["PEOPLE","PEOPLE"]}},"exchanges":{"Binance":{"symbol":["PEOPLEUSDC","PEOPLEUSDT"]},"Bitget":{"symbol":["PEOPLEUSDT_SPBL"]},"Bybit":{"symbol":["PEOPLEUSDT"]},"GateIo":{"id":["PEOPLE_USDC","PEOPLE_USDT"]},"KuCoin":{"symbol":["PEOPLE-USDT"]},"MEXC":{"symbol":["PEOPLEUSDT"]},"OKX":{"instId":["PEOPLE-USDC","PEOPLE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "553"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PEOPLE","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["PEOPLEUSDT"]},"Bitget":{"symbol":["PEOPLEUSDT_SPBL"]},"Bybit":{"symbol":["PEOPLEUSDT"]},"GateIo":{"id":["PEOPLE_USDT"]},"KuCoin":{"symbol":["PEOPLE-USDT"]},"MEXC":{"symbol":["PEOPLEUSDT"]},"OKX":{"instId":["PEOPLE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "554"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PEOPLE","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["PEOPLEUSDC"]},"GateIo":{"id":["PEOPLE_USDC"]},"OKX":{"instId":["PEOPLE-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "555"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"TRB","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[4944],"symbol":["TRB"]}},"exchanges":{"Binance":{"symbol":["TRBUSDC","TRBUSDT"]},"Bitget":{"symbol":["TRBUSDT_SPBL"]},"Coinbase":{"id":["TRB-USD"]},"CryptoCom":{"instrument_name":["TRBUSD-PERP","TRB_USD","TRB_USDT"]},"GateIo":{"id":["TRB_USDC","TRB_USDT"]},"KuCoin":{"symbol":["TRB-USDT"]},"OKX":{"instId":["TRB-USDC","TRB-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "556"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"TRB","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["TRBUSDT"]},"Bitget":{"symbol":["TRBUSDT_SPBL"]},"CryptoCom":{"instrument_name":["TRB_USDT"]},"GateIo":{"id":["TRB_USDT"]},"KuCoin":{"symbol":["TRB-USDT"]},"OKX":{"instId":["TRB-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "557"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"TRB","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["TRBUSDC"]},"GateIo":{"id":["TRB_USDC"]},"OKX":{"instId":["TRB-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "558"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PIXEL","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[29335],"symbol":["PIXEL"]}},"exchanges":{"Binance":{"symbol":["PIXELUSDC","PIXELUSDT"]},"Bitget":{"symbol":["PIXELUSDT_SPBL"]},"CryptoCom":{"instrument_name":["PIXELUSD-PERP","PIXEL_USD","PIXEL_USDT"]},"GateIo":{"id":["PIXEL_USDC","PIXEL_USDT"]},"KuCoin":{"symbol":["PIXEL-USDT"]},"MEXC":{"symbol":["PIXELUSDT"]},"OKX":{"instId":["PIXEL-USD","PIXEL-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "559"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PIXEL","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["PIXELUSDT"]},"Bitget":{"symbol":["PIXELUSDT_SPBL"]},"CryptoCom":{"instrument_name":["PIXEL_USDT"]},"GateIo":{"id":["PIXEL_USDT"]},"KuCoin":{"symbol":["PIXEL-USDT"]},"MEXC":{"symbol":["PIXELUSDT"]},"OKX":{"instId":["PIXEL-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "560"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"PIXEL","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["PIXELUSDC"]},"GateIo":{"id":["PIXEL_USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "561"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"XAI","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[11726,25143,25679,28285,28357,28933,29049],"symbol":["XAI","XAI","XAI","XAI","XAI","XAI","XAI"]}},"exchanges":{"Binance":{"symbol":["XAIUSDT"]},"Bitget":{"symbol":["XAIUSDT_SPBL"]},"Bybit":{"symbol":["XAIUSDT"]},"CryptoCom":{"instrument_name":["XAI_USD"]},"GateIo":{"id":["XAI_USDT"]},"KuCoin":{"symbol":["XAI-USDT"]},"MEXC":{"symbol":["XAIUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "562"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"XAI","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["XAIUSDT"]},"Bitget":{"symbol":["XAIUSDT_SPBL"]},"Bybit":{"symbol":["XAIUSDT"]},"GateIo":{"id":["XAI_USDT"]},"KuCoin":{"symbol":["XAI-USDT"]},"MEXC":{"symbol":["XAIUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "563"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SLP","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[5824],"symbol":["SLP"]}},"exchanges":{"Binance":{"symbol":["SLPUSDT"]},"BinanceUS":{"symbol":["SLPUSDT"]},"Bitget":{"symbol":["SLPUSDT_SPBL"]},"Bybit":{"symbol":["SLPUSDT"]},"CryptoCom":{"instrument_name":["SLP_USD","SLP_USDT"]},"GateIo":{"id":["SLP_USDT"]},"KuCoin":{"symbol":["SLP-USDT"]},"MEXC":{"symbol":["SLPUSDT"]},"OKX":{"instId":["SLP-USDC","SLP-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "564"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SLP","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SLPUSDT"]},"BinanceUS":{"symbol":["SLPUSDT"]},"Bitget":{"symbol":["SLPUSDT_SPBL"]},"Bybit":{"symbol":["SLPUSDT"]},"CryptoCom":{"instrument_name":["SLP_USDT"]},"GateIo":{"id":["SLP_USDT"]},"KuCoin":{"symbol":["SLP-USDT"]},"MEXC":{"symbol":["SLPUSDT"]},"OKX":{"instId":["SLP-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "565"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SLP","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["SLP-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "566"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDtb","quote":"USD"},"decimals":8,"category":"","market_hours":null,"arguments":{"aggregators":{"CoinMarketCap":{"id":[34691],"symbol":["USDTb"]}},"exchanges":{"Bybit":{"symbol":["USDTBUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "567"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDtb","quote":"USDT"},"decimals":8,"category":"","market_hours":null,"arguments":{"exchanges":{"Bybit":{"symbol":["USDTBUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "568"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"HSK","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[33849],"symbol":["HSK"]}},"exchanges":{"GateIo":{"id":["HSK_USDT"]},"KuCoin":{"symbol":["HSK-USDT"]},"MEXC":{"symbol":["HSKUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "569"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"HSK","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"GateIo":{"id":["HSK_USDT"]},"KuCoin":{"symbol":["HSK-USDT"]},"MEXC":{"symbol":["HSKUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "570"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"JOE","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[11396,28292,28504],"symbol":["JOE","JOE","JOE"]}},"exchanges":{"Binance":{"symbol":["JOEUSDT"]},"Bitget":{"symbol":["JOEUSDT_SPBL"]},"CryptoCom":{"instrument_name":["JOEUSD-PERP","JOE_USD"]},"GateIo":{"id":["JOE_USDT"]},"MEXC":{"symbol":["JOEUSDT"]},"OKX":{"instId":["JOE-USD","JOE-USDC","JOE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "571"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"JOE","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["JOEUSDT"]},"Bitget":{"symbol":["JOEUSDT_SPBL"]},"GateIo":{"id":["JOE_USDT"]},"MEXC":{"symbol":["JOEUSDT"]},"OKX":{"instId":["JOE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "572"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"JOE","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["JOE-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "573"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SCR","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[26998,3094],"symbol":["SCR","SCR"]}},"exchanges":{"Binance":{"symbol":["SCRUSDT"]},"Bitget":{"symbol":["SCRUSDT_SPBL"]},"Bybit":{"symbol":["SCRUSDT"]},"GateIo":{"id":["SCR_USDT"]},"KuCoin":{"symbol":["SCR-USDT"]},"MEXC":{"symbol":["SCRUSDT"]},"OKX":{"instId":["SCR-USDC","SCR-USDT"]},"Upbit":{"market":["USDT-SCR"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "574"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SCR","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["SCRUSDT"]},"Bitget":{"symbol":["SCRUSDT_SPBL"]},"Bybit":{"symbol":["SCRUSDT"]},"GateIo":{"id":["SCR_USDT"]},"KuCoin":{"symbol":["SCR-USDT"]},"MEXC":{"symbol":["SCRUSDT"]},"OKX":{"instId":["SCR-USDT"]},"Upbit":{"market":["USDT-SCR"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "575"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"SCR","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["SCR-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "576"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"DOGS","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[29720,32698,32713,32777,32815,33519,33660],"symbol":["DOGS","DOGS","DOGS","DOGS","DOGS","DOGS","DOGS"]}},"exchanges":{"Binance":{"symbol":["DOGSUSDC","DOGSUSDT"]},"Bitget":{"symbol":["DOGSUSDT_SPBL"]},"Bybit":{"symbol":["DOGSUSDC","DOGSUSDT"]},"CryptoCom":{"instrument_name":["DOGSUSD-PERP","DOGS_USD","DOGS_USDT"]},"GateIo":{"id":["DOGS_USDT"]},"Kraken":{"pair":["DOGSUSD"],"wsname":["DOGS/USD"]},"KuCoin":{"symbol":["DOGS-USDT"]},"MEXC":{"symbol":["DOGSUSDT"]},"OKX":{"instId":["DOGS-USDC","DOGS-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "577"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"DOGS","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["DOGSUSDT"]},"Bitget":{"symbol":["DOGSUSDT_SPBL"]},"Bybit":{"symbol":["DOGSUSDT"]},"CryptoCom":{"instrument_name":["DOGS_USDT"]},"GateIo":{"id":["DOGS_USDT"]},"KuCoin":{"symbol":["DOGS-USDT"]},"MEXC":{"symbol":["DOGSUSDT"]},"OKX":{"instId":["DOGS-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "578"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"DOGS","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["DOGSUSDC"]},"Bybit":{"symbol":["DOGSUSDC"]},"OKX":{"instId":["DOGS-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "579"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"EDU","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[24613],"symbol":["EDU"]}},"exchanges":{"Binance":{"symbol":["EDUUSDT"]},"GateIo":{"id":["EDU_USDT"]},"KuCoin":{"symbol":["EDU-USDT"]},"MEXC":{"symbol":["EDUUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "580"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"EDU","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["EDUUSDT"]},"GateIo":{"id":["EDU_USDT"]},"KuCoin":{"symbol":["EDU-USDT"]},"MEXC":{"symbol":["EDUUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "581"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ANON","quote":"USD"},"decimals":8,"category":"","market_hours":"","arguments":{"aggregators":{"CoinMarketCap":{"id":[30846,31734,35092],"symbol":["ANON","ANON","ANON"]}},"exchanges":{"GateIo":{"id":["ANON_USDT"]},"Kraken":{"pair":["ANONUSD"],"wsname":["ANON/USD"]},"MEXC":{"symbol":["ANONUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "582"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ANON","quote":"USDT"},"decimals":8,"category":"","market_hours":"","arguments":{"exchanges":{"GateIo":{"id":["ANON_USDT"]},"MEXC":{"symbol":["ANONUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "583"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"C98","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[10903],"symbol":["C98"]}},"exchanges":{"Binance":{"symbol":["C98USDT"]},"Bitget":{"symbol":["C98USDT_SPBL"]},"Bybit":{"symbol":["C98USDT"]},"Coinbase":{"id":["C98-USD","C98-USDT"]},"CryptoCom":{"instrument_name":["C98_USD"]},"GateIo":{"id":["C98_USDT"]},"Kraken":{"pair":["C98USD"],"wsname":["C98/USD"]},"KuCoin":{"symbol":["C98-USDT"]},"MEXC":{"symbol":["C98USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "584"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"C98","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["C98USDT"]},"Bitget":{"symbol":["C98USDT_SPBL"]},"Bybit":{"symbol":["C98USDT"]},"Coinbase":{"id":["C98-USDT"]},"GateIo":{"id":["C98_USDT"]},"KuCoin":{"symbol":["C98-USDT"]},"MEXC":{"symbol":["C98USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "585"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"KNC","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[9444],"symbol":["KNC"]}},"exchanges":{"Binance":{"symbol":["KNCUSDT"]},"BinanceUS":{"symbol":["KNCUSDT"]},"Bitget":{"symbol":["KNCUSDT_SPBL"]},"Coinbase":{"id":["KNC-USD"]},"CryptoCom":{"instrument_name":["KNC_USD"]},"GateIo":{"id":["KNC_USDT"]},"Kraken":{"pair":["KNCUSD"],"wsname":["KNC/USD"]},"KuCoin":{"symbol":["KNC-USDT"]},"MEXC":{"symbol":["KNCUSDT"]},"OKX":{"instId":["KNC-USDC","KNC-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "586"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"KNC","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["KNCETH"]},"KuCoin":{"symbol":["KNC-ETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "587"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"KNC","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["KNCUSDT"]},"BinanceUS":{"symbol":["KNCUSDT"]},"Bitget":{"symbol":["KNCUSDT_SPBL"]},"GateIo":{"id":["KNC_USDT"]},"KuCoin":{"symbol":["KNC-USDT"]},"MEXC":{"symbol":["KNCUSDT"]},"OKX":{"instId":["KNC-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "588"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"KNC","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["KNC-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "589"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BB","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[15231,18996,30746,33102],"symbol":["BB","BB","BB","BB"]}},"exchanges":{"Binance":{"symbol":["BBUSDC","BBUSDT"]},"Bitget":{"symbol":["BBUSDT_SPBL"]},"Bybit":{"symbol":["BBUSDT"]},"GateIo":{"id":["BB_USDC","BB_USDT"]},"KuCoin":{"symbol":["BB-USDT"]},"MEXC":{"symbol":["BBUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "590"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BB","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BBUSDT"]},"Bitget":{"symbol":["BBUSDT_SPBL"]},"Bybit":{"symbol":["BBUSDT"]},"GateIo":{"id":["BB_USDT"]},"KuCoin":{"symbol":["BB-USDT"]},"MEXC":{"symbol":["BBUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "591"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"BB","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BBUSDC"]},"GateIo":{"id":["BB_USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "592"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BUSD","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[4687],"symbol":["BUSD"]}},"exchanges":{"Binance":{"symbol":["BUSDUSDT"]},"BinanceUS":{"symbol":["BUSDUSDT"]},"Coinbase":{"id":["BUSD-USD"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "593"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BUSD","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BUSDUSDT"]},"BinanceUS":{"symbol":["BUSDUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "594"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"WIN","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28992,31754,4206],"symbol":["WIN","WIN","WIN"]}},"exchanges":{"Binance":{"symbol":["WINUSDC","WINUSDT"]},"Bitget":{"symbol":["WINUSDT_SPBL"]},"GateIo":{"id":["WIN_USDT"]},"KuCoin":{"symbol":["WIN-USDT"]},"MEXC":{"symbol":["WINUSDT"]},"OKX":{"instId":["WIN-USD","WIN-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "595"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"WIN","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["WINUSDT"]},"Bitget":{"symbol":["WINUSDT_SPBL"]},"GateIo":{"id":["WIN_USDT"]},"KuCoin":{"symbol":["WIN-USDT"]},"MEXC":{"symbol":["WINUSDT"]},"OKX":{"instId":["WIN-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "596"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"WIN","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["WINUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "597"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MOVR","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[9285],"symbol":["MOVR"]}},"exchanges":{"Binance":{"symbol":["MOVRUSDT"]},"Bitget":{"symbol":["MOVRUSDT_SPBL"]},"Bybit":{"symbol":["MOVRUSDT"]},"CryptoCom":{"instrument_name":["MOVR_USD","MOVR_USDT"]},"GateIo":{"id":["MOVR_USDT"]},"Kraken":{"pair":["MOVRUSD"],"wsname":["MOVR/USD"]},"KuCoin":{"symbol":["MOVR-USDT"]},"MEXC":{"symbol":["MOVRUSDT"]},"OKX":{"instId":["MOVR-USDC","MOVR-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "598"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MOVR","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["MOVRUSDT"]},"Bitget":{"symbol":["MOVRUSDT_SPBL"]},"Bybit":{"symbol":["MOVRUSDT"]},"CryptoCom":{"instrument_name":["MOVR_USDT"]},"GateIo":{"id":["MOVR_USDT"]},"KuCoin":{"symbol":["MOVR-USDT"]},"MEXC":{"symbol":["MOVRUSDT"]},"OKX":{"instId":["MOVR-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "599"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MOVR","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["MOVR-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "600"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"GOAT","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[30647,33440,33814,9069],"symbol":["GOAT","GOAT","GOAT","GOAT"]}},"exchanges":{"Bitget":{"symbol":["GOATUSDT_SPBL"]},"Bybit":{"symbol":["GOATUSDT"]},"CryptoCom":{"instrument_name":["GOATUSD-PERP","GOAT_USD","GOAT_USDT"]},"GateIo":{"id":["GOAT_USDT"]},"Gemini":{"symbol":["GOATUSD"]},"Kraken":{"pair":["GOATUSD"],"wsname":["GOAT/USD"]},"KuCoin":{"symbol":["GOAT-USDT"]},"MEXC":{"symbol":["GOATUSDT"]},"OKX":{"instId":["GOAT-USD","GOAT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "601"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"GOAT","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["GOATUSDT_SPBL"]},"Bybit":{"symbol":["GOATUSDT"]},"CryptoCom":{"instrument_name":["GOAT_USDT"]},"GateIo":{"id":["GOAT_USDT"]},"KuCoin":{"symbol":["GOAT-USDT"]},"MEXC":{"symbol":["GOATUSDT"]},"OKX":{"instId":["GOAT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "602"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"AI","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[10712,11061,14838,23955,27344,28846,28847,28902,28916],"symbol":["AI","AI","AI","AI","AI","AI","AI","AI","AI"]}},"exchanges":{"Binance":{"symbol":["AIUSDT"]},"GateIo":{"id":["AI_USDT"]},"MEXC":{"symbol":["AIUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "603"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"AI","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["AIUSDT"]},"GateIo":{"id":["AI_USDT"]},"MEXC":{"symbol":["AIUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "604"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"OMNI","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28827,30315,83],"symbol":["OMNI","OMNI","OMNI"]}},"exchanges":{"Binance":{"symbol":["OMNIUSDC","OMNIUSDT"]},"Bybit":{"symbol":["OMNIUSDT"]},"Coinbase":{"id":["OMNI-USD"]},"CryptoCom":{"instrument_name":["OMNI_USD"]},"GateIo":{"id":["OMNI_USDC","OMNI_USDT"]},"Kraken":{"pair":["OMNIUSD"],"wsname":["OMNI/USD"]},"KuCoin":{"symbol":["OMNI-USDT"]},"MEXC":{"symbol":["OMNIUSDT"]},"Upbit":{"market":["USDT-OMNI"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "605"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"OMNI","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["OMNIUSDT"]},"Bybit":{"symbol":["OMNIUSDT"]},"GateIo":{"id":["OMNI_USDT"]},"KuCoin":{"symbol":["OMNI-USDT"]},"MEXC":{"symbol":["OMNIUSDT"]},"Upbit":{"market":["USDT-OMNI"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "606"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"OMNI","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["OMNIUSDC"]},"GateIo":{"id":["OMNI_USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "607"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BONE","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[11865,34616],"symbol":["BONE","BONE"]}},"exchanges":{"Bitget":{"symbol":["BONEUSDT_SPBL"]},"CryptoCom":{"instrument_name":["BONE_USD","BONE_USDT"]},"GateIo":{"id":["BONE_USDT"]},"MEXC":{"symbol":["BONEUSDT"]},"OKX":{"instId":["BONE-USDC","BONE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "608"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BONE","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["BONEUSDT_SPBL"]},"CryptoCom":{"instrument_name":["BONE_USDT"]},"GateIo":{"id":["BONE_USDT"]},"MEXC":{"symbol":["BONEUSDT"]},"OKX":{"instId":["BONE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "609"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BONE","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["BONE-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "610"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"REZ","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[30843],"symbol":["REZ"]}},"exchanges":{"Binance":{"symbol":["REZUSDC","REZUSDT"]},"Bitget":{"symbol":["REZUSDT_SPBL"]},"Coinbase":{"id":["REZ-USD"]},"GateIo":{"id":["REZ_USDC","REZ_USDT"]},"Kraken":{"pair":["REZUSD"],"wsname":["REZ/USD"]},"KuCoin":{"symbol":["REZ-USDT"]},"MEXC":{"symbol":["REZUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "611"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"REZ","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["REZUSDT"]},"Bitget":{"symbol":["REZUSDT_SPBL"]},"GateIo":{"id":["REZ_USDT"]},"KuCoin":{"symbol":["REZ-USDT"]},"MEXC":{"symbol":["REZUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "612"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"REZ","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["REZUSDC"]},"GateIo":{"id":["REZ_USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "613"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DODO","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[30411,32530,7224],"symbol":["DODO","DODO","DODO"]}},"exchanges":{"Binance":{"symbol":["DODOUSDT"]},"BinanceTR":{"symbol":["DODO_USDT"]},"Bitget":{"symbol":["DODOUSDT_SPBL"]},"GateIo":{"id":["DODO_USDT"]},"KuCoin":{"symbol":["DODO-USDT"]},"MEXC":{"symbol":["DODOUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "614"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DODO","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["DODOUSDT"]},"BinanceTR":{"symbol":["DODO_USDT"]},"Bitget":{"symbol":["DODOUSDT_SPBL"]},"GateIo":{"id":["DODO_USDT"]},"KuCoin":{"symbol":["DODO-USDT"]},"MEXC":{"symbol":["DODOUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "615"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"QI","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[10237,8510,9288],"symbol":["QI","QI","QI"]}},"exchanges":{"Binance":{"symbol":["QIUSDT"]},"Coinbase":{"id":["QI-USD"]},"CryptoCom":{"instrument_name":["QI_USD","QI_USDT"]},"GateIo":{"id":["QI_USDT"]},"KuCoin":{"symbol":["QI-USDT"]},"MEXC":{"symbol":["QIUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "616"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"QI","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["QIUSDT"]},"CryptoCom":{"instrument_name":["QI_USDT"]},"GateIo":{"id":["QI_USDT"]},"KuCoin":{"symbol":["QI-USDT"]},"MEXC":{"symbol":["QIUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "617"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"CYBER","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[23879,24781],"symbol":["CYBER","CYBER"]}},"exchanges":{"Binance":{"symbol":["CYBERUSDT"]},"Bitget":{"symbol":["CYBERUSDT_SPBL"]},"Bybit":{"symbol":["CYBERUSDT"]},"CryptoCom":{"instrument_name":["CYBER_USD"]},"GateIo":{"id":["CYBER_USDT"]},"Kraken":{"pair":["CYBERUSD"],"wsname":["CYBER/USD"]},"KuCoin":{"symbol":["CYBER-USDT"]},"MEXC":{"symbol":["CYBERUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "618"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"CYBER","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["CYBERUSDT"]},"Bitget":{"symbol":["CYBERUSDT_SPBL"]},"Bybit":{"symbol":["CYBERUSDT"]},"GateIo":{"id":["CYBER_USDT"]},"KuCoin":{"symbol":["CYBER-USDT"]},"MEXC":{"symbol":["CYBERUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "619"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MERL","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[30712],"symbol":["MERL"]}},"exchanges":{"Bitget":{"symbol":["MERLUSDT_SPBL"]},"Bybit":{"symbol":["MERLUSDT"]},"GateIo":{"id":["MERL_USDT"]},"KuCoin":{"symbol":["MERL-USDT"]},"MEXC":{"symbol":["MERLUSDT"]},"OKX":{"instId":["MERL-USD","MERL-USDC","MERL-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "620"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MERL","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["MERLUSDT_SPBL"]},"Bybit":{"symbol":["MERLUSDT"]},"GateIo":{"id":["MERL_USDT"]},"KuCoin":{"symbol":["MERL-USDT"]},"MEXC":{"symbol":["MERLUSDT"]},"OKX":{"instId":["MERL-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "621"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MERL","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["MERL-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "622"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DEGEN","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[24276,25514,28773,30096,34380],"symbol":["DEGEN","DEGEN","DEGEN","DEGEN","DEGEN"]}},"exchanges":{"Bybit":{"symbol":["DEGENUSDT"]},"Coinbase":{"id":["DEGEN-USD"]},"CryptoCom":{"instrument_name":["DEGENUSD-PERP","DEGEN_USD"]},"GateIo":{"id":["DEGEN_USDT"]},"KuCoin":{"symbol":["DEGEN-USDT"]},"MEXC":{"symbol":["DEGENUSDT"]},"OKX":{"instId":["DEGEN-USD","DEGEN-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "623"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"DEGEN","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bybit":{"symbol":["DEGENUSDT"]},"GateIo":{"id":["DEGEN_USDT"]},"KuCoin":{"symbol":["DEGEN-USDT"]},"MEXC":{"symbol":["DEGENUSDT"]},"OKX":{"instId":["DEGEN-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "624"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"HIGH","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[11232],"symbol":["HIGH"]}},"exchanges":{"Binance":{"symbol":["HIGHUSDT"]},"Bitget":{"symbol":["HIGHUSDT_SPBL"]},"Coinbase":{"id":["HIGH-USD"]},"CryptoCom":{"instrument_name":["HIGH_USD","HIGH_USDT"]},"GateIo":{"id":["HIGH_USDT"]},"KuCoin":{"symbol":["HIGH-USDT"]},"MEXC":{"symbol":["HIGHUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "625"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"HIGH","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["HIGHUSDT"]},"Bitget":{"symbol":["HIGHUSDT_SPBL"]},"CryptoCom":{"instrument_name":["HIGH_USDT"]},"GateIo":{"id":["HIGH_USDT"]},"KuCoin":{"symbol":["HIGH-USDT"]},"MEXC":{"symbol":["HIGHUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "626"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"COQ","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28675],"symbol":["COQ"]}},"exchanges":{"Bitget":{"symbol":["COQUSDT_SPBL"]},"Bybit":{"symbol":["COQUSDT"]},"CryptoCom":{"instrument_name":["COQ_USD"]},"GateIo":{"id":["COQ_USDT"]},"KuCoin":{"symbol":["COQ-USDT"]},"MEXC":{"symbol":["COQUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "627"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"COQ","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["COQUSDT_SPBL"]},"Bybit":{"symbol":["COQUSDT"]},"GateIo":{"id":["COQ_USDT"]},"KuCoin":{"symbol":["COQ-USDT"]},"MEXC":{"symbol":["COQUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "628"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"GNS","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[13663],"symbol":["GNS"]}},"exchanges":{"Binance":{"symbol":["GNSUSDT"]},"Bitget":{"symbol":["GNSUSDT_SPBL"]},"CryptoCom":{"instrument_name":["GNS_USD"]},"GateIo":{"id":["GNS_USDT"]},"KuCoin":{"symbol":["GNS-USDT"]},"MEXC":{"symbol":["GNSUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "629"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"GNS","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["GNSUSDT"]},"Bitget":{"symbol":["GNSUSDT_SPBL"]},"GateIo":{"id":["GNS_USDT"]},"KuCoin":{"symbol":["GNS-USDT"]},"MEXC":{"symbol":["GNSUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "630"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"GRIFFAIN","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[34792],"symbol":["GRIFFAIN"]}},"exchanges":{"Bitget":{"symbol":["GRIFFAINUSDT_SPBL"]},"GateIo":{"id":["GRIFFAIN_USDT"]},"Kraken":{"pair":["GRIFFAINUSD"],"wsname":["GRIFFAIN/USD"]},"KuCoin":{"symbol":["GRIFFAIN-USDT"]},"MEXC":{"symbol":["GRIFFAINUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "631"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"GRIFFAIN","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["GRIFFAINUSDT_SPBL"]},"GateIo":{"id":["GRIFFAIN_USDT"]},"KuCoin":{"symbol":["GRIFFAIN-USDT"]},"MEXC":{"symbol":["GRIFFAINUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "632"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"OGN","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[5117],"symbol":["OGN"]}},"exchanges":{"Binance":{"symbol":["OGNUSDT"]},"BinanceUS":{"symbol":["OGNUSDT"]},"Bitget":{"symbol":["OGNUSDT_SPBL"]},"Coinbase":{"id":["OGN-USD"]},"CryptoCom":{"instrument_name":["OGNUSD-PERP","OGN_USD"]},"GateIo":{"id":["OGN_USDT"]},"Kraken":{"pair":["OGNUSD"],"wsname":["OGN/USD"]},"KuCoin":{"symbol":["OGN-USDT"]},"MEXC":{"symbol":["OGNUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "633"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"OGN","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["OGNUSDT"]},"BinanceUS":{"symbol":["OGNUSDT"]},"Bitget":{"symbol":["OGNUSDT_SPBL"]},"GateIo":{"id":["OGN_USDT"]},"KuCoin":{"symbol":["OGN-USDT"]},"MEXC":{"symbol":["OGNUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "634"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MAGIC","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[14783],"symbol":["MAGIC"]}},"exchanges":{"Binance":{"symbol":["MAGICUSDT"]},"BinanceUS":{"symbol":["MAGICUSDT"]},"Bitget":{"symbol":["MAGICUSDT_SPBL"]},"Bybit":{"symbol":["MAGICUSDT"]},"Coinbase":{"id":["MAGIC-USD"]},"CryptoCom":{"instrument_name":["MAGICUSD-PERP","MAGIC_USD","MAGIC_USDT"]},"GateIo":{"id":["MAGIC_USDT"]},"KuCoin":{"symbol":["MAGIC-USDT"]},"MEXC":{"symbol":["MAGICUSDT"]},"OKX":{"instId":["MAGIC-USDC","MAGIC-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "635"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MAGIC","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["MAGICUSDT"]},"BinanceUS":{"symbol":["MAGICUSDT"]},"Bitget":{"symbol":["MAGICUSDT_SPBL"]},"Bybit":{"symbol":["MAGICUSDT"]},"CryptoCom":{"instrument_name":["MAGIC_USDT"]},"GateIo":{"id":["MAGIC_USDT"]},"KuCoin":{"symbol":["MAGIC-USDT"]},"MEXC":{"symbol":["MAGICUSDT"]},"OKX":{"instId":["MAGIC-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "636"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MAGIC","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["MAGIC-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "637"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"STG","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[18934],"symbol":["STG"]}},"exchanges":{"Binance":{"symbol":["STGUSDT"]},"BinanceUS":{"symbol":["STGUSDT"]},"Bitfinex":{"symbol":["STGUSD"]},"Bitget":{"symbol":["STGUSDT_SPBL"]},"Bybit":{"symbol":["STGUSDT"]},"Coinbase":{"id":["STG-USD","STG-USDT"]},"CryptoCom":{"instrument_name":["STGUSD-PERP","STG_USD"]},"GateIo":{"id":["STG_USDT"]},"Kraken":{"pair":["STGUSD"],"wsname":["STG/USD"]},"KuCoin":{"symbol":["STG-USDT"]},"MEXC":{"symbol":["STGUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "638"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"STG","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["STGUSDT"]},"BinanceUS":{"symbol":["STGUSDT"]},"Bitget":{"symbol":["STGUSDT_SPBL"]},"Bybit":{"symbol":["STGUSDT"]},"Coinbase":{"id":["STG-USDT"]},"GateIo":{"id":["STG_USDT"]},"KuCoin":{"symbol":["STG-USDT"]},"MEXC":{"symbol":["STGUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "639"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MOODENG","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[33065,33076,33093,33647],"symbol":["MOODENG","MOODENG","MOODENG","MOODENG"]}},"exchanges":{"Bitget":{"symbol":["MOODENGUSDT_SPBL"]},"Coinbase":{"id":["MOODENG-USD"]},"CryptoCom":{"instrument_name":["MOODENGUSD-PERP","MOODENG_USD"]},"GateIo":{"id":["MOODENG_USDT"]},"Gemini":{"symbol":["MOODENGUSD"]},"Kraken":{"pair":["MOODENGUSD"],"wsname":["MOODENG/USD"]},"KuCoin":{"symbol":["MOODENG-USDT"]},"MEXC":{"symbol":["MOODENGUSDT"]},"OKX":{"instId":["MOODENG-USDC","MOODENG-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "640"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MOODENG","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["MOODENGUSDT_SPBL"]},"GateIo":{"id":["MOODENG_USDT"]},"KuCoin":{"symbol":["MOODENG-USDT"]},"MEXC":{"symbol":["MOODENGUSDT"]},"OKX":{"instId":["MOODENG-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "641"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MOODENG","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["MOODENG-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "642"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BADGER","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[7859],"symbol":["BADGER"]}},"exchanges":{"Binance":{"symbol":["BADGERUSDT"]},"Bitget":{"symbol":["BADGERUSDT_SPBL"]},"Coinbase":{"id":["BADGER-USD","BADGER-USDT"]},"CryptoCom":{"instrument_name":["BADGER_USD"]},"GateIo":{"id":["BADGER_USDT"]},"Kraken":{"pair":["BADGERUSD"],"wsname":["BADGER/USD"]},"MEXC":{"symbol":["BADGERUSDT"]},"OKX":{"instId":["BADGER-USDC","BADGER-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "643"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BADGER","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BADGERUSDT"]},"Bitget":{"symbol":["BADGERUSDT_SPBL"]},"Coinbase":{"id":["BADGER-USDT"]},"GateIo":{"id":["BADGER_USDT"]},"MEXC":{"symbol":["BADGERUSDT"]},"OKX":{"instId":["BADGER-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "644"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BADGER","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["BADGER-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "645"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ACE","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[22307,28674,31453,33825,9792],"symbol":["ACE","ACE","ACE","ACE","ACE"]}},"exchanges":{"Binance":{"symbol":["ACEUSDT"]},"Bitget":{"symbol":["ACEUSDT_SPBL"]},"GateIo":{"id":["ACE_USDT"]},"KuCoin":{"symbol":["ACE-USDT"]},"MEXC":{"symbol":["ACEUSDT"]},"OKX":{"instId":["ACE-USDC","ACE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "646"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ACE","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ACEUSDT"]},"Bitget":{"symbol":["ACEUSDT_SPBL"]},"GateIo":{"id":["ACE_USDT"]},"KuCoin":{"symbol":["ACE-USDT"]},"MEXC":{"symbol":["ACEUSDT"]},"OKX":{"instId":["ACE-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "647"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ACE","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["ACE-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "648"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CUSD","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[21871,7236],"symbol":["CUSD","CUSD"]}},"exchanges":{"Bybit":{"symbol":["CUSDUSDT"]},"GateIo":{"id":["CUSD_USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "649"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"CUSD","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bybit":{"symbol":["CUSDUSDT"]},"GateIo":{"id":["CUSD_USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "650"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MAV","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[18037,19642],"symbol":["MAV","MAV"]}},"exchanges":{"Binance":{"symbol":["MAVUSDT"]},"Bitget":{"symbol":["MAVUSDT_SPBL"]},"CryptoCom":{"instrument_name":["MAV_USD"]},"GateIo":{"id":["MAV_USDT"]},"KuCoin":{"symbol":["MAV-USDT"]},"MEXC":{"symbol":["MAVUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "651"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MAV","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["MAVUSDT"]},"Bitget":{"symbol":["MAVUSDT_SPBL"]},"GateIo":{"id":["MAV_USDT"]},"KuCoin":{"symbol":["MAV-USDT"]},"MEXC":{"symbol":["MAVUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "652"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ALPHA","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[12179,19262,32745,7232],"symbol":["ALPHA","ALPHA","ALPHA","ALPHA"]}},"exchanges":{"Binance":{"symbol":["ALPHAUSDT"]},"Bitget":{"symbol":["ALPHAUSDT_SPBL"]},"CryptoCom":{"instrument_name":["ALPHA_USD"]},"GateIo":{"id":["ALPHA_USDT"]},"Kraken":{"pair":["ALPHAUSD"],"wsname":["ALPHA/USD"]},"KuCoin":{"symbol":["ALPHA-USDT"]},"MEXC":{"symbol":["ALPHAUSDT"]},"OKX":{"instId":["ALPHA-USDC","ALPHA-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "653"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ALPHA","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ALPHAUSDT"]},"Bitget":{"symbol":["ALPHAUSDT_SPBL"]},"GateIo":{"id":["ALPHA_USDT"]},"KuCoin":{"symbol":["ALPHA-USDT"]},"MEXC":{"symbol":["ALPHAUSDT"]},"OKX":{"instId":["ALPHA-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "654"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ALPHA","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["ALPHA-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "655"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"LISTA","quote":"USD"},"decimals":8,"category":"","market_hours":null,"arguments":{"aggregators":{"CoinMarketCap":{"id":[21533],"symbol":["LISTA"]}},"exchanges":{"Binance":{"symbol":["LISTAUSDT"]},"Bitget":{"symbol":["LISTAUSDT_SPBL"]},"GateIo":{"id":["LISTA_USDT"]},"KuCoin":{"symbol":["LISTA-USDT"]},"MEXC":{"symbol":["LISTAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "656"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"LISTA","quote":"USDT"},"decimals":8,"category":"","market_hours":null,"arguments":{"exchanges":{"Binance":{"symbol":["LISTAUSDT"]},"Bitget":{"symbol":["LISTAUSDT_SPBL"]},"GateIo":{"id":["LISTA_USDT"]},"KuCoin":{"symbol":["LISTA-USDT"]},"MEXC":{"symbol":["LISTAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "657"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"AMPL","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[4056],"symbol":["AMPL"]}},"exchanges":{"GateIo":{"id":["AMPL_USDT"]},"KuCoin":{"symbol":["AMPL-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "658"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"AMPL","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"GateIo":{"id":["AMPL_USDT"]},"KuCoin":{"symbol":["AMPL-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "659"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"HOOK","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[22764],"symbol":["HOOK"]}},"exchanges":{"Binance":{"symbol":["HOOKUSDT"]},"Bitget":{"symbol":["HOOKUSDT_SPBL"]},"Bybit":{"symbol":["HOOKUSDT"]},"GateIo":{"id":["HOOK_USDT"]},"MEXC":{"symbol":["HOOKUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "660"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"HOOK","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["HOOKUSDT"]},"Bitget":{"symbol":["HOOKUSDT_SPBL"]},"Bybit":{"symbol":["HOOKUSDT"]},"GateIo":{"id":["HOOK_USDT"]},"MEXC":{"symbol":["HOOKUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "661"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ZEREBRO","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[34083],"symbol":["ZEREBRO"]}},"exchanges":{"Bitget":{"symbol":["ZEREBROUSDT_SPBL"]},"Bybit":{"symbol":["ZEREBROUSDT"]},"GateIo":{"id":["ZEREBRO_USDT"]},"Kraken":{"pair":["ZEREBROUSD"],"wsname":["ZEREBRO/USD"]},"KuCoin":{"symbol":["ZEREBRO-USDT"]},"MEXC":{"symbol":["ZEREBROUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "662"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ZEREBRO","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["ZEREBROUSDT_SPBL"]},"Bybit":{"symbol":["ZEREBROUSDT"]},"GateIo":{"id":["ZEREBRO_USDT"]},"KuCoin":{"symbol":["ZEREBRO-USDT"]},"MEXC":{"symbol":["ZEREBROUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "663"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ORDER","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[32809],"symbol":["ORDER"]}},"exchanges":{"Bitget":{"symbol":["ORDERUSDT_SPBL"]},"Bybit":{"symbol":["ORDERUSDT"]},"GateIo":{"id":["ORDER_USDT"]},"KuCoin":{"symbol":["ORDER-USDT"]},"MEXC":{"symbol":["ORDERUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "664"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ORDER","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["ORDERUSDT_SPBL"]},"Bybit":{"symbol":["ORDERUSDT"]},"GateIo":{"id":["ORDER_USDT"]},"KuCoin":{"symbol":["ORDER-USDT"]},"MEXC":{"symbol":["ORDERUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "665"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RDNT","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[21106],"symbol":["RDNT"]}},"exchanges":{"Binance":{"symbol":["RDNTUSDT"]},"Bitget":{"symbol":["RDNTUSDT_SPBL"]},"Bybit":{"symbol":["RDNTUSDT"]},"CryptoCom":{"instrument_name":["RDNT_USD"]},"GateIo":{"id":["RDNT_USDT"]},"KuCoin":{"symbol":["RDNT-USDT"]},"MEXC":{"symbol":["RDNTUSDT"]},"OKX":{"instId":["RDNT-USDC","RDNT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "666"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RDNT","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["RDNTUSDT"]},"Bitget":{"symbol":["RDNTUSDT_SPBL"]},"Bybit":{"symbol":["RDNTUSDT"]},"GateIo":{"id":["RDNT_USDT"]},"KuCoin":{"symbol":["RDNT-USDT"]},"MEXC":{"symbol":["RDNTUSDT"]},"OKX":{"instId":["RDNT-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "667"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RDNT","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["RDNT-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "668"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MLN","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1552],"symbol":["MLN"]}},"exchanges":{"Binance":{"symbol":["MLNUSDT"]},"Coinbase":{"id":["MLN-USD"]},"CryptoCom":{"instrument_name":["MLN_USD"]},"GateIo":{"id":["MLN_USDT"]},"Kraken":{"pair":["XMLNZUSD"],"wsname":["MLN/USD"]},"MEXC":{"symbol":["MLNUSDT"]},"OKX":{"instId":["MLN-USD","MLN-USDC","MLN-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "669"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MLN","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"MEXC":{"symbol":["MLNETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "670"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MLN","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["MLNUSDT"]},"GateIo":{"id":["MLN_USDT"]},"MEXC":{"symbol":["MLNUSDT"]},"OKX":{"instId":["MLN-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "671"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MLN","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["MLN-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "672"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"QUICK","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[19966,8206],"symbol":["QUICK","QUICK"]}},"exchanges":{"Binance":{"symbol":["QUICKUSDT"]},"Bitget":{"symbol":["QUICKUSDT_SPBL"]},"Coinbase":{"id":["QUICK-USD"]},"CryptoCom":{"instrument_name":["QUICK_USD"]},"GateIo":{"id":["QUICK_USDT"]},"KuCoin":{"symbol":["QUICK-USDT"]},"MEXC":{"symbol":["QUICKUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "673"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"QUICK","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["QUICKUSDT"]},"Bitget":{"symbol":["QUICKUSDT_SPBL"]},"GateIo":{"id":["QUICK_USDT"]},"KuCoin":{"symbol":["QUICK-USDT"]},"MEXC":{"symbol":["QUICKUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "674"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ALCX","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[8613],"symbol":["ALCX"]}},"exchanges":{"Binance":{"symbol":["ALCXUSDT"]},"Coinbase":{"id":["ALCX-USD","ALCX-USDT"]},"CryptoCom":{"instrument_name":["ALCX_USD"]},"GateIo":{"id":["ALCX_USDT"]},"Kraken":{"pair":["ALCXUSD"],"wsname":["ALCX/USD"]},"OKX":{"instId":["ALCX-USDC","ALCX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "675"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ALCX","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ALCXUSDT"]},"Coinbase":{"id":["ALCX-USDT"]},"GateIo":{"id":["ALCX_USDT"]},"OKX":{"instId":["ALCX-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "676"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ALCX","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["ALCX-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "677"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"PERP","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[6950],"symbol":["PERP"]}},"exchanges":{"Binance":{"symbol":["PERPUSDT"]},"Bitget":{"symbol":["PERPUSDT_SPBL"]},"Bybit":{"symbol":["PERPUSDT"]},"Coinbase":{"id":["PERP-USD","PERP-USDT"]},"CryptoCom":{"instrument_name":["PERP_USD"]},"GateIo":{"id":["PERP_USDT"]},"Kraken":{"pair":["PERPUSD"],"wsname":["PERP/USD"]},"KuCoin":{"symbol":["PERP-USDT"]},"MEXC":{"symbol":["PERPUSDT"]},"OKX":{"instId":["PERP-USD","PERP-USDC","PERP-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "678"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"PERP","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["PERPUSDT"]},"Bitget":{"symbol":["PERPUSDT_SPBL"]},"Bybit":{"symbol":["PERPUSDT"]},"Coinbase":{"id":["PERP-USDT"]},"GateIo":{"id":["PERP_USDT"]},"KuCoin":{"symbol":["PERP-USDT"]},"MEXC":{"symbol":["PERPUSDT"]},"OKX":{"instId":["PERP-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "679"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"PERP","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["PERP-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "680"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"GHST","quote":"ETH"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["GHSTETH"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "681"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"GHST","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[7046],"symbol":["GHST"]}},"exchanges":{"Binance":{"symbol":["GHSTUSDT"]},"Bitget":{"symbol":["GHSTUSDT_SPBL"]},"Coinbase":{"id":["GHST-USD"]},"CryptoCom":{"instrument_name":["GHST_USD"]},"GateIo":{"id":["GHST_USDT"]},"Kraken":{"pair":["GHSTUSD"],"wsname":["GHST/USD"]},"MEXC":{"symbol":["GHSTUSDT"]},"OKX":{"instId":["GHST-USD","GHST-USDC","GHST-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "682"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"GHST","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["GHSTUSDT"]},"Bitget":{"symbol":["GHSTUSDT_SPBL"]},"GateIo":{"id":["GHST_USDT"]},"MEXC":{"symbol":["GHSTUSDT"]},"OKX":{"instId":["GHST-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "683"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"GHST","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["GHST-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "684"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BSW","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[10746,30724],"symbol":["BSW","BSW"]}},"exchanges":{"Binance":{"symbol":["BSWUSDT"]},"Bitget":{"symbol":["BSWUSDT_SPBL"]},"GateIo":{"id":["BSW_USDT"]},"KuCoin":{"symbol":["BSW-USDT"]},"MEXC":{"symbol":["BSWUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "685"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"BSW","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["BSWUSDT"]},"Bitget":{"symbol":["BSWUSDT_SPBL"]},"GateIo":{"id":["BSW_USDT"]},"KuCoin":{"symbol":["BSW-USDT"]},"MEXC":{"symbol":["BSWUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "686"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"NULS","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[2092],"symbol":["NULS"]}},"exchanges":{"Binance":{"symbol":["NULSUSDT"]},"GateIo":{"id":["NULS_USDT"]},"MEXC":{"symbol":["NULSUSDT"]},"OKX":{"instId":["NULS-USD","NULS-USDC","NULS-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "687"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"NULS","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["NULSUSDT"]},"GateIo":{"id":["NULS_USDT"]},"MEXC":{"symbol":["NULSUSDT"]},"OKX":{"instId":["NULS-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "688"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"NULS","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"OKX":{"instId":["NULS-USDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "689"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"WING","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[33798,7048],"symbol":["WING","WING"]}},"exchanges":{"Binance":{"symbol":["WINGUSDT"]},"Bitget":{"symbol":["WINGUSDT_SPBL"]},"GateIo":{"id":["WING_USDT"]},"MEXC":{"symbol":["WINGUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "690"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"WING","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["WINGUSDT"]},"Bitget":{"symbol":["WINGUSDT_SPBL"]},"GateIo":{"id":["WING_USDT"]},"MEXC":{"symbol":["WINGUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "691"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TOKEN","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28299],"symbol":["TOKEN"]}},"exchanges":{"Bitfinex":{"symbol":["TOKEN:USD"]},"Bybit":{"symbol":["TOKENUSDT"]},"GateIo":{"id":["TOKEN_USDT"]},"Kraken":{"pair":["TOKENUSD"],"wsname":["TOKEN/USD"]},"KuCoin":{"symbol":["TOKEN-USDT"]},"MEXC":{"symbol":["TOKENUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "692"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TOKEN","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bybit":{"symbol":["TOKENUSDT"]},"GateIo":{"id":["TOKEN_USDT"]},"KuCoin":{"symbol":["TOKEN-USDT"]},"MEXC":{"symbol":["TOKENUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "693"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"LINA","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[7102],"symbol":["LINA"]}},"exchanges":{"Binance":{"symbol":["LINAUSDT"]},"Bitget":{"symbol":["LINAUSDT_SPBL"]},"GateIo":{"id":["LINA_USDT"]},"KuCoin":{"symbol":["LINA-USDT"]},"MEXC":{"symbol":["LINAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "694"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"LINA","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["LINAUSDT"]},"Bitget":{"symbol":["LINAUSDT_SPBL"]},"GateIo":{"id":["LINA_USDT"]},"KuCoin":{"symbol":["LINA-USDT"]},"MEXC":{"symbol":["LINAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "695"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TRUMP","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[24615,26338,27872,28514,29382,29561,29602,31400,31553,31680,31692,31792,31846,31874,32305,32557,32835,32865,32929,32932,33561,33831,33888,34490,34589],"symbol":["TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP","TRUMP"]}},"exchanges":{"Binance":{"symbol":["TRUMPUSDC","TRUMPUSDT"]},"BinanceUS":{"symbol":["TRUMPUSDT"]},"Bitget":{"symbol":["TRUMPUSDC_SPBL","TRUMPUSDT_SPBL"]},"Bybit":{"symbol":["TRUMPUSDC","TRUMPUSDT"]},"Coinbase":{"id":["TRUMP-USD"]},"CryptoCom":{"instrument_name":["TRUMPUSD-PERP","TRUMP_USD","TRUMP_USDT"]},"GateIo":{"id":["TRUMP_USDT"]},"Kraken":{"pair":["TRUMPUSD","TRUMPUSDC","TRUMPUSDT"],"wsname":["TRUMP/USD","TRUMP/USDC","TRUMP/USDT"]},"KuCoin":{"symbol":["TRUMP-USDC","TRUMP-USDT"]},"MEXC":{"symbol":["TRUMPUSDC","TRUMPUSDT"]},"OKX":{"instId":["TRUMP-USD","TRUMP-USDT"]},"Upbit":{"market":["USDT-TRUMP"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "696"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TRUMP","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["TRUMPUSDT"]},"BinanceUS":{"symbol":["TRUMPUSDT"]},"Bitget":{"symbol":["TRUMPUSDT_SPBL"]},"Bybit":{"symbol":["TRUMPUSDT"]},"CryptoCom":{"instrument_name":["TRUMP_USDT"]},"GateIo":{"id":["TRUMP_USDT"]},"Kraken":{"pair":["TRUMPUSDT"],"wsname":["TRUMP/USDT"]},"KuCoin":{"symbol":["TRUMP-USDT"]},"MEXC":{"symbol":["TRUMPUSDT"]},"OKX":{"instId":["TRUMP-USDT"]},"Upbit":{"market":["USDT-TRUMP"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "697"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"TRUMP","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["TRUMPUSDC"]},"Bitget":{"symbol":["TRUMPUSDC_SPBL"]},"Bybit":{"symbol":["TRUMPUSDC"]},"Kraken":{"pair":["TRUMPUSDC"],"wsname":["TRUMP/USDC"]},"KuCoin":{"symbol":["TRUMP-USDC"]},"MEXC":{"symbol":["TRUMPUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "698"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ULTI","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[31504],"symbol":["ULTI"]}},"exchanges":{"Bitget":{"symbol":["ULTIUSDT_SPBL"]},"Bybit":{"symbol":["ULTIUSDT"]},"GateIo":{"id":["ULTI_USDT"]},"KuCoin":{"symbol":["ULTI-USDT"]},"MEXC":{"symbol":["ULTIUSDT"]},"OKX":{"instId":["ULTI-USD","ULTI-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "699"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"ULTI","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["ULTIUSDT_SPBL"]},"Bybit":{"symbol":["ULTIUSDT"]},"GateIo":{"id":["ULTI_USDT"]},"KuCoin":{"symbol":["ULTI-USDT"]},"MEXC":{"symbol":["ULTIUSDT"]},"OKX":{"instId":["ULTI-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "700"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ALPACA","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[8707],"symbol":["ALPACA"]}},"exchanges":{"Binance":{"symbol":["ALPACAUSDT"]},"Bitget":{"symbol":["ALPACAUSDT_SPBL"]},"GateIo":{"id":["ALPACA_USDT"]},"MEXC":{"symbol":["ALPACAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "701"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"ALPACA","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["ALPACAUSDT"]},"Bitget":{"symbol":["ALPACAUSDT_SPBL"]},"GateIo":{"id":["ALPACA_USDT"]},"MEXC":{"symbol":["ALPACAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "702"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"REN","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[2539],"symbol":["REN"]}},"exchanges":{"Binance":{"symbol":["RENUSDT"]},"BinanceUS":{"symbol":["RENUSDT"]},"Bitget":{"symbol":["RENUSDT_SPBL"]},"Bybit":{"symbol":["RENUSDT"]},"Coinbase":{"id":["REN-USD"]},"GateIo":{"id":["REN_USDT"]},"Gemini":{"symbol":["RENUSD"]},"Kraken":{"pair":["RENUSD"],"wsname":["REN/USD"]},"KuCoin":{"symbol":["REN-USDT"]},"MEXC":{"symbol":["RENUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "703"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"REN","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["RENUSDT"]},"BinanceUS":{"symbol":["RENUSDT"]},"Bitget":{"symbol":["RENUSDT_SPBL"]},"Bybit":{"symbol":["RENUSDT"]},"GateIo":{"id":["REN_USDT"]},"KuCoin":{"symbol":["REN-USDT"]},"MEXC":{"symbol":["RENUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "704"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MAVIA","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[28829],"symbol":["MAVIA"]}},"exchanges":{"Bitget":{"symbol":["MAVIAUSDT_SPBL"]},"Bybit":{"symbol":["MAVIAUSDT"]},"CryptoCom":{"instrument_name":["MAVIA_USD","MAVIA_USDT"]},"GateIo":{"id":["MAVIA_USDT"]},"KuCoin":{"symbol":["MAVIA-USDT"]},"MEXC":{"symbol":["MAVIAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "705"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"MAVIA","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["MAVIAUSDT_SPBL"]},"Bybit":{"symbol":["MAVIAUSDT"]},"CryptoCom":{"instrument_name":["MAVIA_USDT"]},"GateIo":{"id":["MAVIA_USDT"]},"KuCoin":{"symbol":["MAVIA-USDT"]},"MEXC":{"symbol":["MAVIAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "706"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"KLIMA","quote":"USD"},"decimals":8,"category":"","market_hours":null,"arguments":{"aggregators":{"CoinMarketCap":{"id":[12873],"symbol":["KLIMA"]}},"exchanges":{"GateIo":{"id":["KLIMA_USDT"]},"MEXC":{"symbol":["KLIMAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "707"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"KLIMA","quote":"USDT"},"decimals":8,"category":"","market_hours":null,"arguments":{"exchanges":{"GateIo":{"id":["KLIMA_USDT"]},"MEXC":{"symbol":["KLIMAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "708"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SKY","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[1619,33038],"symbol":["SKY","SKY"]}},"exchanges":{"Bitget":{"symbol":["SKYUSDT_SPBL"]},"Kraken":{"pair":["SKYUSD"],"wsname":["SKY/USD"]},"KuCoin":{"symbol":["SKY-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "709"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"SKY","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["SKYUSDT_SPBL"]},"KuCoin":{"symbol":["SKY-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "710"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"WELL","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[20734],"symbol":["WELL"]}},"exchanges":{"Bitget":{"symbol":["WELLUSDT_SPBL"]},"Bybit":{"symbol":["WELLUSDT"]},"Coinbase":{"id":["WELL-USD"]},"GateIo":{"id":["WELL_USDT"]},"Kraken":{"pair":["WELLUSD"],"wsname":["WELL/USD"]},"KuCoin":{"symbol":["WELL-USDT"]},"MEXC":{"symbol":["WELLUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "711"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"WELL","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["WELLUSDT_SPBL"]},"Bybit":{"symbol":["WELLUSDT"]},"GateIo":{"id":["WELL_USDT"]},"KuCoin":{"symbol":["WELL-USDT"]},"MEXC":{"symbol":["WELLUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "712"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"FOXY","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[20801,30591],"symbol":["FOXY","FOXY"]}},"exchanges":{"Bybit":{"symbol":["FOXYUSDT"]},"GateIo":{"id":["FOXY_USDT"]},"KuCoin":{"symbol":["FOXY-USDT"]},"OKX":{"instId":["FOXY-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "713"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"FOXY","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bybit":{"symbol":["FOXYUSDT"]},"GateIo":{"id":["FOXY_USDT"]},"KuCoin":{"symbol":["FOXY-USDT"]},"OKX":{"instId":["FOXY-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "714"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MELANIA","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[29844],"symbol":["MELANIA"]}},"exchanges":{"Bitget":{"symbol":["MELANIAUSDT_SPBL"]},"CryptoCom":{"instrument_name":["MELANIAUSD-PERP","MELANIA_USD","MELANIA_USDT"]},"GateIo":{"id":["MELANIA_USDT"]},"Kraken":{"pair":["MELANIAUSD","MELANIAUSDC","MELANIAUSDT"],"wsname":["MELANIA/USD","MELANIA/USDC","MELANIA/USDT"]},"KuCoin":{"symbol":["MELANIA-USDT"]},"MEXC":{"symbol":["MELANIAUSDC","MELANIAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "715"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MELANIA","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["MELANIAUSDT_SPBL"]},"CryptoCom":{"instrument_name":["MELANIA_USDT"]},"GateIo":{"id":["MELANIA_USDT"]},"Kraken":{"pair":["MELANIAUSDT"],"wsname":["MELANIA/USDT"]},"KuCoin":{"symbol":["MELANIA-USDT"]},"MEXC":{"symbol":["MELANIAUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "716"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MELANIA","quote":"USDC"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Kraken":{"pair":["MELANIAUSDC"],"wsname":["MELANIA/USDC"]},"MEXC":{"symbol":["MELANIAUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "717"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MICHI","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"aggregators":{"CoinMarketCap":{"id":[32044],"symbol":["MICHI"]}},"exchanges":{"GateIo":{"id":["MICHI_USDT"]},"Kraken":{"pair":["MICHIUSD"],"wsname":["MICHI/USD"]},"KuCoin":{"symbol":["MICHI-USDT"]},"MEXC":{"symbol":["MICHIUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "718"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"MICHI","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"GateIo":{"id":["MICHI_USDT"]},"KuCoin":{"symbol":["MICHI-USDT"]},"MEXC":{"symbol":["MICHIUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "719"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"NEIROETH","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"CryptoCom":{"instrument_name":["NEIROETHUSD-PERP","NEIROETH_USD"]},"GateIo":{"id":["NEIROETH_USDT"]},"MEXC":{"symbol":["NEIROETHUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "720"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"NEIROETH","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"GateIo":{"id":["NEIROETH_USDT"]},"MEXC":{"symbol":["NEIROETHUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "721"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"VVV","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Coinbase":{"id":["VVV-USD"]},"GateIo":{"id":["VVV_USDT"]},"Kraken":{"pair":["VVVUSD"],"wsname":["VVV/USD"]},"KuCoin":{"symbol":["VVV-USDT"]},"MEXC":{"symbol":["VVVUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "722"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"VVV","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"GateIo":{"id":["VVV_USDT"]},"KuCoin":{"symbol":["VVV-USDT"]},"MEXC":{"symbol":["VVVUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "723"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"IP","quote":"USD"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["IPUSDT_SPBL"]},"Bybit":{"symbol":["IPUSDT"]},"Coinbase":{"id":["IP-USD"]},"CryptoCom":{"instrument_name":["IPUSD-PERP","IP_USD"]},"GateIo":{"id":["IP_USDT"]},"Kraken":{"pair":["IPUSD"],"wsname":["IP/USD"]},"KuCoin":{"symbol":["IP-USDT"]},"MEXC":{"symbol":["IPUSDT"]},"OKX":{"instId":["IP-USD","IP-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "724"
+stride = 0
+decimals = 18
 data = '{"pair":{"base":"IP","quote":"USDT"},"decimals":18,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Bitget":{"symbol":["IPUSDT_SPBL"]},"Bybit":{"symbol":["IPUSDT"]},"GateIo":{"id":["IP_USDT"]},"KuCoin":{"symbol":["IP-USDT"]},"MEXC":{"symbol":["IPUSDT"]},"OKX":{"instId":["IP-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "725"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FTM","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["FTMUSDC","FTMUSDT"]},"BinanceUS":{"symbol":["FTMUSDT"]},"Gemini":{"symbol":["FTMUSD"]},"Kraken":{"pair":["FTMUSD"],"wsname":["FTM/USD"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "726"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FTM","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["FTMUSDT"]},"BinanceUS":{"symbol":["FTMUSDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "727"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"FTM","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["FTMUSDC"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "728"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RNDR","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["RNDRUSDC","RNDRUSDT"]},"BinanceUS":{"symbol":["RNDRUSDT"]},"Coinbase":{"id":["RNDR-USD","RNDR-USDT"]},"Gemini":{"symbol":["RNDRUSD"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "729"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RNDR","quote":"USDT"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["RNDRUSDT"]},"BinanceUS":{"symbol":["RNDRUSDT"]},"Coinbase":{"id":["RNDR-USDT"]}}}}'
 
 [[trigger.oracle.data_feeds]]
 id = "730"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"RNDR","quote":"USDC"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Binance":{"symbol":["RNDRUSDC"]}}}}'
+
+[[trigger.oracle.data_feeds]]
+id = "50000"
+stride = 0
+decimals = 8
+data = '{"pair":{"base":"USDT","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Coinbase":{"id":["USDT-USD"]},"CryptoCom":{"instrument_name":["USDT_USD"]},"GateIo":{"id":["USDT_USD"]},"Gemini":{"symbol":["USDTUSD"]},"Kraken":{"pair":["USDTZUSD"],"wsname":["USDT/USD"]},"OKX":{"instId":["USDT-USD"]}}}}'
+
+[[trigger.oracle.data_feeds]]
+id = "50001"
+stride = 0
+decimals = 8
+data = '{"pair":{"base":"USDC","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":{"exchanges":{"Gemini":{"symbol":["USDCUSD"]},"Kraken":{"pair":["USDCUSD"],"wsname":["USDC/USD"]}}}}'
 
 [component.crypto-price-feeds]
 source = "../../../target/wasm32-wasip1/release/crypto_price_feeds.wasm"
 allowed_outbound_hosts = [
-    "https://api.kraken.com",
-    "https://api.bybit.com",
-    "https://api.coinbase.com",
-    "https://api.exchange.coinbase.com",
-    "https://api1.binance.com",
-    "https://api.kucoin.com",
-    "https://api.mexc.com",
-    "https://api.crypto.com",
-    "https://api.binance.us",
-    "https://api.gemini.com",
-    "https://api-pub.bitfinex.com",
-    "https://api.upbit.com",
-    "https://api.bitget.com",
-    "https://api.gateio.ws",
-    "https://www.okx.com",
+  "https://api.kraken.com",
+  "https://api.bybit.com",
+  "https://api.coinbase.com",
+  "https://api.exchange.coinbase.com",
+  "https://api1.binance.com",
+  "https://api.kucoin.com",
+  "https://api.mexc.com",
+  "https://api.crypto.com",
+  "https://api.binance.us",
+  "https://api.gemini.com",
+  "https://api-pub.bitfinex.com",
+  "https://api.upbit.com",
+  "https://api.bitget.com",
+  "https://api.gateio.ws",
+  "https://www.okx.com",
 ]
 key_value_stores = ["default"]
 

--- a/apps/oracles/eth-rpc/spin.toml
+++ b/apps/oracles/eth-rpc/spin.toml
@@ -7,20 +7,27 @@ version = "0.1.0"
 
 [application.trigger.settings]
 interval_time_in_seconds = 90
-sequencer = "http://127.0.0.1:9856/post_reports_batch"
-secret_key = "536d1f9d97166eba5ff0efb8cc8dbeb856fb13d2d126ed1efc761e9955014003"
 reporter_id = 0
+sequencer = "http://127.0.0.1:8877/post_reports_batch"
+secret_key = "536d1f9d97166eba5ff0efb8cc8dbeb856fb13d2d126ed1efc761e9955014003"
+second_consensus_secret_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+kafka_endpoint = "http://127.0.0.1:9092"
 
 [[trigger.oracle]]
 component = "eth-rpc"
 
 [[trigger.oracle.data_feeds]]
 id = "100001"
+stride = 0
+decimals = 0
 data = '{"pair":{"base":"","quote":""},"decimals":0,"category":"","market_hours":"Crypto","arguments":[]}'
+
 [component.eth-rpc]
 source = "../../../target/wasm32-wasip1/release/eth_rpc.wasm"
-
-allowed_outbound_hosts = ["https://eth.llamarpc.com", "https://rpc.eth.gateway.fm"]
+allowed_outbound_hosts = [
+  "https://eth.llamarpc.com",
+  "https://rpc.eth.gateway.fm",
+]
 
 [component.eth-rpc.build]
 command = "cargo build --target wasm32-wasip1 --release"

--- a/apps/oracles/exsat-holdings/spin.toml
+++ b/apps/oracles/exsat-holdings/spin.toml
@@ -6,28 +6,31 @@ name = "Exsat network btc holdings"
 version = "0.1.0"
 
 [application.trigger.settings]
-interval_time_in_seconds = 600
-sequencer = "http://127.0.0.1:9856/post_reports_batch"
-secret_key = "536d1f9d97166eba5ff0efb8cc8dbeb856fb13d2d126ed1efc761e9955014003"
+interval_time_in_seconds = 300
 reporter_id = 0
+sequencer = "http://127.0.0.1:8877/post_reports_batch"
+secret_key = "536d1f9d97166eba5ff0efb8cc8dbeb856fb13d2d126ed1efc761e9955014003"
+second_consensus_secret_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+kafka_endpoint = "http://127.0.0.1:9092"
 
 [[trigger.oracle]]
 component = "exsat-holdings"
 
 [[trigger.oracle.data_feeds]]
 id = "100000"
+stride = 0
+decimals = 0
 data = '{"pair":{"base":"Exsat","quote":"satoshi"},"decimals":0,"category":"Crypto","market_hours":"Crypto","arguments":{}}'
-
 
 [component.exsat-holdings]
 source = "../../../target/wasm32-wasip1/release/exsat_holdings.wasm"
-key_value_stores = ["default"]
 allowed_outbound_hosts = [
-    "https://raw.githubusercontent.com",
-    "https://rpc-us.exsat.network",
-    "https://blockchain.info",
-    "https://mempool.space",
+  "https://raw.githubusercontent.com",
+  "https://rpc-us.exsat.network",
+  "https://blockchain.info",
+  "https://mempool.space",
 ]
+key_value_stores = ["default"]
 
 [component.exsat-holdings.build]
 command = "cargo build --target wasm32-wasip1 --release"

--- a/apps/oracles/gecko-terminal/spin.toml
+++ b/apps/oracles/gecko-terminal/spin.toml
@@ -7,28 +7,35 @@ version = "0.1.0"
 
 [application.trigger.settings]
 interval_time_in_seconds = 10
-sequencer = "http://127.0.0.1:9856/post_reports_batch"
-secret_key = "536d1f9d97166eba5ff0efb8cc8dbeb856fb13d2d126ed1efc761e9955014003"
 reporter_id = 0
+sequencer = "http://127.0.0.1:8877/post_reports_batch"
+secret_key = "536d1f9d97166eba5ff0efb8cc8dbeb856fb13d2d126ed1efc761e9955014003"
+second_consensus_secret_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+kafka_endpoint = "http://127.0.0.1:9092"
 
 [[trigger.oracle]]
 component = "gecko-terminal"
 
 [[trigger.oracle.data_feeds]]
 id = "1000000"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"WMON","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":[{"min_volume_usd":500000.0,"network":"monad-testnet","pool":"0x264e9b75723d75e3c607627d8e21d2c758db4c80","reverse":true},{"min_volume_usd":500000.0,"network":"monad-testnet","pool":"0x8552706d9a27013f20ea0f9df8e20b61e283d2d3","reverse":true},{"min_volume_usd":500000.0,"network":"monad-testnet","pool":"0x5323821de342c56b80c99fbc7cd725f2da8eb87b","reverse":true},{"min_volume_usd":500000.0,"network":"monad-testnet","pool":"0x6e4b7be5ef7f8950c76baa0bd90125bc9b33c8db","reverse":true},{"min_volume_usd":500000.0,"network":"monad-testnet","pool":"0x212fde77a42d55f980d0a0304e7eebe1e999c60f","reverse":true},{"min_volume_usd":500000.0,"network":"monad-testnet","pool":"0xc0ce32eee0eb8bf24fa2b00923a78abc5002f91e","reverse":true},{"min_volume_usd":500000.0,"network":"monad-testnet","pool":"0x786f4aa162457ecdf8fa4657759fa3e86c9394ff","reverse":true},{"min_volume_usd":500000.0,"network":"monad-testnet","pool":"0xf2afc5aa9965cdb2d4be94823c98411291b61297","reverse":true},{"min_volume_usd":500000.0,"network":"monad-testnet","pool":"0xf22d36b6bee8a7fd51def4e3badf35a8733b284f","reverse":true},{"min_volume_usd":500000.0,"network":"monad-testnet","pool":"0xe8a806ae6ecb1f02063e21c6f0579b145399ee5f","reverse":true}]}'
 
 [[trigger.oracle.data_feeds]]
 id = "1000001"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USDZ","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":[{"min_volume_usd":10000.0,"network":"base","pool":"0xcf88b8bf7ccce2d836878e538197eb20fc673bce","reverse":false},{"min_volume_usd":10000.0,"network":"base","pool":"0x6d0b9c9e92a3de30081563c3657b5258b3ffa38b","reverse":false},{"min_volume_usd":10000.0,"network":"base","pool":"0xebf0e4da26a0d040c2343a9e072a0d0b8cf1e0b0","reverse":false},{"min_volume_usd":10000.0,"network":"base","pool":"0x96cc4b6a75fa1dfea66091589d1f25aff3aa0318","reverse":false},{"min_volume_usd":10000.0,"network":"base","pool":"0xcea8ef6ce6235f2c2cdd13c9e8a3ed470725a638","reverse":false},{"min_volume_usd":10000.0,"network":"base","pool":"0xde5ff829fef54d1bdec957d9538a306f0ead1368","reverse":false},{"min_volume_usd":10000.0,"network":"base","pool":"0x2ce63497999f520cc2afaaadbcfc37afd9def4b0","reverse":false},{"min_volume_usd":10000.0,"network":"base","pool":"0xe722e6bce1a598e6b5d26e9975bf44140d2aa3e5","reverse":false},{"min_volume_usd":10000.0,"network":"base","pool":"0x4ef1e503c4f1e5664ac98294d0e42ddc9c0ff961","reverse":false},{"min_volume_usd":10000.0,"network":"base","pool":"0x2c206c7de24787f85b5c52d2ea339adc6d5af40f","reverse":false}]}'
 
 [[trigger.oracle.data_feeds]]
 id = "1000002"
+stride = 0
+decimals = 8
 data = '{"pair":{"base":"USR","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":[{"min_volume_usd":500000.0,"network":"base","pool":"0xd3ee0a3b349237d68517df30bfb66be971f46ad9","reverse":false},{"min_volume_usd":500000.0,"network":"base","pool":"0xb924561a57fc60041414b8471cbc99d3497097fa","reverse":false},{"min_volume_usd":500000.0,"network":"base","pool":"0x97c9750305a39e06002edd851f3d37a862ac7060","reverse":false},{"min_volume_usd":500000.0,"network":"eth","pool":"0x3ee841f47947fefbe510366e4bbb49e145484195","reverse":false},{"min_volume_usd":500000.0,"network":"eth","pool":"0xc907ba505c2e1cbc4658c395d4a2c7e6d2c32656","reverse":false},{"min_volume_usd":500000.0,"network":"eth","pool":"0x8bb9cd887dd51c5aa8d7da9e244c94bec035e47c","reverse":false},{"min_volume_usd":500000.0,"network":"eth","pool":"0x8461537a9bfc5a1df57cf825f8a58049ef61557b","reverse":false},{"min_volume_usd":500000.0,"network":"eth","pool":"0x4628f13651ead6793f8d838b34b8f8522fb0cc52","reverse":true},{"min_volume_usd":500000.0,"network":"eth","pool":"0x38de22a3175708d45e7c7c64cd78479c8b56f76e","reverse":true},{"min_volume_usd":500000.0,"network":"eth","pool":"0xd552716f3bba4224a19d7eb37a31650d7ae10144","reverse":true}]}'
 
 [component.gecko-terminal]
 source = "../../../target/wasm32-wasip1/release/gecko_terminal.wasm"
-
 allowed_outbound_hosts = ["https://api.geckoterminal.com"]
 
 [component.gecko-terminal.build]


### PR DESCRIPTION
### Motivation

This PR updates the `spin.toml` files for all oracles to match the structure introduced in [#814](https://github.com/blocksense-network/blocksense/pull/814). These changes are necessary for the oracles to function correctly when using the `just start-oracle <oracle>` command during local development.

### Changes

- Updated `spin.toml` files for each oracle to conform to the latest schema.
- Format the `spin.toml` files


### How to prevent this in the future

To catch issues like this earlier:

- We will incorporate a basic E2E check that runs `just start-oracle <oracle>` for all registered oracles and asserts they boot successfully.
- We should also document this requirement clearly when introducing future changes to the structure.


**Please be mindful when introducing changes like this in the future.**
They can silently break local workflows (e.g., just start-oracle <oracle>), which slows down development.

cc: @Xearty @PetarKirov @melatron @ymadzhunkov 