### PR TITLE
[nft/refactor]: Organize `Intersection Observer functionality` to prevent `Code Duplication`

### DIFF
--- a/apps/nft.blocksense.network/components/About.tsx
+++ b/apps/nft.blocksense.network/components/About.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 
 import aboutVector from '/public/images/about-vector.svg';
@@ -13,6 +12,8 @@ import bsxParrotMobile from '/public/images/bsx-parrot-mobile.png';
 import bsxRobotMobile from '/public/images/bsx-robot-mobile.png';
 import bsxWarriorMobile from '/public/images/bsx-warrior-mobile.png';
 
+import { useRevealOnView } from 'hooks/useRevealOnView';
+
 export const About = () => {
   return (
     <>
@@ -23,27 +24,11 @@ export const About = () => {
 };
 
 const AboutDesktop = () => {
-  const [inView, setInView] = useState(false);
-  const desktopRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        setInView(entry?.isIntersecting ?? false);
-      },
-      { threshold: 0.1 },
-    );
-
-    if (desktopRef.current) observer.observe(desktopRef.current);
-
-    return () => {
-      if (desktopRef.current) observer.unobserve(desktopRef.current);
-    };
-  }, []);
+  const { targetRef, show } = useRevealOnView();
 
   return (
     <section
-      ref={desktopRef}
+      ref={targetRef}
       className="hidden md:block px-20 relative py-[7.75rem]"
     >
       <Image
@@ -57,14 +42,14 @@ const AboutDesktop = () => {
       <section className="about about--desktop max-w-[59.125rem] mx-auto">
         <header
           className={`about__row about__row--top flex justify-between gap-4 items-center mb-[4rem] transition-all duration-800 ease-out transform origin-bottom ${
-            inView
+            show
               ? 'opacity-100 translate-y-0 scale-100'
               : 'opacity-0 translate-y-12 scale-95'
           }`}
         >
           <section
             className={`about__text about__text--left max-w-[28.875rem] transition-all duration-800 ease-out ${
-              inView
+              show
                 ? 'delay-[180ms] opacity-100 translate-y-0'
                 : 'opacity-0 translate-y-6'
             }`}
@@ -91,7 +76,7 @@ const AboutDesktop = () => {
             src={bsxPirate}
             alt="Pirate NFT"
             className={`about__image max-w-max transition-all duration-800 ease-out ${
-              inView
+              show
                 ? 'delay-[350ms] opacity-100 translate-y-0'
                 : 'opacity-0 translate-y-6'
             }`}
@@ -102,7 +87,7 @@ const AboutDesktop = () => {
         <article className="about__row about__row--bottom flex justify-between gap-4 items-center">
           <section
             className={`about__gallery max-w-[30.75rem] flex gap-[1.25rem] transition-all duration-800 ease-out ${
-              inView
+              show
                 ? 'delay-[500ms] opacity-100 translate-y-0'
                 : 'opacity-0 translate-y-6'
             }`}
@@ -133,7 +118,7 @@ const AboutDesktop = () => {
           </section>
           <aside
             className={`about__details max-w-[22.688rem] mx-auto transition-all duration-800 ease-out ${
-              inView
+              show
                 ? 'delay-[650ms] opacity-100 translate-y-0'
                 : 'opacity-0 translate-y-6'
             }`}
@@ -151,32 +136,16 @@ const AboutDesktop = () => {
 };
 
 const AboutMobile = () => {
-  const [inView, setInView] = useState(false);
-  const mobileRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        setInView(entry?.isIntersecting ?? false);
-      },
-      { threshold: 0.1 },
-    );
-
-    if (mobileRef.current) observer.observe(mobileRef.current);
-
-    return () => {
-      if (mobileRef.current) observer.unobserve(mobileRef.current);
-    };
-  }, []);
+  const { targetRef, show } = useRevealOnView();
 
   return (
     <section
-      ref={mobileRef}
+      ref={targetRef}
       className="about about--mobile md:hidden px-5 py-12 flex flex-col gap-12"
     >
       <header
         className={`about__text transition-all duration-800 ease-out ${
-          inView
+          show
             ? 'opacity-100 translate-y-0 delay-[180ms]'
             : 'opacity-0 translate-y-6'
         }`}
@@ -202,7 +171,7 @@ const AboutMobile = () => {
         src={bsxPirate}
         alt="Pirate NFT Mobile"
         className={`about__image w-full transition-all duration-800 ease-out ${
-          inView
+          show
             ? 'opacity-100 translate-y-0 delay-[350ms]'
             : 'opacity-0 translate-y-6'
         }`}
@@ -211,7 +180,7 @@ const AboutMobile = () => {
       />
       <footer
         className={`about__details transition-all duration-800 ease-out ${
-          inView
+          show
             ? 'opacity-100 translate-y-0 delay-[500ms]'
             : 'opacity-0 translate-y-6'
         }`}
@@ -224,7 +193,7 @@ const AboutMobile = () => {
       </footer>
       <div
         className={`about__gallery flex flex-col gap-4 w-full transition-all duration-800 ease-out ${
-          inView
+          show
             ? 'opacity-100 translate-y-0 delay-[650ms]'
             : 'opacity-0 translate-y-6'
         }`}

--- a/apps/nft.blocksense.network/components/CTA.tsx
+++ b/apps/nft.blocksense.network/components/CTA.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import Image from 'next/image';
-import { useEffect, useRef, useState } from 'react';
 
 import { Button } from 'components/Button';
 import bgCtaDesktop from '/public/images/bg-cta-desktop.png';
+
+import { useRevealOnView } from 'hooks/useRevealOnView';
 
 export const CTA = () => {
   return (
@@ -15,37 +16,11 @@ export const CTA = () => {
   );
 };
 
-const useRevealOnView = (threshold = 0.5) => {
-  const ref = useRef<HTMLDivElement | null>(null);
-  const [show, setShow] = useState(false);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      entries => {
-        const entry = entries[0];
-        if (entry) {
-          setShow(entry.isIntersecting);
-        }
-      },
-      { threshold },
-    );
-
-    const currentRef = ref.current;
-    if (currentRef) observer.observe(currentRef);
-
-    return () => {
-      if (currentRef) observer.unobserve(currentRef);
-    };
-  }, [threshold]);
-
-  return { ref, show };
-};
-
 const CTADesktop = () => {
-  const { ref, show } = useRevealOnView();
+  const { targetRef, show } = useRevealOnView(0.5);
 
   return (
-    <section ref={ref} className="cta cta-desktop p-8 hidden md:block">
+    <section ref={targetRef} className="cta cta-desktop p-8 hidden md:block">
       <section
         className={`cta-desktop__container bg-[var(--gray-dark)] px-12 py-16 rounded-3xl max-w-[71.25rem] mx-auto relative transition-all duration-1000 ease-out transform will-change-transform ${
           show
@@ -125,11 +100,11 @@ const CTADesktop = () => {
 };
 
 const CTAMobile = () => {
-  const { ref, show } = useRevealOnView();
+  const { targetRef, show } = useRevealOnView(0.5);
 
   return (
     <section
-      ref={ref}
+      ref={targetRef}
       className={`cta cta--mobile md:hidden bg-[var(--gray-dark)] my-12 rounded-2xl mx-5 transition-all duration-700 ease-[cubic-bezier(0.4,0,0.2,1)] transform will-change-transform ${
         show ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
       }`}

--- a/apps/nft.blocksense.network/components/Footer.tsx
+++ b/apps/nft.blocksense.network/components/Footer.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
-
 import { Logo } from './Logo';
 import { SocialNetworks } from './SocialNetworks';
+
+import { useRevealOnView } from 'hooks/useRevealOnView';
 
 const links = [
   { name: 'Blog', href: 'https://blog.blocksense.network/' },
@@ -13,35 +13,11 @@ const links = [
 ];
 
 export const Footer = () => {
-  const [inView, setInView] = useState(false);
-  const footerRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry?.isIntersecting) {
-          setInView(true);
-        } else {
-          setInView(false);
-        }
-      },
-      { threshold: 0.1 },
-    );
-
-    if (footerRef.current) {
-      observer.observe(footerRef.current);
-    }
-
-    return () => {
-      if (footerRef.current) {
-        observer.unobserve(footerRef.current);
-      }
-    };
-  }, []);
+  const { targetRef, show } = useRevealOnView();
 
   return (
     <footer
-      ref={footerRef}
+      ref={targetRef}
       className="footer text-[var(--white)] px-5 pt-12 pb-12 md:px-20 md:pt-16 md:pb-12"
       role="contentinfo"
     >
@@ -49,7 +25,7 @@ export const Footer = () => {
         <section className="footer__top flex flex-col gap-8 md:flex-row md:justify-between md:items-start md:gap-0">
           <header
             className={`footer__logo mb-8 md:mb-0 transition-all duration-800 ease-out transform origin-bottom ${
-              inView
+              show
                 ? 'opacity-100 translate-y-0 scale-100'
                 : 'opacity-0 translate-y-12 scale-90'
             }`}
@@ -61,7 +37,7 @@ export const Footer = () => {
               {links.map((link, i) => (
                 <li
                   className={`footer__nav-item transition-all duration-800 ease-out transform origin-bottom ${
-                    inView
+                    show
                       ? `opacity-100 translate-y-0 scale-100 delay-[${(i + 1) * 150}ms]`
                       : 'opacity-0 translate-y-12 scale-90'
                   }`}
@@ -83,7 +59,7 @@ export const Footer = () => {
         <section className="footer__bottom mt-12 flex flex-col gap-8 md:flex-row md:justify-between md:items-center md:gap-0">
           <aside
             className={`footer__social-networks self-start md:self-auto md:ml-auto transition-all duration-800 ease-out transform origin-bottom ${
-              inView
+              show
                 ? 'opacity-100 translate-y-0 scale-100'
                 : 'opacity-0 translate-y-12 scale-90'
             }`}
@@ -92,7 +68,7 @@ export const Footer = () => {
           </aside>
           <p
             className={`footer__copyright not-italic text-sm text-[var(--gray-medium)] md:order-first transition-all duration-800 ease-out transform origin-bottom ${
-              inView
+              show
                 ? 'opacity-100 translate-y-0 scale-100'
                 : 'opacity-0 translate-y-12 scale-90'
             }`}

--- a/apps/nft.blocksense.network/components/Form.tsx
+++ b/apps/nft.blocksense.network/components/Form.tsx
@@ -4,25 +4,11 @@ import { useState, useEffect, useRef } from 'react';
 import { MintForm } from './MintForm';
 import { SuccessForm } from './SuccessForm';
 
-export const Form = () => {
-  const [inView, setInView] = useState(false);
-  const [showSuccess, setShowSuccess] = useState(false);
-  const ref = useRef<HTMLDivElement | null>(null);
+import { useRevealOnView } from 'hooks/useRevealOnView';
 
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry) {
-          setInView(entry.isIntersecting);
-        }
-      },
-      { threshold: 0.1 },
-    );
-    if (ref.current) observer.observe(ref.current);
-    return () => {
-      if (ref.current) observer.unobserve(ref.current);
-    };
-  }, []);
+export const Form = () => {
+  const [showSuccess, setShowSuccess] = useState(false);
+  const { targetRef, show } = useRevealOnView();
 
   const onSuccess = () => {
     setShowSuccess(true);
@@ -31,7 +17,7 @@ export const Form = () => {
   return (
     <section className="form md:p-20 px-5 py-8" id="mint-form">
       <article
-        ref={ref}
+        ref={targetRef}
         className="form__article max-w-[32.75rem] mx-auto flex flex-col items-center justify-center md:gap-12 gap-8"
       >
         <h2 className="form__title text-center">
@@ -39,7 +25,7 @@ export const Form = () => {
         </h2>
         <div
           className={`transition-all ease-out transform duration-1000 ${
-            inView ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
+            show ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
           } delay-200`}
         >
           <MintForm onSuccessAction={onSuccess} />

--- a/apps/nft.blocksense.network/components/Hero.tsx
+++ b/apps/nft.blocksense.network/components/Hero.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 
 import { ClaimNFTButton } from './ClaimNFTButton';
 import heroVector from '/public/images/hero-vector.svg';
 import heroPirateFlag from '/public/images/hero-pirate-flag.png';
 import heroPirateFlagMobile from '/public/images/hero-pirate-flag-mobile.png';
+
+import { useRevealOnView } from 'hooks/useRevealOnView';
 
 export const Hero = () => {
   return (
@@ -18,23 +19,11 @@ export const Hero = () => {
 };
 
 const HeroDesktop = () => {
-  const [inView, setInView] = useState(false);
-  const ref = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => setInView(entry?.isIntersecting ?? false),
-      { threshold: 0.1 },
-    );
-    if (ref.current) observer.observe(ref.current);
-    return () => {
-      if (ref.current) observer.unobserve(ref.current);
-    };
-  }, []);
+  const { targetRef, show } = useRevealOnView();
 
   return (
     <section
-      ref={ref}
+      ref={targetRef}
       className="hidden md:block relative px-20 pb-8 pt-[4.672rem]"
     >
       <Image
@@ -49,7 +38,7 @@ const HeroDesktop = () => {
         <article className="hero flex gap-[1.625rem] justify-between pb-20">
           <section
             className={`flex-1 flex flex-col gap-10 justify-between max-w-[36rem] transition-all duration-[700ms] ease-out ${
-              inView
+              show
                 ? 'opacity-100 translate-x-0 delay-75'
                 : 'opacity-0 -translate-x-8'
             }`}
@@ -61,7 +50,7 @@ const HeroDesktop = () => {
           </section>
           <p
             className={`flex-1 max-w-[27rem] pt-[0.75rem] transition-all duration-[700ms] ease-out ${
-              inView
+              show
                 ? 'opacity-100 translate-x-0 delay-150'
                 : 'opacity-0 translate-x-8'
             }`}
@@ -79,7 +68,7 @@ const HeroDesktop = () => {
           src={heroPirateFlag}
           alt="Hero Pirate Flag"
           className={`w-full max-w-[71.25rem] mt-8 transition-all duration-[700ms] ease-out ${
-            inView
+            show
               ? 'opacity-100 translate-y-0 delay-250'
               : 'opacity-0 translate-y-8'
           }`}
@@ -93,28 +82,16 @@ const HeroDesktop = () => {
 };
 
 const HeroMobile = () => {
-  const [inView, setInView] = useState(false);
-  const ref = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => setInView(entry?.isIntersecting ?? false),
-      { threshold: 0.1 },
-    );
-    if (ref.current) observer.observe(ref.current);
-    return () => {
-      if (ref.current) observer.unobserve(ref.current);
-    };
-  }, []);
+  const { targetRef, show } = useRevealOnView();
 
   return (
     <article
-      ref={ref}
+      ref={targetRef}
       className="md:hidden flex flex-col gap-[2.188rem] px-5 pt-[2.172rem] pb-12"
     >
       <h1
         className={`text-[2rem] transition-all duration-[700ms] ease-out ${
-          inView
+          show
             ? 'opacity-100 -translate-x-0 delay-75'
             : 'opacity-0 -translate-x-8'
         }`}
@@ -125,7 +102,7 @@ const HeroMobile = () => {
         src={heroPirateFlagMobile}
         alt="Hero Pirate Flag Mobile"
         className={`mx-auto w-full transition-all duration-[700ms] ease-out ${
-          inView
+          show
             ? 'opacity-100 -translate-y-0 delay-150'
             : 'opacity-0 -translate-y-8'
         }`}
@@ -135,7 +112,7 @@ const HeroMobile = () => {
       />
       <p
         className={`transition-all duration-[700ms] ease-out ${
-          inView
+          show
             ? 'opacity-100 translate-x-0 delay-250'
             : 'opacity-0 translate-x-8'
         }`}
@@ -150,7 +127,7 @@ const HeroMobile = () => {
       </p>
       <div
         className={`transition-all duration-[700ms] ease-out ${
-          inView
+          show
             ? 'opacity-100 -translate-x-0 delay-350'
             : 'opacity-0 -translate-x-8'
         }`}

--- a/apps/nft.blocksense.network/hooks/useRevealOnView.ts
+++ b/apps/nft.blocksense.network/hooks/useRevealOnView.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef, useState, RefObject } from 'react';
+
+type UseRevealOnViewReturn = {
+  targetRef: RefObject<HTMLDivElement>;
+  show: boolean;
+};
+
+export const useRevealOnView = (
+  threshold: number = 0.1,
+): UseRevealOnViewReturn => {
+  const targetRef = useRef<HTMLDivElement>(null);
+  const [show, setShow] = useState<boolean>(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      entries => {
+        const entry = entries[0];
+        if (entry) {
+          setShow(entry.isIntersecting);
+        }
+      },
+      { threshold },
+    );
+
+    if (targetRef.current) observer.observe(targetRef.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return { targetRef, show };
+};


### PR DESCRIPTION
## Pull Request Description

### Summary

This PR introduces a reusable hook, `useRevealOnView`, to centralize and simplify the logic for triggering animations and bringing elements into view using the `IntersectionObserver` API. Previously, this logic was duplicated across multiple components, including the Hero Section, Form Block, About NFT Section, CTA Section, and Footer. By consolidating this functionality into a single hook, we improve code consistency, maintainability, and readability.

### Changes

1. **Added**: `useRevealOnView.ts` in `/hooks` to encapsulate the `IntersectionObserver` logic.
2. **Updated**: Components (`Hero.tsx`, `Form.tsx`, `About.tsx`, `CTA.tsx`, `Footer.tsx`) to use the new `useRevealOnView` hook.
3. **Removed**: Inline `IntersectionObserver` logic from the above components to eliminate code duplication.

### Usage:

### `useRevealOnView` Hook

---

#### **Parameters**

- **`threshold`** (optional):
  - **Type**: `number`
  - **Default**: `0.1`
  - **Description**: A number between `0` and `1` that specifies how much of the element must be visible in the viewport to trigger the `show` state. For example:
    - `0.1` means 10% of the element must be visible.
    - `1` means the entire element must be visible.
---
#### **Return Values**

The hook returns an object with the following properties:

- **`targetRef`**:
  - **Type**: `RefObject<HTMLDivElement>`
  - **Description**: A `ref` to attach to the element you want to observe.

- **`show`**:
  - **Type**: `boolean`
  - **Description**: A boolean indicating whether the element is currently visible in the viewport.
---

#### **Usage Example**
```tsx
'use client';

import { useRevealOnView } from 'hooks/useRevealOnView';

export const ExampleComponent = () => {
  const { targetRef, show } = useRevealOnView(0.5); // Trigger when 50% of the element is visible

  return (
    <div
      ref={targetRef}
      className={`transition-opacity duration-500 ${
        show ? 'opacity-100' : 'opacity-0'
      }`}
    >
      This content fades in when it comes into view.
    </div>
  );
};