### PR TITLE
fix(nft.blocksense.network): Apply backdrop effect to main header

### DIFF
--- a/apps/nft.blocksense.network/components/Navbar.tsx
+++ b/apps/nft.blocksense.network/components/Navbar.tsx
@@ -39,8 +39,8 @@ const navLinks = [
 
 const DesktopNavbar = () => {
   return (
-    <header className="navbar hidden md:flex z-20 fixed w-full bg-[var(--black)] text-[var(--white)] px-20 py-[1.125rem]">
-      <div className="w-full max-w-[66.875rem] mx-auto flex justify-between items-center">
+    <header className="navbar hidden md:flex bg-[var(--black)/0.85] backdrop-blur-2xl z-10 fixed w-full text-[var(--white)] px-20 py-[1.125rem]">
+      <div className="w-full max-w-[66.875rem] mx-auto z-30 flex justify-between items-center">
         <Logo />
         <nav className="navbar__nav flex gap-8">
           {navLinks.map(link => (


### PR DESCRIPTION
Requested by designers.

**Desktop:** 
![image](https://github.com/user-attachments/assets/e79891c9-8e74-4444-96c0-86eef646b8bb)

>**Note**: This update will be applied to desktop only. For mobile, it will be, as it was before.
