### PR TITLE
fix(services): Change service restart policy from "on-failure" to "always"

### DIFF
--- a/nix/modules/blocksense/backends/systemd.nix
+++ b/nix/modules/blocksense/backends/systemd.nix
@@ -17,7 +17,7 @@ let
         wantedBy = [ "multi-user.target" ];
         serviceConfig = {
           ExecStart = command;
-          Restart = "on-failure";
+          Restart = "always";
         };
       };
     }
@@ -49,7 +49,7 @@ let
             ${blocksense.program} node build --up \
               --from ${cfg.config-files."reporter_config_${name}".path}
           '';
-          Restart = "on-failure";
+          Restart = "always";
         };
       };
     }
@@ -73,7 +73,7 @@ in
           };
           serviceConfig = {
             ExecStart = sequencer.program;
-            Restart = "on-failure";
+            Restart = "always";
           };
         };
       }


### PR DESCRIPTION
Quoting from the systemD man page:
```
`Restart= `

Configures whether the service shall be restarted when the service process exits, is killed, or a timeout is reached. (..)

If set to no (the default), the service will not be restarted
```
https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Restart=

We need to set the restart condition to always, to handle the scenario where one of our services may erroneously exit with code 0 (our services are meant to be continuously running and there are no case where we would expect any of them to “finish successfully”).
