### PR TITLE
[onchain-interactions]: Use networkName as Gauge label for prometheus

### DIFF
--- a/libs/ts/onchain-interactions/src/scripts/balance-script.ts
+++ b/libs/ts/onchain-interactions/src/scripts/balance-script.ts
@@ -17,7 +17,7 @@ import express from 'express';
 const balanceGauge = new client.Gauge({
   name: 'eth_account_balance',
   help: 'Ethereum account balance in Ether',
-  labelNames: ['networkName', 'address'],
+  labelNames: ['networkName', 'address', 'rpcUrl'],
 });
 
 function filterSmallBalance(balance: string, threshold = 1e-6): number {
@@ -121,7 +121,7 @@ const main = async (): Promise<void> => {
 
         if (argv.prometheus) {
           balanceGauge.set(
-            { networkName, address },
+            { networkName, address, rpcUrl },
             filterSmallBalance(balance),
           );
         }
@@ -152,7 +152,10 @@ const main = async (): Promise<void> => {
       const { currency } = networkMetadata[networkName];
       console.log(chalk.green(`${networkName}: ${balance} ${currency}`));
       if (argv.prometheus) {
-        balanceGauge.set({ networkName, address }, filterSmallBalance(balance));
+        balanceGauge.set(
+          { networkName, address, rpcUrl },
+          filterSmallBalance(balance),
+        );
       }
     } catch (error) {
       console.error(


### PR DESCRIPTION
Prometheus metrics exposed at http://0.0.0.0:9100/metrics

Before:
HELP eth_account_balance Ethereum account balance in Ether
TYPE eth_account_balance gauge
eth_account_balance{chainId="168587773",address="0xd756119012CcabBC59910dE0ecEbE406B5b952bE"} 9.465554776027217
eth_account_balance{chainId="44787",address="0xd756119012CcabBC59910dE0ecEbE406B5b952bE"} 3.4101056136289887
eth_account_balance{chainId="763373",address="0xd756119012CcabBC59910dE0ecEbE406B5b952bE"} 1.7170801628062853

Now:
HELP eth_account_balance Ethereum account balance in Ether
TYPE eth_account_balance gauge
eth_account_balance{networkName="blast-sepolia",address="0xd756119012CcabBC59910dE0ecEbE406B5b952bE",rpcUrl="https://rpc.ankr.com/blast_testnet_sepolia"} 9.465555730820917
eth_account_balance{networkName="celo-alfajores",address="0xd756119012CcabBC59910dE0ecEbE406B5b952bE",rpcUrl="https://alfajores-forno.celo-testnet.org"} 3.4130250136291056
eth_account_balance{networkName="ink-sepolia",address="0xd756119012CcabBC59910dE0ecEbE406B5b952bE",rpcUrl="https://rpc-gel-sepolia.inkonchain.com"} 1.7170801628062853

