### PR TITLE
fix(sequencer/adfs): Fix round counters value correction for neighbors when sending to reporter

### DIFF
--- a/apps/sequencer/src/aggregate_batch_consensus_processor.rs
+++ b/apps/sequencer/src/aggregate_batch_consensus_processor.rs
@@ -155,8 +155,7 @@ pub async fn aggregation_batch_consensus_loop(
                                         eyre::bail!("Nonce in safe contract {} not as expected {}! Skipping transaction. Blocksense block height: {block_height}", latest_nonce._0, safe_tx.nonce);
                                     }
 
-                                    Ok(match contract
-                                    .execTransaction(
+                                    let receipt = match contract.execTransaction(
                                         safe_tx.to,
                                         safe_tx.value,
                                         safe_tx.data,
@@ -172,13 +171,16 @@ pub async fn aggregation_batch_consensus_loop(
                                     .await {
                                         Ok(v) => {
                                             info!("Posted tx for network {net}, Blocksense block height: {block_height}! Waiting for receipt ...");
-                                            v.get_receipt()
-                                            .await
+                                            let receipt = v.get_receipt().await;
+                                            info!("Got receipt for network {net}, Blocksense block height: {block_height}! {:?}", receipt);
+                                            receipt
                                         }
                                         Err(e) => {
                                             eyre::bail!("Failed to post tx for network {net}: {e}! Blocksense block height: {block_height}");
                                         }
-                                    })
+                                    };
+
+                                    Ok(receipt)
                                 }).expect("Failed to spawn tx sender for network {net} Blocksense block height: {block_height}!")
                         );
                     }

--- a/libs/feeds_processing/src/utils.rs
+++ b/libs/feeds_processing/src/utils.rs
@@ -510,16 +510,40 @@ pub mod tests {
         .await
         .unwrap();
 
+        let contract_address = "0x663F3ad617193148711d28f5334eE4Ed07016602";
+        let nonce_str = "10";
+        let chain_id = 31337;
+        let safe_address_str = "0x7f09E80DA1dFF8df7F1513E99a3458b228b9e19C";
+
+        let nonce = match Uint::<256, 4>::from_str(nonce_str) {
+            Ok(n) => n,
+            Err(e) => {
+                anyhow::bail!("Non valid nonce ({}) provided: {}", nonce_str, e);
+            }
+        };
+
+        let safe_transaction = create_safe_tx(
+            Address::from_str(contract_address).unwrap(),
+            Bytes::from(calldata.clone()),
+            nonce,
+        );
+
+        let tx_hash = generate_transaction_hash(
+            Address::from_str(safe_address_str).unwrap(),
+            U256::from(chain_id),
+            safe_transaction,
+        )
+        .to_vec();
+
         let consensus_second_rond_batch = ConsensusSecondRoundBatch {
             sequencer_id: 0,
             block_height,
             network,
-            contract_address: "0x663F3ad617193148711d28f5334eE4Ed07016602".to_string(),
-            safe_address: "0x7f09E80DA1dFF8df7F1513E99a3458b228b9e19C".to_string(),
-            nonce: "10".to_string(),
-            chain_id: "31337".to_string(),
-            tx_hash: "0xf2ee45d69fc602204159abf6efaf49991f24db7d6ee89b679441d20d15f55bd3"
-                .to_string(),
+            contract_address: contract_address.to_string(),
+            safe_address: safe_address_str.to_string(),
+            nonce: nonce_str.to_string(),
+            chain_id: chain_id.to_string(),
+            tx_hash: hex::encode(tx_hash),
             calldata: hex::encode(calldata),
             updates,
             feeds_rounds,


### PR DESCRIPTION
Fix in sequencer to correctly fill the values of the round counters that will be passed to the reporters before correction is made for the neighbors of the updated feed ids. 
Added a unit test to cover this scenario + refactor existing unit test to not use a hard coded tx_hash.