### PR TITLE
[oracles]: Implement initial version of `stock-price-feeds` oracle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10157,6 +10157,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "blocksense-sdk",
+ "futures",
+ "itertools 0.14.0",
  "prettytable-rs",
  "serde 1.0.217",
  "serde-this-or-that",

--- a/apps/oracles/crypto-price-feeds/src/exchanges/binance.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/binance.rs
@@ -43,6 +43,7 @@ impl<'a> PricesFetcher<'a> for BinancePriceFetcher<'a> {
             let response = http_get_json::<BinancePriceResponse>(
                 "https://api1.binance.com/api/v3/ticker/24hr",
                 Some(&[("symbols", req_symbols.as_str())]),
+                None,
             )
             .await?;
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/binance.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/binance.rs
@@ -29,7 +29,7 @@ pub struct BinancePriceFetcher<'a> {
 impl<'a> PricesFetcher<'a> for BinancePriceFetcher<'a> {
     const NAME: &'static str = "Binance";
 
-    fn new(symbols: &'a [String]) -> Self {
+    fn new(symbols: &'a [String], _api_key: Option<&'a str>) -> Self {
         Self { symbols }
     }
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/binance_us.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/binance_us.rs
@@ -29,7 +29,7 @@ pub struct BinanceUsPriceFetcher<'a> {
 impl<'a> PricesFetcher<'a> for BinanceUsPriceFetcher<'a> {
     const NAME: &'static str = "Binance US";
 
-    fn new(symbols: &'a [String]) -> Self {
+    fn new(symbols: &'a [String], _api_key: Option<&'a str>) -> Self {
         Self { symbols }
     }
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/binance_us.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/binance_us.rs
@@ -43,6 +43,7 @@ impl<'a> PricesFetcher<'a> for BinanceUsPriceFetcher<'a> {
             let response = http_get_json::<BinanceUsPriceResponse>(
                 "https://api.binance.us/api/v3/ticker/24hr",
                 Some(&[("symbols", req_symbols.as_str())]),
+                None,
             )
             .await?;
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/bitfinex.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/bitfinex.rs
@@ -60,6 +60,7 @@ impl<'a> PricesFetcher<'a> for BitfinexPriceFetcher<'a> {
             let response = http_get_json::<Vec<TradingPairTicker>>(
                 "https://api-pub.bitfinex.com/v2/tickers",
                 Some(&[("symbols", all_symbols.as_str())]),
+                None,
             )
             .await?;
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/bitfinex.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/bitfinex.rs
@@ -49,7 +49,7 @@ pub struct BitfinexPriceFetcher<'a> {
 impl<'a> PricesFetcher<'a> for BitfinexPriceFetcher<'a> {
     const NAME: &'static str = "Bitfinex";
 
-    fn new(symbols: &'a [String]) -> Self {
+    fn new(symbols: &'a [String], _api_key: Option<&'a str>) -> Self {
         Self { symbols }
     }
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/bitget.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/bitget.rs
@@ -30,7 +30,7 @@ pub struct BitgetPriceFetcher;
 impl PricesFetcher<'_> for BitgetPriceFetcher {
     const NAME: &'static str = "Bitget";
 
-    fn new(_symbols: &[String]) -> Self {
+    fn new(_symbols: &[String], _api_key: Option<&str>) -> Self {
         Self
     }
     fn fetch(&self) -> LocalBoxFuture<Result<PairPriceData>> {

--- a/apps/oracles/crypto-price-feeds/src/exchanges/bitget.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/bitget.rs
@@ -38,6 +38,7 @@ impl PricesFetcher<'_> for BitgetPriceFetcher {
             let response = http_get_json::<BitgetPriceResponse>(
                 "https://api.bitget.com/api/spot/v1/market/tickers",
                 None,
+                None,
             )
             .await?;
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/bybit.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/bybit.rs
@@ -46,6 +46,7 @@ impl PricesFetcher<'_> for BybitPriceFetcher {
             let response = http_get_json::<BybitPriceResponse>(
                 "https://api.bybit.com/v5/market/tickers",
                 Some(&[("category", "spot"), ("symbols", "")]),
+                None,
             )
             .await?;
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/bybit.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/bybit.rs
@@ -38,7 +38,7 @@ pub struct BybitPriceFetcher;
 impl PricesFetcher<'_> for BybitPriceFetcher {
     const NAME: &'static str = "Bybit";
 
-    fn new(_symbols: &[String]) -> Self {
+    fn new(_symbols: &[String], _api_key: Option<&str>) -> Self {
         Self
     }
     fn fetch(&self) -> LocalBoxFuture<Result<PairPriceData>> {

--- a/apps/oracles/crypto-price-feeds/src/exchanges/coinbase.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/coinbase.rs
@@ -29,7 +29,7 @@ pub struct CoinbasePriceFetcher<'a> {
 impl<'a> PricesFetcher<'a> for CoinbasePriceFetcher<'a> {
     const NAME: &'static str = "Coinbase";
 
-    fn new(symbols: &'a [String]) -> Self {
+    fn new(symbols: &'a [String], _api_key: Option<&'a str>) -> Self {
         Self { symbols }
     }
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/coinbase.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/coinbase.rs
@@ -57,7 +57,7 @@ impl<'a> PricesFetcher<'a> for CoinbasePriceFetcher<'a> {
 }
 pub async fn fetch_price_for_symbol(symbol: &str) -> Result<(String, PricePoint)> {
     let url = format!("https://api.exchange.coinbase.com/products/{symbol}/ticker");
-    let response = http_get_json::<CoinbasePriceResponse>(&url, None).await?;
+    let response = http_get_json::<CoinbasePriceResponse>(&url, None, None).await?;
 
     Ok((
         symbol.to_string().replace("-", ""),

--- a/apps/oracles/crypto-price-feeds/src/exchanges/crypto_com_exchange.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/crypto_com_exchange.rs
@@ -43,6 +43,7 @@ impl PricesFetcher<'_> for CryptoComPriceFetcher {
             let response = http_get_json::<CryptoComPriceResponse>(
                 "https://api.crypto.com/exchange/v1/public/get-tickers",
                 None,
+                None,
             )
             .await?;
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/crypto_com_exchange.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/crypto_com_exchange.rs
@@ -34,7 +34,7 @@ pub struct CryptoComPriceFetcher;
 impl PricesFetcher<'_> for CryptoComPriceFetcher {
     const NAME: &'static str = "Crypto.com";
 
-    fn new(_symbols: &[String]) -> Self {
+    fn new(_symbols: &[String], _api_key: Option<&str>) -> Self {
         Self
     }
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/gate_io.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/gate_io.rs
@@ -25,7 +25,7 @@ pub struct GateIoPriceFetcher;
 impl PricesFetcher<'_> for GateIoPriceFetcher {
     const NAME: &'static str = "Gate.io";
 
-    fn new(_symbols: &[String]) -> Self {
+    fn new(_symbols: &[String], _api_key: Option<&str>) -> Self {
         Self
     }
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/gate_io.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/gate_io.rs
@@ -34,6 +34,7 @@ impl PricesFetcher<'_> for GateIoPriceFetcher {
             let response = http_get_json::<GateIoPriceResponse>(
                 "https://api.gateio.ws/api/v4/spot/tickers",
                 None,
+                None,
             )
             .await?;
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/gemini.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/gemini.rs
@@ -58,7 +58,7 @@ impl<'a> PricesFetcher<'a> for GeminiPriceFetcher<'a> {
 
 pub async fn fetch_price_for_symbol(symbol: &str) -> Result<(String, PricePoint)> {
     let url = format!("https://api.gemini.com/v1/pubticker/{symbol}");
-    let response = http_get_json::<GeminiPriceResponse>(&url, None).await?;
+    let response = http_get_json::<GeminiPriceResponse>(&url, None, None).await?;
 
     let volume_data = response
         .volume

--- a/apps/oracles/crypto-price-feeds/src/exchanges/gemini.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/gemini.rs
@@ -29,7 +29,7 @@ pub struct GeminiPriceFetcher<'a> {
 impl<'a> PricesFetcher<'a> for GeminiPriceFetcher<'a> {
     const NAME: &'static str = "Gemini";
 
-    fn new(symbols: &'a [String]) -> Self {
+    fn new(symbols: &'a [String], _api_key: Option<&'a str>) -> Self {
         Self { symbols }
     }
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/kraken.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/kraken.rs
@@ -41,7 +41,7 @@ pub struct KrakenPriceFetcher;
 impl PricesFetcher<'_> for KrakenPriceFetcher {
     const NAME: &'static str = "Kraken";
 
-    fn new(_symbols: &[String]) -> Self {
+    fn new(_symbols: &[String], _api_key: Option<&str>) -> Self {
         Self
     }
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/kraken.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/kraken.rs
@@ -50,6 +50,7 @@ impl PricesFetcher<'_> for KrakenPriceFetcher {
             let response = http_get_json::<KrakenPriceResponse>(
                 "https://api.kraken.com/0/public/Ticker",
                 None,
+                None,
             )
             .await?;
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/kucoin.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/kucoin.rs
@@ -57,6 +57,7 @@ impl PricesFetcher<'_> for KuCoinPriceFetcher {
             let response = http_get_json::<KuCoinPriceResponse>(
                 "https://api.kucoin.com/api/v1/market/allTickers",
                 None,
+                None,
             )
             .await?;
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/kucoin.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/kucoin.rs
@@ -48,7 +48,7 @@ pub struct KuCoinPriceFetcher;
 impl PricesFetcher<'_> for KuCoinPriceFetcher {
     const NAME: &'static str = "KuCoin";
 
-    fn new(_symbols: &[String]) -> Self {
+    fn new(_symbols: &[String], _api_key: Option<&str>) -> Self {
         Self
     }
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/mexc.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/mexc.rs
@@ -26,7 +26,7 @@ pub struct MEXCPriceFetcher;
 impl PricesFetcher<'_> for MEXCPriceFetcher {
     const NAME: &'static str = "MEXC";
 
-    fn new(_symbols: &[String]) -> Self {
+    fn new(_symbols: &[String], _api_key: Option<&str>) -> Self {
         Self
     }
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/mexc.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/mexc.rs
@@ -32,9 +32,12 @@ impl PricesFetcher<'_> for MEXCPriceFetcher {
 
     fn fetch(&self) -> LocalBoxFuture<Result<PairPriceData>> {
         async {
-            let response =
-                http_get_json::<MEXCPriceResponse>("https://api.mexc.com/api/v3/ticker/24hr", None)
-                    .await?;
+            let response = http_get_json::<MEXCPriceResponse>(
+                "https://api.mexc.com/api/v3/ticker/24hr",
+                None,
+                None,
+            )
+            .await?;
 
             Ok(response
                 .into_iter()

--- a/apps/oracles/crypto-price-feeds/src/exchanges/okx.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/okx.rs
@@ -30,7 +30,7 @@ pub struct OKXPriceFetcher;
 impl PricesFetcher<'_> for OKXPriceFetcher {
     const NAME: &'static str = "OKX";
 
-    fn new(_symbols: &[String]) -> Self {
+    fn new(_symbols: &[String], _api_key: Option<&str>) -> Self {
         Self
     }
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/okx.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/okx.rs
@@ -39,6 +39,7 @@ impl PricesFetcher<'_> for OKXPriceFetcher {
             let response = http_get_json::<OKXTickerResponse>(
                 "https://www.okx.com/api/v5/market/tickers",
                 Some(&[("instType", "SPOT")]),
+                None,
             )
             .await?;
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/upbit.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/upbit.rs
@@ -24,7 +24,7 @@ pub struct UpBitPriceFetcher<'a> {
 impl<'a> PricesFetcher<'a> for UpBitPriceFetcher<'a> {
     const NAME: &'static str = "UpBit";
 
-    fn new(symbols: &'a [String]) -> Self {
+    fn new(symbols: &'a [String], _api_key: Option<&'a str>) -> Self {
         Self { symbols }
     }
 

--- a/apps/oracles/crypto-price-feeds/src/exchanges/upbit.rs
+++ b/apps/oracles/crypto-price-feeds/src/exchanges/upbit.rs
@@ -34,6 +34,7 @@ impl<'a> PricesFetcher<'a> for UpBitPriceFetcher<'a> {
             let response = http_get_json::<UpBitResponse>(
                 "https://api.upbit.com/v1/ticker",
                 Some(&[("markets", all_markets.as_str())]),
+                None,
             )
             .await?;
 

--- a/apps/oracles/crypto-price-feeds/src/fetch_prices.rs
+++ b/apps/oracles/crypto-price-feeds/src/fetch_prices.rs
@@ -61,20 +61,20 @@ pub async fn fetch_all_prices(resources: &ResourceData) -> Result<TradingPairToR
     let symbols = SymbolsData::from_resources(&resources.symbols)?;
 
     let mut futures_set = FuturesUnordered::from_iter([
-        fetch::<BinancePriceFetcher>(&symbols.binance),
-        fetch::<BinanceUsPriceFetcher>(&symbols.binance_us),
-        fetch::<BitfinexPriceFetcher>(&symbols.bitfinex),
-        fetch::<BitgetPriceFetcher>(&[]),
-        fetch::<BybitPriceFetcher>(&[]),
-        fetch::<CoinbasePriceFetcher>(&symbols.coinbase),
-        fetch::<CryptoComPriceFetcher>(&[]),
-        fetch::<GateIoPriceFetcher>(&[]),
-        fetch::<GeminiPriceFetcher>(&symbols.gemini),
-        fetch::<KrakenPriceFetcher>(&[]),
-        fetch::<KuCoinPriceFetcher>(&[]),
-        fetch::<MEXCPriceFetcher>(&[]),
-        fetch::<OKXPriceFetcher>(&[]),
-        fetch::<UpBitPriceFetcher>(&symbols.upbit),
+        fetch::<BinancePriceFetcher>(&symbols.binance, None),
+        fetch::<BinanceUsPriceFetcher>(&symbols.binance_us, None),
+        fetch::<BitfinexPriceFetcher>(&symbols.bitfinex, None),
+        fetch::<BitgetPriceFetcher>(&[], None),
+        fetch::<BybitPriceFetcher>(&[], None),
+        fetch::<CoinbasePriceFetcher>(&symbols.coinbase, None),
+        fetch::<CryptoComPriceFetcher>(&[], None),
+        fetch::<GateIoPriceFetcher>(&[], None),
+        fetch::<GeminiPriceFetcher>(&symbols.gemini, None),
+        fetch::<KrakenPriceFetcher>(&[], None),
+        fetch::<KuCoinPriceFetcher>(&[], None),
+        fetch::<MEXCPriceFetcher>(&[], None),
+        fetch::<OKXPriceFetcher>(&[], None),
+        fetch::<UpBitPriceFetcher>(&symbols.upbit, None),
     ]);
 
     let before_fetch = Instant::now();

--- a/apps/oracles/gecko-terminal/src/lib.rs
+++ b/apps/oracles/gecko-terminal/src/lib.rs
@@ -111,7 +111,7 @@ async fn fetch_pools_data_for_network(
         .join(",");
     let url = format!("https://api.geckoterminal.com/api/v2/networks/{network}/pools/multi/{r}");
 
-    let mut value = http_get_json::<GeckoTerminalMultipleResponce>(&url, None).await?;
+    let mut value = http_get_json::<GeckoTerminalMultipleResponce>(&url, None, None).await?;
     for v in value.data.iter_mut() {
         if let Some(p) = pools
             .iter()

--- a/apps/oracles/stock-price-feeds/Cargo.toml
+++ b/apps/oracles/stock-price-feeds/Cargo.toml
@@ -17,3 +17,5 @@ url = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde-this-or-that = { workspace = true }
 prettytable-rs = { workspace = true }
+futures = { workspace = true }
+itertools = { workspace = true }

--- a/apps/oracles/stock-price-feeds/spin.toml
+++ b/apps/oracles/stock-price-feeds/spin.toml
@@ -20,13 +20,13 @@ component = "stock-price-feeds"
 id = "2000000"
 stride = 0
 decimals = 8
-data = '{"pair":{"base":"IBIT","quote":"USD"},"decimals":8,"category":"Equities","market_hours":"US_Equities","arguments":{}}'
+data = '{"pair":{"base":"IBIT","quote":"USD"},"decimals":8,"category":"Equities","market_hours":"US_Equities","arguments":{"providers":["AlphaVantage","PolygonIO","Finnhum","YahooFinance","twelvedata","Tiingo","FMP"]}}'
 
 [[trigger.oracle.data_feeds]]
 id = "2000001"
 stride = 0
 decimals = 8
-data = '{"pair":{"base":"SPY","quote":"USD"},"decimals":8,"category":"Equities","market_hours":"US_Equities","arguments":{}}'
+data = '{"pair":{"base":"SPY","quote":"USD"},"decimals":8,"category":"Equities","market_hours":"US_Equities","arguments":{"providers":["AlphaVantage","PolygonIO","Finnhum","YahooFinance","twelvedata","Tiingo","FMP"]}}'
 
 [component.stock-price-feeds]
 source = "../../../target/wasm32-wasip1/release/stock_price_feeds.wasm"

--- a/apps/oracles/stock-price-feeds/spin.toml
+++ b/apps/oracles/stock-price-feeds/spin.toml
@@ -34,5 +34,9 @@ allowed_outbound_hosts = [
   "https://www.alphavantage.co",
 ]
 
+[[trigger.oracle.capabilities]]
+data = "4DIDDYTCVFDYDP27"
+id = "ALPHAVANTAGE_API_KEY"
+
 [component.stock-price-feeds.build]
 command = "cargo build --target wasm32-wasip1 --release"

--- a/apps/oracles/stock-price-feeds/spin.toml
+++ b/apps/oracles/stock-price-feeds/spin.toml
@@ -32,11 +32,16 @@ data = '{"pair":{"base":"SPY","quote":"USD"},"decimals":8,"category":"Equities",
 source = "../../../target/wasm32-wasip1/release/stock_price_feeds.wasm"
 allowed_outbound_hosts = [
   "https://www.alphavantage.co",
+  "https://yfapi.net"
 ]
 
 [[trigger.oracle.capabilities]]
 data = "4DIDDYTCVFDYDP27"
 id = "ALPHAVANTAGE_API_KEY"
+
+[[trigger.oracle.capabilities]]
+data = "uLQo1q92aE9ttxGsNj0aO6bdGwXlf8oL8MG7OGma"
+id = "YAHOO_FINANCE_API_KEY"
 
 [component.stock-price-feeds.build]
 command = "cargo build --target wasm32-wasip1 --release"

--- a/apps/oracles/stock-price-feeds/spin.toml
+++ b/apps/oracles/stock-price-feeds/spin.toml
@@ -30,8 +30,9 @@ data = '{"pair":{"base":"SPY","quote":"USD"},"decimals":8,"category":"Equities",
 
 [component.stock-price-feeds]
 source = "../../../target/wasm32-wasip1/release/stock_price_feeds.wasm"
-
-allowed_outbound_hosts = []
+allowed_outbound_hosts = [
+  "https://www.alphavantage.co",
+]
 
 [component.stock-price-feeds.build]
 command = "cargo build --target wasm32-wasip1 --release"

--- a/apps/oracles/stock-price-feeds/spin.toml
+++ b/apps/oracles/stock-price-feeds/spin.toml
@@ -20,13 +20,13 @@ component = "stock-price-feeds"
 id = "2000000"
 stride = 0
 decimals = 8
-data = '{"pair":{"base":"IBIT","quote":"USD"},"decimals":8,"category":"Equities","market_hours":"US_Equities","arguments":{"providers":["AlphaVantage","PolygonIO","Finnhum","YahooFinance","twelvedata","Tiingo","FMP"]}}'
+data = '{"pair":{"base":"IBIT","quote":"USD"},"decimals":8,"category":"Equities","provider_hours":"US_Equities","arguments":{"providers":["AlphaVantage","PolygonIO","Finnhum","YahooFinance","twelvedata","Tiingo","FMP"]}}'
 
 [[trigger.oracle.data_feeds]]
 id = "2000001"
 stride = 0
 decimals = 8
-data = '{"pair":{"base":"SPY","quote":"USD"},"decimals":8,"category":"Equities","market_hours":"US_Equities","arguments":{"providers":["AlphaVantage","PolygonIO","Finnhum","YahooFinance","twelvedata","Tiingo","FMP"]}}'
+data = '{"pair":{"base":"SPY","quote":"USD"},"decimals":8,"category":"Equities","provider_hours":"US_Equities","arguments":{"providers":["AlphaVantage","PolygonIO","Finnhum","YahooFinance","twelvedata","Tiingo","FMP"]}}'
 
 [component.stock-price-feeds]
 source = "../../../target/wasm32-wasip1/release/stock_price_feeds.wasm"

--- a/apps/oracles/stock-price-feeds/src/fetch_prices.rs
+++ b/apps/oracles/stock-price-feeds/src/fetch_prices.rs
@@ -9,7 +9,11 @@ use blocksense_sdk::traits::prices_fetcher::{fetch, TradingPairSymbol};
 
 use crate::{
     providers::alpha_vantage::AlphaVantagePriceFetcher,
-    types::{PairToResults, ProviderPriceData, ProvidersSymbols, ResourceData, ResourcePairData},
+    types::{
+        Capabilities, ProviderPriceData, ProvidersSymbols, PairToResults, ResourceData,
+        ResourcePairData,
+    },
+    utils::get_api_key,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -33,11 +37,16 @@ impl SymbolsData {
     The `fetch_all_prices` function is very similar to the one we use in `crypto-price-feeds` oracle.
     It should be moved to blocksense-sdk
 */
-pub async fn fetch_all_prices(resources: &ResourceData) -> Result<PairToResults> {
+pub async fn fetch_all_prices(
+    resources: &ResourceData,
+    capabilities: Option<&Capabilities>,
+) -> Result<PairToResults> {
     let symbols = SymbolsData::from_resources(&resources.symbols)?;
 
-    let mut futures_set =
-        FuturesUnordered::from_iter([fetch::<AlphaVantagePriceFetcher>(&symbols.alpha_vantage)]);
+    let mut futures_set = FuturesUnordered::from_iter([fetch::<AlphaVantagePriceFetcher>(
+        &symbols.alpha_vantage,
+        get_api_key(capabilities, "ALPHAVANTAGE_API_KEY"),
+    )]);
 
     let before_fetch = Instant::now();
     let mut results = PairToResults::new();

--- a/apps/oracles/stock-price-feeds/src/fetch_prices.rs
+++ b/apps/oracles/stock-price-feeds/src/fetch_prices.rs
@@ -1,0 +1,77 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use std::time::Instant;
+
+use futures::stream::{FuturesUnordered, StreamExt};
+
+use blocksense_sdk::traits::prices_fetcher::{fetch, TradingPairSymbol};
+
+use crate::types::{
+    PairToResults, ProviderPriceData, ProvidersSymbols, ResourceData, ResourcePairData,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SymbolsData {}
+
+impl SymbolsData {
+    pub fn from_resources(_providers_symbols: &ProvidersSymbols) -> Result<Self> {
+        Ok(Self {})
+    }
+}
+
+/*TODO:(EmilIvanichkovv):
+    The `fetch_all_prices` function is very similar to the one we use in `crypto-price-feeds` oracle.
+    It should be moved to blocksense-sdk
+*/
+pub async fn fetch_all_prices(resources: &ResourceData) -> Result<PairToResults> {
+    let symbols = SymbolsData::from_resources(&resources.symbols)?;
+
+    let mut futures_set = FuturesUnordered::from_iter([]);
+
+    let before_fetch = Instant::now();
+    let mut results = PairToResults::new();
+
+    // Process results as they complete
+    while let Some((provider_id, result)) = futures_set.next().await {
+        match result {
+            Ok(prices) => {
+                let time_taken = before_fetch.elapsed();
+                println!("ℹ️  Successfully fetched prices from {provider_id} in {time_taken:?}",);
+                let prices_per_provider = ProviderPriceData {
+                    name: "demo_provider".to_string(),
+                    data: prices,
+                };
+                fill_results(&resources.pairs, prices_per_provider, &mut results);
+            }
+            Err(err) => println!("❌ Error fetching prices from {provider_id}: {err:?}"),
+        }
+    }
+
+    println!("🕛 All prices fetched in {:?}", before_fetch.elapsed());
+
+    Ok(results)
+}
+
+fn fill_results(
+    resources: &[ResourcePairData],
+    prices_per_provider: ProviderPriceData,
+    results: &mut PairToResults,
+) {
+    let provider_name = &prices_per_provider.name.clone();
+    for resource in resources {
+        let symbol = &resource.pair.base;
+
+        let res = results.entry(resource.id.clone()).or_default();
+        res.symbol = symbol.clone();
+
+        if let Some(price_point) = prices_per_provider.data.get(symbol) {
+            res.providers_data
+                .insert(provider_name.clone(), price_point.clone());
+        }
+        if res.providers_data.is_empty() {
+            results.remove(&resource.id);
+        }
+    }
+}

--- a/apps/oracles/stock-price-feeds/src/lib.rs
+++ b/apps/oracles/stock-price-feeds/src/lib.rs
@@ -1,4 +1,5 @@
 mod fetch_prices;
+mod providers;
 mod types;
 
 use anyhow::{Context, Result};

--- a/apps/oracles/stock-price-feeds/src/lib.rs
+++ b/apps/oracles/stock-price-feeds/src/lib.rs
@@ -1,12 +1,202 @@
-use anyhow::{Error, Result};
+mod fetch_prices;
+mod types;
+
+use anyhow::{Context, Result};
+use itertools::Itertools;
+use prettytable::{format, Cell, Row, Table};
+use std::{collections::HashMap, fmt::Write};
+
 use blocksense_sdk::{
-    oracle::{Payload, Settings},
+    oracle::{DataFeedResult, DataFeedResultValue, Payload, Settings},
     oracle_component,
+    traits::prices_fetcher::PricePoint,
 };
+
+use fetch_prices::fetch_all_prices;
+use types::{FeedConfigData, PairToResults, ProvidersSymbols, ResourceData, ResourcePairData};
 
 #[oracle_component]
 async fn oracle_request(settings: Settings) -> Result<Payload> {
     println!("Starting oracle component - Stock Price Feeds");
-    println!("Settings: {:?}", settings.data_feeds);
-    Err(Error::msg("Not implemented yet"))
+
+    let resources = get_resources_from_settings(&settings)?;
+
+    let results = fetch_all_prices(&resources).await?;
+    let payload = process_results(&results)?;
+
+    print_results(&resources.pairs, &results, &payload);
+
+    Ok(payload)
+}
+
+fn process_results(results: &PairToResults) -> Result<Payload> {
+    let mut payload = Payload::new();
+    for (feed_id, results) in results.iter() {
+        let price_points = results.providers_data.values();
+
+        payload.values.push(match compute_vwap(price_points) {
+            Ok(price) => DataFeedResult {
+                id: feed_id.to_string(),
+                value: DataFeedResultValue::Numerical(price),
+            },
+            Err(err) => DataFeedResult {
+                id: feed_id.to_string(),
+                value: DataFeedResultValue::Error(err.to_string()),
+            },
+        });
+    }
+
+    Ok(payload)
+}
+
+fn get_resources_from_settings(settings: &Settings) -> Result<ResourceData> {
+    let mut feeds_data = Vec::new();
+    let mut providers_symbols: ProvidersSymbols = HashMap::new();
+
+    for feed_setting in &settings.data_feeds {
+        let feed_config_data: FeedConfigData =
+            serde_json::from_str(&feed_setting.data).context("Couldn't parse data feed")?;
+
+        let base = &feed_config_data.pair.base;
+
+        feeds_data.push(ResourcePairData {
+            pair: feed_config_data.pair.clone(),
+            id: feed_setting.id.clone(),
+        });
+
+        if let Some(providers) = &feed_config_data.arguments.providers {
+            for provider in providers {
+                let symbols = providers_symbols.entry(provider.clone()).or_default();
+
+                if !symbols.contains(base) {
+                    symbols.push(base.clone());
+                }
+            }
+        }
+    }
+
+    Ok(ResourceData {
+        pairs: feeds_data,
+        symbols: providers_symbols,
+    })
+}
+
+struct ResultInfo {
+    pub id: i64,
+    pub name: String,
+    pub value: String,
+    pub providers: Vec<String>,
+}
+
+/*TODO:(EmilIvanichkovv):
+    The `print_results` function is very similar to the one we use in `crypto-price-feeds` oracle.
+    It should be moved to blocksense-sdk
+*/
+fn print_results(resources: &[ResourcePairData], results: &PairToResults, payload: &Payload) {
+    let mut results_info: Vec<ResultInfo> = Vec::new();
+    let mut pairs_with_missing_provider_data: String = String::new();
+    let mut pairs_with_missing_provider_data_count = 0;
+    let mut missing_prices: String = String::new();
+    let mut missing_prices_count = 0;
+
+    for resource in resources.iter() {
+        if results.get(&resource.id).is_some() {
+            let providers = results
+                .get(&resource.id)
+                .map(|res| {
+                    res.providers_data
+                        .keys()
+                        .map(|x| x.split(' ').next().unwrap().to_string())
+                        .unique()
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let value = match payload
+                .values
+                .iter()
+                .find(|x| x.id == resource.id)
+                .unwrap()
+                .value
+                .clone()
+            {
+                DataFeedResultValue::Numerical(num) => format!("{num:.8}"),
+                _ => {
+                    missing_prices_count += 1;
+                    write!(
+                        missing_prices,
+                        "{{ {}: {} / {}, providers: {:?} }},",
+                        resource.id, resource.pair.base, resource.pair.quote, providers
+                    )
+                    .unwrap();
+                    "-".to_string()
+                }
+            };
+
+            results_info.push(ResultInfo {
+                id: resource.id.parse().unwrap(),
+                name: format!("{} / {}", resource.pair.base, resource.pair.quote),
+                value,
+                providers,
+            });
+        } else {
+            pairs_with_missing_provider_data_count += 1;
+            write!(
+                pairs_with_missing_provider_data,
+                "{{ {}: {} / {} }},",
+                resource.id, resource.pair.base, resource.pair.quote
+            )
+            .unwrap();
+        }
+    }
+
+    results_info.sort_by(|a, b| a.id.cmp(&b.id));
+
+    let mut table = Table::new();
+    table.set_format(*format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
+
+    table.set_titles(Row::new(vec![
+        Cell::new("ID").style_spec("bc"),
+        Cell::new("Name").style_spec("bc"),
+        Cell::new("Value").style_spec("bc"),
+        Cell::new("Providers").style_spec("bc"),
+    ]));
+
+    for data in results_info {
+        table.add_row(Row::new(vec![
+            Cell::new(&data.id.to_string()).style_spec("r"),
+            Cell::new(&data.name).style_spec("r"),
+            Cell::new(&data.value).style_spec("r"),
+            Cell::new(&data.providers.len().to_string()).style_spec("r"),
+        ]));
+    }
+
+    println!(
+        "\n{} Pairs with no provider data:",
+        pairs_with_missing_provider_data_count
+    );
+    println!("[{}]", pairs_with_missing_provider_data);
+
+    println!(
+        "\n{} Pairs with missing price / volume data from provider:",
+        missing_prices_count
+    );
+    println!("[{}]", missing_prices);
+
+    println!("\nResults:");
+    table.printstd();
+}
+
+/*TODO:(EmilIvanichkovv):
+    This is a copy-paste from the `crypto-price-feeds` oracle.
+    It should be moved to blocksense-sdk
+*/
+pub fn compute_vwap<'a>(price_points: impl IntoIterator<Item = &'a PricePoint>) -> Result<f64> {
+    price_points
+        .into_iter()
+        .filter(|pp| pp.volume > 0.0)
+        .map(|PricePoint { price, volume }| (price * volume, *volume))
+        .reduce(|(num, denom), (weighted_price, volume)| (num + weighted_price, denom + volume))
+        .context("No price points found")
+        .map(|(weighted_prices_sum, total_volume)| weighted_prices_sum / total_volume)
 }

--- a/apps/oracles/stock-price-feeds/src/lib.rs
+++ b/apps/oracles/stock-price-feeds/src/lib.rs
@@ -17,7 +17,7 @@ use blocksense_sdk::{
 use fetch_prices::fetch_all_prices;
 
 use types::{
-    Capabilities, FeedConfigData, ProvidersSymbols, PairToResults, ResourceData, ResourcePairData,
+    Capabilities, FeedConfigData, PairToResults, ProvidersSymbols, ResourceData, ResourcePairData,
 };
 
 #[oracle_component]

--- a/apps/oracles/stock-price-feeds/src/providers/alpha_vantage.rs
+++ b/apps/oracles/stock-price-feeds/src/providers/alpha_vantage.rs
@@ -32,13 +32,14 @@ pub struct AlphaVantageResponse {
 
 pub struct AlphaVantagePriceFetcher<'a> {
     pub symbols: &'a [String],
+    api_key: Option<&'a str>,
 }
 
 impl<'a> PricesFetcher<'a> for AlphaVantagePriceFetcher<'a> {
     const NAME: &'static str = "AlphaVantage";
 
-    fn new(symbols: &'a [String]) -> Self {
-        Self { symbols }
+    fn new(symbols: &'a [String], api_key: Option<&'a str>) -> Self {
+        Self { symbols, api_key }
     }
 
     fn fetch(&self) -> LocalBoxFuture<Result<PairPriceData>> {

--- a/apps/oracles/stock-price-feeds/src/providers/alpha_vantage.rs
+++ b/apps/oracles/stock-price-feeds/src/providers/alpha_vantage.rs
@@ -89,6 +89,7 @@ pub async fn fetch_price_for_symbol(symbol: &str, api_key: &str) -> Result<(Stri
             ("symbol", symbol),
             ("apikey", api_key),
         ]),
+        None,
     )
     .await;
 

--- a/apps/oracles/stock-price-feeds/src/providers/alpha_vantage.rs
+++ b/apps/oracles/stock-price-feeds/src/providers/alpha_vantage.rs
@@ -1,0 +1,99 @@
+use std::ops::Deref;
+
+use anyhow::{Error, Result};
+use futures::{
+    future::LocalBoxFuture,
+    stream::{FuturesUnordered, StreamExt},
+    FutureExt,
+};
+
+use serde::Deserialize;
+use serde_this_or_that::as_f64;
+
+use blocksense_sdk::{
+    http::http_get_json,
+    traits::prices_fetcher::{PairPriceData, PricePoint, PricesFetcher},
+};
+
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+pub struct AlphaVantagePriceData {
+    #[serde(rename = "05. price", deserialize_with = "as_f64")]
+    pub price: f64,
+
+    #[serde(rename = "06. volume", deserialize_with = "as_f64")]
+    pub volume: f64,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+pub struct AlphaVantageResponse {
+    #[serde(rename = "Global Quote")]
+    pub global_quote: AlphaVantagePriceData,
+}
+
+pub struct AlphaVantagePriceFetcher<'a> {
+    pub symbols: &'a [String],
+}
+
+impl<'a> PricesFetcher<'a> for AlphaVantagePriceFetcher<'a> {
+    const NAME: &'static str = "AlphaVantage";
+
+    fn new(symbols: &'a [String]) -> Self {
+        Self { symbols }
+    }
+
+    fn fetch(&self) -> LocalBoxFuture<Result<PairPriceData>> {
+        async {
+            let prices_futures = self
+                .symbols
+                .iter()
+                .map(Deref::deref)
+                .map(fetch_price_for_symbol);
+
+            let mut futures = FuturesUnordered::from_iter(prices_futures);
+            let mut prices = PairPriceData::new();
+
+            while let Some(result) = futures.next().await {
+                match result {
+                    Ok((symbol, price_point)) => {
+                        prices.insert(symbol, price_point);
+                    }
+                    Err(err) => {
+                        eprintln!("Fetching price from {:?} failed: {:?}", Self::NAME, err);
+                    }
+                }
+            }
+
+            if prices.is_empty() {
+                return Err(Error::msg("No prices fetched. Rate limit exceeded?"));
+            }
+            Ok(prices)
+        }
+        .boxed_local()
+    }
+}
+
+pub async fn fetch_price_for_symbol(symbol: &str) -> Result<(String, PricePoint)> {
+    let url = "https://www.alphavantage.co/query".to_string();
+    let response = http_get_json::<AlphaVantageResponse>(
+        &url,
+        Some(&[
+            ("function", "GLOBAL_QUOTE"),
+            ("symbol", symbol),
+            ("apikey", "demo"), //TODO:(EmilIvanichkovv): replace with real API key
+        ]),
+    )
+    .await;
+
+    match response {
+        Ok(response) => Ok((
+            symbol.to_string(),
+            PricePoint {
+                price: response.global_quote.price,
+                volume: response.global_quote.volume,
+            },
+        )),
+        Err(err) => Err(Error::msg(format!(
+            "Error fetching price for symbol {symbol}: {err}"
+        ))),
+    }
+}

--- a/apps/oracles/stock-price-feeds/src/providers/mod.rs
+++ b/apps/oracles/stock-price-feeds/src/providers/mod.rs
@@ -1,1 +1,2 @@
 pub mod alpha_vantage;
+pub mod yahoo_finance;

--- a/apps/oracles/stock-price-feeds/src/providers/mod.rs
+++ b/apps/oracles/stock-price-feeds/src/providers/mod.rs
@@ -1,0 +1,1 @@
+pub mod alpha_vantage;

--- a/apps/oracles/stock-price-feeds/src/providers/yahoo_finance.rs
+++ b/apps/oracles/stock-price-feeds/src/providers/yahoo_finance.rs
@@ -1,0 +1,102 @@
+use anyhow::{Error, Result};
+use futures::{future::LocalBoxFuture, FutureExt};
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use blocksense_sdk::{
+    http::http_get_json,
+    traits::prices_fetcher::{PairPriceData, PricePoint, PricesFetcher},
+};
+
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PriceData {
+    pub symbol: String,
+    pub regular_market_previous_close: Option<f64>,
+    pub regular_market_price: Option<f64>,
+    pub regular_market_volume: Option<f64>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuoteResponse {
+    pub result: Vec<PriceData>,
+    pub error: Value,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct YFResponse {
+    pub quote_response: Option<QuoteResponse>,
+}
+
+pub struct YFPriceFetcher<'a> {
+    pub symbols: &'a [String],
+    api_key: Option<&'a str>,
+}
+
+impl<'a> PricesFetcher<'a> for YFPriceFetcher<'a> {
+    const NAME: &'static str = "YahooFinance";
+
+    fn new(symbols: &'a [String], api_key: Option<&'a str>) -> Self {
+        Self { symbols, api_key }
+    }
+
+    fn fetch(&self) -> LocalBoxFuture<Result<PairPriceData>> {
+        async {
+            let api_key = match self.api_key {
+                Some(key) => key,
+                None => {
+                    return Err(Error::msg("API key is required for YahooFinance"));
+                }
+            };
+
+            let all_symbols = self.symbols.join(",");
+
+            let response = http_get_json::<YFResponse>(
+                "https://yfapi.net/v6/finance/quote",
+                Some(&[("symbols", all_symbols.as_str())]),
+                Some(&[("x-api-key", api_key)]),
+            )
+            .await?;
+
+            let results = response
+                .quote_response
+                .ok_or_else(|| Error::msg("YahooFinance: No quote response"))?
+                .result
+                .into_iter()
+                .filter_map(|value| {
+                    let price = value
+                        .regular_market_price
+                        .or(value.regular_market_previous_close);
+
+                    let volume = value.regular_market_volume;
+
+                    match (price, volume) {
+                        (Some(price), Some(volume)) => {
+                            Some((value.symbol, PricePoint { price, volume }))
+                        }
+                        _ => {
+                            eprintln!(
+                                "[YahooFinance] Skipping symbol {}: missing {}{}{}",
+                                value.symbol,
+                                if price.is_none() { "price" } else { "" },
+                                if price.is_none() && volume.is_none() {
+                                    " and "
+                                } else {
+                                    ""
+                                },
+                                if volume.is_none() { "volume" } else { "" },
+                            );
+                            None
+                        }
+                    }
+                })
+                .collect();
+
+            Ok(results)
+        }
+        .boxed_local()
+    }
+}

--- a/apps/oracles/stock-price-feeds/src/types.rs
+++ b/apps/oracles/stock-price-feeds/src/types.rs
@@ -1,0 +1,63 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use blocksense_sdk::traits::prices_fetcher::{PairPriceData, PricePoint, TradingPairSymbol};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Pair {
+    pub base: String,
+    pub quote: String,
+}
+
+pub type ProviderName = String;
+
+// A mapping of provider names to the respective symbols they support
+pub type ProvidersSymbols = HashMap<ProviderName, Vec<String>>;
+
+// A mapping of provider names to information about the price
+pub type ProvidersPricePoints = HashMap<ProviderName, PricePoint>;
+
+#[derive(Clone, Debug)]
+pub struct ProviderPriceData {
+    pub name: ProviderName,
+    pub data: PairPriceData,
+}
+
+/* Feed configuration data related types */
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProvidersConfig {
+    pub providers: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FeedConfigData {
+    pub pair: Pair,
+    pub arguments: ProvidersConfig,
+}
+
+/*  Oracle resource data related types */
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ResourcePairData {
+    pub pair: Pair,
+    pub id: String,
+}
+
+#[derive(Debug)]
+pub struct ResourceData {
+    pub pairs: Vec<ResourcePairData>,
+    pub symbols: ProvidersSymbols,
+}
+
+/* Oracle results related types */
+
+#[derive(Debug, Default)]
+pub struct DataFeedResult {
+    pub symbol: String,
+    pub providers_data: ProvidersPricePoints,
+}
+
+// A mapping of feed pairs to their respective results
+pub type PairToResults = HashMap<TradingPairSymbol, DataFeedResult>;

--- a/apps/oracles/stock-price-feeds/src/types.rs
+++ b/apps/oracles/stock-price-feeds/src/types.rs
@@ -51,6 +51,8 @@ pub struct ResourceData {
     pub symbols: ProvidersSymbols,
 }
 
+pub type Capabilities = HashMap<String, String>;
+
 /* Oracle results related types */
 
 #[derive(Debug, Default)]

--- a/apps/oracles/stock-price-feeds/src/utils.rs
+++ b/apps/oracles/stock-price-feeds/src/utils.rs
@@ -1,0 +1,5 @@
+use crate::types::Capabilities;
+
+pub fn get_api_key<'a>(capabilities: Option<&'a Capabilities>, key: &str) -> Option<&'a str> {
+    capabilities.and_then(|c| c.get(key)).map(|s| s.as_str())
+}

--- a/config/feeds_config_v2.json
+++ b/config/feeds_config_v2.json
@@ -53152,7 +53152,17 @@
         "decimals": 8,
         "category": "Equities",
         "market_hours": "US_Equities",
-        "arguments": {}
+        "arguments": {
+          "providers": [
+            "AlphaVantage",
+            "PolygonIO",
+            "Finnhum",
+            "YahooFinance",
+            "twelvedata",
+            "Tiingo",
+            "FMP"
+          ]
+        }
       }
     },
     {
@@ -53181,7 +53191,17 @@
         "decimals": 8,
         "category": "Equities",
         "market_hours": "US_Equities",
-        "arguments": {}
+        "arguments": {
+          "providers": [
+            "AlphaVantage",
+            "PolygonIO",
+            "Finnhum",
+            "YahooFinance",
+            "twelvedata",
+            "Tiingo",
+            "FMP"
+          ]
+        }
       }
     }
   ]


### PR DESCRIPTION
This PR introduces the first functional version of the `stock-price-feeds` oracle.

---

### Core Features

- Implements the main oracle pipeline:
  - Fetches data from multiple providers concurrently.
  - Computes VWAP from provider-level price points.
  - Outputs payloads in the standard `blocksense-sdk` format.

- Adds support for two providers:
  - **AlphaVantage** ( end-of-day data, little daily requests )
  - **YahooFinance** ( real-time data )

Both fetchers read their respective API keys from the `capabilities` section of `Settings`.

---

### SDK & Utility Enhancements

- Generalizes the `PricesFetcher` trait to accept an optional `api_key`.
- Introduces a helper `get_api_key(...)` to extract provider credentials.
- Adds support for optional HTTP headers in `http_get_json(...)`.

---

### Configuration and Setup

- Adds initial feed configuration to `spin.toml` and `feeds_config_v2.json`, including `providers` under `arguments`.
- Declares outbound hosts for both providers.
- Introduces the `Capabilities` type and propagates it through the fetch pipeline.
- Adds dependencies: `futures` and `itertools`.

---

This PR sets the foundation for extending `stock-price-feeds` with additional providers in future iterations.