### PR TITLE
[nft]: Add `GoogleAnalytics` and send events

### DIFF
--- a/apps/nft.blocksense.network/app/layout.tsx
+++ b/apps/nft.blocksense.network/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { ReactNode } from 'react';
-import { GoogleTagManager } from '@next/third-parties/google';
+import { GoogleAnalytics, GoogleTagManager } from '@next/third-parties/google';
 
 import { Navbar } from '../components/Navbar';
 import { Footer } from '../components/Footer';
@@ -83,6 +83,7 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
       suppressHydrationWarning
     >
       <GoogleTagManager gtmId="GTM-WB9ZRVTV" />
+      <GoogleAnalytics gaId="G-7E3PF0WSSM" />
       <body className="nft-drop-layout__body">
         <Navbar />
         <main className="nft-drop-layout__main pt-[3.85rem]">{children}</main>

--- a/apps/nft.blocksense.network/components/MintForm.tsx
+++ b/apps/nft.blocksense.network/components/MintForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ChangeEvent, MouseEvent, useState } from 'react';
+import { sendGAEvent } from '@next/third-parties/google';
 
 import { Button } from './Button';
 import { FormStepTitle } from './FormStepTitle';
@@ -32,6 +33,18 @@ export const MintForm = ({ onSuccessAction }: MintFormProps) => {
 
   const onMintClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
+
+    sendGAEvent('event', 'mintButtonClicked', {
+      xHandle,
+      discord,
+      retweetCode,
+    });
+
+    sendGAEvent('event', 'mintedNFT', {
+      xHandle,
+      discord,
+      retweetCode,
+    });
 
     setRetweetCode('');
     // setMintLoading(true);


### PR DESCRIPTION
In reference to [[nft]: Add Google Tag Manager with Next.js](https://github.com/blocksense-network/blocksense/pull/1285)
- add `GoogleAnalytics` and `gaID`
- send two GA events - `mintButtonClicked` & `mintedNFT` with `xHandle`, `discord` and `retweetCode` parameters

![image](https://github.com/user-attachments/assets/b17438c3-f462-4dae-84b9-2322cf788eee)
![image](https://github.com/user-attachments/assets/b4b69969-03a6-47a4-9412-86203f37e5a1)

