### PR TITLE
refactor(nft.blocksense.network): Replace Next link with plain anchor in Logo component

### DIFF
--- a/apps/nft.blocksense.network/components/Logo.tsx
+++ b/apps/nft.blocksense.network/components/Logo.tsx
@@ -1,9 +1,14 @@
-import Link from 'next/link';
+const BLOCKSENSE_URL = 'https://blocksense.network/';
 
 export const Logo = () => {
   return (
-    <Link href="/" className="logo">
-      <img src="/images/logo.svg" alt="blocksense logo" />
-    </Link>
+    <a
+      href={BLOCKSENSE_URL}
+      className="bs logo"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <img src="/images/logo.svg" alt="Blocksense logo" />
+    </a>
   );
 };


### PR DESCRIPTION
### Refactor external link in Logo component

- Replaced `next/link` with a standard `<a>` tag for the logo link.
- Moved the URL into a constant named `BLOCKSENSE_URL`.
- Added `target="_blank"` and `rel="noopener noreferrer"` to open the link in a new tab securely.

These changes align with best practices for handling external links in Next.js 15.

> Requested by marketing team. 