### PR TITLE
Contract library optimisations

### DIFF
--- a/libs/ts/contracts/README.md
+++ b/libs/ts/contracts/README.md
@@ -63,12 +63,12 @@ All read calls must start with the first bit set to 1, where the whole selector 
 - Setter:
   - `0x01`: setFeeds
 - Getters:
-  - `0x86`: getFeedAtRound(uint8 stride, uint120 feedId, uint16 round, uint32 startSlot?, uint32 slots?) returns (bytes)
-  - `0x81`: getLatestRound(uint8 stride, uint120 feedId) returns (uint16)
+  - `0x86`: getDataAtIndex(uint8 stride, uint120 feedId, uint16 index, uint32 startSlot?, uint32 slots?) returns (bytes)
+  - `0x81`: getLatestIndex(uint8 stride, uint120 feedId) returns (uint16)
   - `0x82`: getLatestSingleData(uint8 stride, uint120 feedId) returns (bytes)
   - `0x84`: getLatestData(uint8 stride, uint120 feedId, uint32 startSlot?, uint32 slots?) returns (bytes)
-  - `0x83` will call both **getLatestRound** and **getLatestSingleData**.
-  - `0x85` will call both **getLatestRound** and **getLatestData**.
+  - `0x83` will call both **getLatestIndex** and **getLatestSingleData**.
+  - `0x85` will call both **getLatestIndex** and **getLatestData**.
 
 > [!IMPORTANT]
 > Selector `0x00` is reserved for use by an Upgradeable Proxy:
@@ -79,8 +79,8 @@ All read calls must start with the first bit set to 1, where the whole selector 
 ### Storage layout representation
 
 The slots between 0 and 2\*\*128-2\*\*116 - 1 are considered management slots. These values are used for admin functionality.
-The slots between 2\*\*128-2\*\*116 and 2\*\*128 - 1 are considered Round table slots. These values are used to store the latest round of a feed. Each slot consists of 16 packed rounds (2 bytes each).
-The slots between 2\*\*128 and 2\*\*160 - 1 are considered Data feed slots. Here all data feeds are stored along with their historical data. Data feeds are of different slot sizes based on the stride (powers of 2). For example, stride 0 is 32b (1 slot) data, stride 1 is 64b, stride 2 is 128b and so on. Data feeds have historical data stored up to 8192 rounds. CL-compatible contracts make use of only stride 0 data feeds. There are 32 strides in total (stride 0 to stride 31) which leaves us with 2\*\*115 feed IDs in each stride (2\*\*115 \* 32 feed IDs combined).
+The slots between 2\*\*128-2\*\*116 and 2\*\*128 - 1 are considered Ring buffer index table slots. These values are used to store the latest ring buffer index of a feed. Each slot consists of 16 packed indices (2 bytes each).
+The slots between 2\*\*128 and 2\*\*160 - 1 are considered Data feed slots. Here all data feeds are stored along with their historical data. Data feeds are of different slot sizes based on the stride (powers of 2). For example, stride 0 is 32b (1 slot) data, stride 1 is 64b, stride 2 is 128b and so on. Data feeds have historical data stored up to 8192 indices. CL-compatible contracts make use of only stride 0 data feeds. There are 32 strides in total (stride 0 to stride 31) which leaves us with 2\*\*115 feed IDs in each stride (2\*\*115 \* 32 feed IDs combined).
 
 ### Events
 

--- a/libs/ts/contracts/README.md
+++ b/libs/ts/contracts/README.md
@@ -17,7 +17,7 @@ contracts
 │   ├── ICLAggregatorAdapter.sol
 │   └── ICLFeedRegistryAdapter.sol
 ├── libraries
-│   ├── Blocksense.sol
+│   ├── ADFS.sol
 │   └── CLAdapterLib.sol
 ├── safe
 │   └── OnlySequencerGuard.sol
@@ -37,7 +37,7 @@ The `cl-adapters` folder contains the Chainlink aggregator contract - CLAggregat
 
 The `interfaces` folder contains the interfaces for the Chainlink aggregator contract - IChainlinkAggregator.sol, the data feed store contract - ICLFeedRegistryAdapter.sol, the modified aggregator contract which extends the functionality of IChainlinkAggregator.sol - ICLAggregatorAdapter.sol.
 
-The `libraries` folder contains the Blocksense library which is used to make calls to the upgradeable ADFS proxy. The CLAdapterLib is used by the Chainlink aggregator contracts and the CLFeedRegistryAdapter contract.
+The `libraries` folder contains the ADFS library which is used to make calls to the upgradeable ADFS proxy. The CLAdapterLib is used by the Chainlink aggregator contracts and the CLFeedRegistryAdapter contract.
 
 The `safe` folder contains the OnlySequencerGuard contract which is used to restrict access when writing data to the ADFS contract.
 

--- a/libs/ts/contracts/contracts/AggregatedDataFeedStore.sol
+++ b/libs/ts/contracts/contracts/AggregatedDataFeedStore.sol
@@ -86,7 +86,7 @@ contract AggregatedDataFeedStore {
           )
 
           // `startSlot` and `slots` are used to read a slice from the feed
-          // check `_callSingleDataFeed` in contracts/libraries/Blocksense.sol for more info about `calldatasize`
+          // check `_callSingleDataFeed` in contracts/libraries/ADFS.sol for more info about `calldatasize`
           if gt(calldatasize(), 19) {
             // last index of feed: (feedId + 1) * 2**13 * 2**stride - 1
             let lastFeedIndex := sub(shl(stride, shl(13, add(feedId, 1))), 1)
@@ -191,7 +191,7 @@ contract AggregatedDataFeedStore {
           )
 
           // `startSlot` and `slots` are used to read a slice from the feed
-          // check `_callSingleDataFeed` in contracts/libraries/Blocksense.sol for more info about `calldatasize`
+          // check `_callSingleDataFeed` in contracts/libraries/ADFS.sol for more info about `calldatasize`
           if gt(calldatasize(), 19) {
             // last index of feed: (feedId + 1) * 2**13 * 2**stride - 1
             let lastFeedIndex := sub(shl(stride, shl(13, add(feedId, 1))), 1)

--- a/libs/ts/contracts/contracts/AggregatedDataFeedStore.sol
+++ b/libs/ts/contracts/contracts/AggregatedDataFeedStore.sol
@@ -20,7 +20,7 @@ pragma solidity ^0.8.28;
 contract AggregatedDataFeedStore {
   address internal constant DATA_FEED_ADDRESS =
     0x0000000100000000000000000000000000000000;
-  address internal constant ROUND_ADDRESS =
+  address internal constant RING_BUFFER_TABLE_ADDRESS =
     0x00000000FFf00000000000000000000000000000;
   address internal immutable ACCESS_CONTROL;
 
@@ -35,7 +35,7 @@ contract AggregatedDataFeedStore {
         0x0000 - latest blocknumber
         0x0001 - implementation slot (UpgradeableProxy)
         0x0002 - admin slot (UpgradeableProxy)
-      Round table: [2**128-2**116 to 2**128)
+      Ring buffer index table: [2**128-2**116 to 2**128)
       Data feed space: [2**128 to 2**160)
   */
 
@@ -50,7 +50,7 @@ contract AggregatedDataFeedStore {
       // Load selector from memory
       let selector := calldataload(0x00)
 
-      /* <selector 1b> <stride 1b> <feedId 15b> (<round 2b> <startSlot? 4b> <slots? 4b> | <startSlot? 4b> <slots? 4b>) */
+      /* <selector 1b> <stride 1b> <feedId 15b> (<index 2b> <startSlot? 4b> <slots? 4b> | <startSlot? 4b> <slots? 4b>) */
       if and(
         selector,
         0x8000000000000000000000000000000000000000000000000000000000000000
@@ -67,22 +67,22 @@ contract AggregatedDataFeedStore {
 
         selector := shr(248, selector)
 
-        // getFeedAtRound(uint8 stride, uint120 feedId, uint16 round, uint32 startSlot?, uint32 slots?) returns (bytes)
+        // getDataAtIndex(uint8 stride, uint120 feedId, uint16 index, uint32 startSlot?, uint32 slots?) returns (bytes)
         if eq(selector, 0x86) {
           // how many slots in this stride: 2**stride
           let strideSlots := shl(stride, 1)
-          let round := shr(240, data)
+          let index := shr(240, data)
 
-          // ensure round is in range [0-8192)
-          if gt(round, 0x1fff) {
+          // ensure index is in range [0-8192)
+          if gt(index, 0x1fff) {
             revert(0, 0)
           }
 
           // base feed index: (feedId * 2**13) * 2**stride
-          // find start index for round: baseFeedIndex + round * 2**stride
-          let startIndex := add(
+          // find start slot for ring buffer index: baseFeedIndex + index * 2**stride
+          let startDataIndex := add(
             shl(stride, shl(13, feedId)),
-            shl(stride, round)
+            shl(stride, index)
           )
 
           // `startSlot` and `slots` are used to read a slice from the feed
@@ -93,7 +93,7 @@ contract AggregatedDataFeedStore {
 
             // read startSlot from calldata
             let startSlot := shr(224, shl(16, data))
-            startIndex := add(startIndex, startSlot)
+            startDataIndex := add(startDataIndex, startSlot)
 
             // strideSlots = slots
             strideSlots := shr(224, shl(48, data))
@@ -102,12 +102,12 @@ contract AggregatedDataFeedStore {
             }
 
             // ensure the caller is not trying to read past the end of the feed
-            if gt(add(startIndex, sub(strideSlots, 1)), lastFeedIndex) {
+            if gt(add(startDataIndex, sub(strideSlots, 1)), lastFeedIndex) {
               revert(0, 0)
             }
           }
 
-          let initialPos := add(shl(stride, DATA_FEED_ADDRESS), startIndex)
+          let initialPos := add(shl(stride, DATA_FEED_ADDRESS), startDataIndex)
 
           let len := 0
           let ptr := mload(0x40)
@@ -136,13 +136,13 @@ contract AggregatedDataFeedStore {
         // feedId%16 * 16
         // mod is represented as `feedId % 2^4 = feedId & (2^4 - 1)`
         let pos := shl(4, and(feedId, 15))
-        let round := shr(
+        let index := shr(
           sub(240, pos),
           and(
             sload(
               add(
-                ROUND_ADDRESS,
-                // find round table slot: (2**115 * stride + feedId)/16
+                RING_BUFFER_TABLE_ADDRESS,
+                // find index table slot: (2**115 * stride + feedId)/16
                 shr(4, add(shl(115, stride), feedId))
               )
             ),
@@ -155,24 +155,24 @@ contract AggregatedDataFeedStore {
         let len := 0
         let ptr := mload(0x40)
 
-        // 0x83 will call both getLatestRound and getLatestSingleData
-        // 0x85 will call both getLatestRound and getLatestData
+        // 0x83 will call both getLatestIndex and getLatestSingleData
+        // 0x85 will call both getLatestIndex and getLatestData
 
-        // getLatestRound(uint8 stride, uint120 feedId) returns (uint16)
+        // getLatestIndex(uint8 stride, uint120 feedId) returns (uint16)
         if and(selector, 0x01) {
           len := 32
-          mstore(ptr, round)
+          mstore(ptr, index)
         }
 
         // getLatestSingleData(uint8 stride, uint120 feedId) returns (bytes)
         if and(selector, 0x02) {
-          // find start index for round: feedId * 2**13 + round
-          let startIndex := add(shl(13, feedId), round)
+          // find start index for index: feedId * 2**13 + index
+          let startDataIndex := add(shl(13, feedId), index)
 
           // load feed data from storage and store it in memory
           mstore(
             add(ptr, len),
-            sload(add(shl(stride, DATA_FEED_ADDRESS), startIndex))
+            sload(add(shl(stride, DATA_FEED_ADDRESS), startDataIndex))
           )
 
           return(ptr, add(len, 32))
@@ -184,10 +184,10 @@ contract AggregatedDataFeedStore {
           let strideSlots := shl(stride, 1)
 
           // base feed index: (feedId * 2**13) * 2**stride
-          // find start index for round: baseFeedIndex + round * 2**stride
-          let startIndex := add(
+          // find start index for index: baseFeedIndex + index * 2**stride
+          let startDataIndex := add(
             shl(stride, shl(13, feedId)),
-            shl(stride, round)
+            shl(stride, index)
           )
 
           // `startSlot` and `slots` are used to read a slice from the feed
@@ -198,7 +198,7 @@ contract AggregatedDataFeedStore {
 
             // read startSlot from calldata
             let startSlot := shr(224, data)
-            startIndex := add(startIndex, startSlot)
+            startDataIndex := add(startDataIndex, startSlot)
 
             // strideSlots = slots
             strideSlots := shr(224, shl(32, data))
@@ -207,12 +207,12 @@ contract AggregatedDataFeedStore {
             }
 
             // ensure the caller is not trying to read past the end of the feed
-            if gt(add(startIndex, sub(strideSlots, 1)), lastFeedIndex) {
+            if gt(add(startDataIndex, sub(strideSlots, 1)), lastFeedIndex) {
               revert(0, 0)
             }
           }
 
-          let initialPos := add(shl(stride, DATA_FEED_ADDRESS), startIndex)
+          let initialPos := add(shl(stride, DATA_FEED_ADDRESS), startDataIndex)
 
           for {
             let i := 0
@@ -237,11 +237,11 @@ contract AggregatedDataFeedStore {
     address accessControl = ACCESS_CONTROL;
 
     /*
-                                                                                                                        ┌--------------------- round table data --------------------┐
+                                                                                                                        ┌--------------------- index table data --------------------┐
                                                                                                                         │                                                           │
                                       ┌---------------------- feed 1 ----------------------------┬-- feed 2 .. feed N --┼-------------- row 1 --------------┬---- row 2 .. row N ---┤
       ┌────────┬───────────┬──────────┬──────┬────────────┬──────────────┬────────────┬─────┬────┬──────────────────────┬────────────┬─────┬────────────────┬───────────────────────┐
-      │selector│blocknumber│# of feeds│stride│index length│feedId + round│bytes length│bytes│data│          ..          │index length│index│round table data│           ..          │
+      │selector│blocknumber│# of feeds│stride│index length│feedId + index│bytes length│bytes│data│          ..          │index length│index│index table data│           ..          │
       ├────────┼───────────┼──────────┼──────┼────────────┼──────────────┼────────────┼─────┼────┼──────────────────────┼────────────┼─────┼────────────────┼───────────────────────┤
       │   1b   │    8b     │    4b    │  1b  │     1b     │      Xb      │     1b     │ Yb  │ Zb │          ..          │     1b     │ Xb  │      32b       │           ..          │
       └────────┴───────────┴──────────┴──────┴────────────┴──────────────┴────────────┴─────┴────┴──────────────────────┴────────────┴─────┴────────────────┴───────────────────────┘
@@ -297,13 +297,13 @@ contract AggregatedDataFeedStore {
           feed id 0 │   │   │   │   │   │   │   │   │    feed id 0 │   │   │   │   │   │   │   │   │
                     ├───└───└───└───└───└───└───└───┤              ├───────────────└───────────────┤
                     │                               │              │                               │
-                    │   ...... 2**13 rounds ......  │              │   ...... 2**13 rounds ......  │
+                    │   ..... 2**13 indices ......  │              │   ..... 2**13 indices ......  │
                     │                               │              │                               │
                     ├───┌───┌───┌───┌───┌───┌───┌───┤              ├───────────────┌───────────────┤
           feed id 1 │   │   │   │   │   │   │   │   │    feed id 1 │   │   │   │   │   │   │   │   │
                     ├───└───└───└───└───└───└───└───┤              ├───────────────└───────────────┤
                   . │                               │            . │                               │
-                  . │   ...... 2**13 rounds ......  │            . │   ...... 2**13 rounds ......  │
+                  . │   ..... 2**13 indices ......  │            . │   ..... 2**13 indices ......  │
                     │                               │              │                               │
           feed id N └───────────────────────────────┘    feed id N └───────────────────────────────┘
         */
@@ -320,7 +320,7 @@ contract AggregatedDataFeedStore {
           // get correct stride address based on provided stride
           let strideAddress := shl(stride, DATA_FEED_ADDRESS)
 
-          // get length of index (feedId + round)
+          // get length of index (feedId + index)
           let indexLength := byte(1, metadata)
           // bytes to bits as shift op code works with bits (for next line)
           let indexLengthBits := shl(3, indexLength)
@@ -375,12 +375,12 @@ contract AggregatedDataFeedStore {
           }
         }
 
-        ///////////////////////////////////
-        //       Update round table      //
-        ///////////////////////////////////
+        ////////////////////////////////////
+        // Update ring buffer index table //
+        ////////////////////////////////////
         /*
                               ┌───────────────────────────────────────────────────────────────┐
-                              │                      latest round table                       │
+                              │                latest ring buffer index table                 │
                               │───────────────────────────────────────────────────────────────│
                               ├───┌───┌───┌───┌───┌───┌───┌───┌───┌───┌───┌───┌───┌───┌───┌───┤slot 0
                 feed ids 0-15 │2b │2b │2b │ . │ . │ . │ . │ . │ . │ . │ . │ . │ . │2b │2b │2b │
@@ -398,27 +398,25 @@ contract AggregatedDataFeedStore {
 
                                 max id: (2**115)*32-1                        max slot index: 2**116-1
         */
+        // This is where the latest ring buffer index for each feed id is stored
         for {
 
         } lt(pointer, len) {
           pointer := add(pointer, 0x20)
         } {
-          let roundTableData := calldataload(pointer)
+          let indexTableData := calldataload(pointer)
           // how many bytes to read for index (max: 15b)
-          let indexLength := byte(0, roundTableData)
-          // get round table index at which to store rounds
-          let index := shr(
-            sub(256, shl(3, indexLength)),
-            shl(8, roundTableData)
-          )
-          // index must always be less than 2**116
-          if gt(index, 0xfffffffffffffffffffffffffffff) {
+          let indexLength := byte(0, indexTableData)
+          // get slot at which to store latest ring buffer indices
+          let slot := shr(sub(256, shl(3, indexLength)), shl(8, indexTableData))
+          // slot must always be less than 2**116
+          if gt(slot, 0xfffffffffffffffffffffffffffff) {
             revert(0, 0)
           }
 
-          // update pointer to start start of round data
+          // update pointer to start start of index data
           pointer := add(pointer, add(indexLength, 1))
-          sstore(add(ROUND_ADDRESS, index), calldataload(pointer))
+          sstore(add(RING_BUFFER_TABLE_ADDRESS, slot), calldataload(pointer))
         }
 
         ///////////////////////////////////

--- a/libs/ts/contracts/contracts/cl-adapters/CLAggregatorAdapter.sol
+++ b/libs/ts/contracts/contracts/cl-adapters/CLAggregatorAdapter.sol
@@ -35,7 +35,7 @@ contract CLAggregatorAdapter is ICLAggregatorAdapter {
   ) {
     description = _description;
     decimals = _decimals;
-    ID = CLAdapterLib._shiftId(_id);
+    ID = CLAdapterLib.shiftId(_id);
     dataFeedStore = _dataFeedStore;
   }
 
@@ -46,12 +46,12 @@ contract CLAggregatorAdapter is ICLAggregatorAdapter {
 
   /// @inheritdoc IChainlinkAggregator
   function latestAnswer() external view override returns (int256) {
-    return CLAdapterLib._latestAnswer(ID, dataFeedStore);
+    return CLAdapterLib.latestAnswer(ID, dataFeedStore);
   }
 
   /// @inheritdoc IChainlinkAggregator
   function latestRound() external view override returns (uint256) {
-    return CLAdapterLib._latestRound(ID, dataFeedStore);
+    return CLAdapterLib.latestRound(ID, dataFeedStore);
   }
 
   /// @inheritdoc IChainlinkAggregator
@@ -61,13 +61,13 @@ contract CLAggregatorAdapter is ICLAggregatorAdapter {
     override
     returns (uint80, int256, uint256, uint256, uint80)
   {
-    return CLAdapterLib._latestRoundData(ID, dataFeedStore);
+    return CLAdapterLib.latestRoundData(ID, dataFeedStore);
   }
 
   /// @inheritdoc IChainlinkAggregator
   function getRoundData(
     uint80 _roundId
   ) external view override returns (uint80, int256, uint256, uint256, uint80) {
-    return CLAdapterLib._getRoundData(_roundId, ID, dataFeedStore);
+    return CLAdapterLib.getRoundData(_roundId, ID, dataFeedStore);
   }
 }

--- a/libs/ts/contracts/contracts/cl-adapters/registries/CLFeedRegistryAdapter.sol
+++ b/libs/ts/contracts/contracts/cl-adapters/registries/CLFeedRegistryAdapter.sol
@@ -48,8 +48,7 @@ contract CLFeedRegistryAdapter is ICLFeedRegistryAdapter {
     address base,
     address quote
   ) external view override returns (int256) {
-    return
-      CLAdapterLib._latestAnswer(feedData[base][quote].id, DATA_FEED_STORE);
+    return CLAdapterLib.latestAnswer(feedData[base][quote].id, DATA_FEED_STORE);
   }
 
   /// @inheritdoc IChainlinkFeedRegistry
@@ -59,7 +58,7 @@ contract CLFeedRegistryAdapter is ICLFeedRegistryAdapter {
     uint80 _roundId
   ) external view override returns (uint80, int256, uint256, uint256, uint80) {
     return
-      CLAdapterLib._getRoundData(
+      CLAdapterLib.getRoundData(
         _roundId,
         feedData[base][quote].id,
         DATA_FEED_STORE
@@ -84,7 +83,7 @@ contract CLFeedRegistryAdapter is ICLFeedRegistryAdapter {
       feedData[feeds[i].base][feeds[i].quote] = FeedData(
         IChainlinkAggregator(feeds[i].feed),
         ICLAggregatorAdapter(feeds[i].feed).decimals(),
-        CLAdapterLib._shiftId(ICLAggregatorAdapter(feeds[i].feed).id()),
+        CLAdapterLib.shiftId(ICLAggregatorAdapter(feeds[i].feed).id()),
         ICLAggregatorAdapter(feeds[i].feed).description()
       );
     }
@@ -95,7 +94,7 @@ contract CLFeedRegistryAdapter is ICLFeedRegistryAdapter {
     address base,
     address quote
   ) external view override returns (uint256) {
-    return CLAdapterLib._latestRound(feedData[base][quote].id, DATA_FEED_STORE);
+    return CLAdapterLib.latestRound(feedData[base][quote].id, DATA_FEED_STORE);
   }
 
   /// @inheritdoc IChainlinkFeedRegistry
@@ -104,6 +103,6 @@ contract CLFeedRegistryAdapter is ICLFeedRegistryAdapter {
     address quote
   ) external view override returns (uint80, int256, uint256, uint256, uint80) {
     return
-      CLAdapterLib._latestRoundData(feedData[base][quote].id, DATA_FEED_STORE);
+      CLAdapterLib.latestRoundData(feedData[base][quote].id, DATA_FEED_STORE);
   }
 }

--- a/libs/ts/contracts/contracts/libraries/ADFS.sol
+++ b/libs/ts/contracts/contracts/libraries/ADFS.sol
@@ -13,11 +13,11 @@ pragma solidity ^0.8.28;
 // Website:         https://blocksense.network/
 // Git Repository:  https://github.com/blocksense-network/blocksense
 
-/// @title Blocksense
+/// @title ADFS
 /// @author Aneta Tsvetkova
 /// @notice Library for calling dataFeedStore functions
 /// @dev Contains utility functions for calling gas efficiently dataFeedStore functions and decoding return data
-library Blocksense {
+library ADFS {
   /// @notice Gets latest single feed data for a given feed from the dataFeedStore
   /// @dev This function reads only stride 0 feeds
   /// @param dataFeedStore The address of the dataFeedStore contract

--- a/libs/ts/contracts/contracts/libraries/CLAdapterLib.sol
+++ b/libs/ts/contracts/contracts/libraries/CLAdapterLib.sol
@@ -154,9 +154,6 @@ library CLAdapterLib {
   ) internal view returns (bytes32 returnData) {
     // using assembly staticcall costs less gas than using a view function
     assembly {
-      // get free memory pointer
-      let ptr := mload(0x40)
-
       // store selector in memory at location 0
       mstore(0x00, selector)
 
@@ -166,7 +163,7 @@ library CLAdapterLib {
         dataFeedStore, // address to call
         0x00, // location of data to call
         19, // size of data to call - usually it is 17b but for _getRoundData it is 19b because of the 2 bytes of the roundId
-        ptr, // where to store the return data
+        returnData, // where to store the return data
         32 // how much data to store
       )
 
@@ -175,8 +172,8 @@ library CLAdapterLib {
         revert(0, 0)
       }
 
-      // assign loaded return value at memory location ptr to returnData
-      returnData := mload(ptr)
+      // assign loaded return value to returnData
+      returnData := mload(returnData)
     }
   }
 

--- a/libs/ts/contracts/contracts/libraries/CLAdapterLib.sol
+++ b/libs/ts/contracts/contracts/libraries/CLAdapterLib.sol
@@ -22,7 +22,7 @@ library CLAdapterLib {
   /// @param dataFeedStore The address of the dataFeedStore contract
   /// @param id The ID of the feed
   /// @return answer The latest stored value after being decoded
-  function _latestAnswer(
+  function latestAnswer(
     uint256 id,
     address dataFeedStore
   ) internal view returns (int256) {
@@ -49,7 +49,7 @@ library CLAdapterLib {
   /// @return startedAt The timestamp when the value was stored
   /// @return updatedAt Same as startedAt
   /// @return answeredInRound Same as roundId
-  function _getRoundData(
+  function getRoundData(
     uint80 _roundId,
     uint256 id,
     address dataFeedStore
@@ -74,7 +74,7 @@ library CLAdapterLib {
   /// @param id The ID of the feed
   /// @param dataFeedStore The address of the dataFeedStore contract
   /// @return roundId The latest round ID
-  function _latestRound(
+  function latestRound(
     uint256 id,
     address dataFeedStore
   ) internal view returns (uint256) {
@@ -95,7 +95,7 @@ library CLAdapterLib {
   /// @return startedAt The timestamp when the value was stored
   /// @return updatedAt Same as startedAt
   /// @return answeredInRound Same as roundId
-  function _latestRoundData(
+  function latestRoundData(
     uint256 id,
     address dataFeedStore
   )
@@ -192,7 +192,7 @@ library CLAdapterLib {
   /// @dev This is used in the constructor to save gas when calling the dataFeedStore
   /// The dataFeedStore expects the feed id to be positioned in the calldata in a 15 bytes value starting from the 3rd byte
   /// @param id The feed id to shift
-  function _shiftId(uint256 id) internal pure returns (uint256) {
+  function shiftId(uint256 id) internal pure returns (uint256) {
     return id << 120;
   }
 }

--- a/libs/ts/contracts/contracts/libraries/CLAdapterLib.sol
+++ b/libs/ts/contracts/contracts/libraries/CLAdapterLib.sol
@@ -31,8 +31,8 @@ library CLAdapterLib {
         uint256(
           uint192(
             bytes24(
-              // 1st 2 bytes are function selector and stride (which is always 0 for CL adapters)
-              // after that are 15 bytes of the feed id
+              // 1st byte is function selector
+              // after that are 16 bytes of the feed id
               _callDataFeed(dataFeedStore, (uint256(0x82) << 248) | id)
             )
           )
@@ -61,8 +61,8 @@ library CLAdapterLib {
     (answer, startedAt) = _decodeData(
       _callDataFeed(
         dataFeedStore,
-        // 1st 2 bytes are function selector and stride (which is always 0 for CL adapters)
-        // after that are 15 bytes of the feed id
+        // 1st byte is function selector
+        // after that are 16 bytes of the feed id
         // after the feed id are 2 bytes of the round id
         (uint256(0x86) << 248) | id | (uint256(_roundId) << 104)
       )
@@ -80,8 +80,8 @@ library CLAdapterLib {
   ) internal view returns (uint256) {
     return
       uint256(
-        // 1st 2 bytes are function selector and stride (which is always 0 for CL adapters)
-        // after that are 15 bytes of the feed id
+        // 1st byte is function selector
+        // after that are 16 bytes of the feed id
         _callDataFeed(dataFeedStore, (uint256(0x81) << 248) | id)
       );
   }
@@ -111,8 +111,8 @@ library CLAdapterLib {
       let ptr := mload(0x40)
 
       // store selector in memory at location 0
-      // 1st 2 bytes are function selector and stride (which is always 0 for CL adapters)
-      // after that are 15 bytes of the feed id
+      // 1st byte is function selector
+      // after that are 16 bytes of the feed id
       mstore(
         0x00,
         or(
@@ -190,7 +190,7 @@ library CLAdapterLib {
 
   /// @notice Shifts the feed id to the left by 120 bits
   /// @dev This is used in the constructor to save gas when calling the dataFeedStore
-  /// The dataFeedStore expects the feed id to be positioned in the calldata in a 15 bytes value starting from the 3rd byte
+  /// The dataFeedStore expects the feed id to be positioned in the calldata in a 16 bytes value starting from the 2nd byte
   /// @param id The feed id to shift
   function shiftId(uint256 id) internal pure returns (uint256) {
     return id << 120;

--- a/libs/ts/contracts/contracts/test/examples/BlocksenseADFSConsumer.sol
+++ b/libs/ts/contracts/contracts/test/examples/BlocksenseADFSConsumer.sol
@@ -18,27 +18,20 @@ contract ADFSConsumer {
     return ADFS.getLatestSingleData(adfs, id);
   }
 
-  function getLatestData(
-    uint256 stride,
-    uint256 id
-  ) external view returns (bytes32[] memory) {
-    return ADFS.getLatestData(adfs, stride, id);
+  function getLatestData(uint256 id) external view returns (bytes32[] memory) {
+    return ADFS.getLatestData(adfs, id);
   }
 
   function getLatestDataSlice(
-    uint256 stride,
     uint256 id,
     uint256 startSlot,
     uint256 slotsCount
   ) external view returns (bytes32[] memory) {
-    return ADFS.getLatestDataSlice(adfs, stride, id, startSlot, slotsCount);
+    return ADFS.getLatestDataSlice(adfs, id, startSlot, slotsCount);
   }
 
-  function getLatestIndex(
-    uint256 stride,
-    uint256 id
-  ) external view returns (uint256 round) {
-    return ADFS.getLatestIndex(adfs, stride, id);
+  function getLatestIndex(uint256 id) external view returns (uint256 index) {
+    return ADFS.getLatestIndex(adfs, id);
   }
 
   function getSingleDataAtIndex(
@@ -49,22 +42,19 @@ contract ADFSConsumer {
   }
 
   function getDataAtIndex(
-    uint256 stride,
     uint256 id,
     uint256 index
   ) external view returns (bytes32[] memory) {
-    return ADFS.getDataAtIndex(adfs, stride, id, index);
+    return ADFS.getDataAtIndex(adfs, id, index);
   }
 
   function getDataSliceAtIndex(
-    uint256 stride,
     uint256 id,
     uint256 index,
     uint256 startSlot,
     uint256 slotsCount
   ) external view returns (bytes32[] memory) {
-    return
-      ADFS.getDataSliceAtIndex(adfs, stride, id, index, startSlot, slotsCount);
+    return ADFS.getDataSliceAtIndex(adfs, id, index, startSlot, slotsCount);
   }
 
   function getLatestSingleDataAndIndex(
@@ -74,20 +64,17 @@ contract ADFSConsumer {
   }
 
   function getLatestDataAndIndex(
-    uint256 stride,
     uint256 id
   ) external view returns (bytes32[] memory data, uint256 index) {
-    return ADFS.getLatestDataAndIndex(adfs, stride, id);
+    return ADFS.getLatestDataAndIndex(adfs, id);
   }
 
   function getLatestDataSliceAndIndex(
-    uint256 stride,
     uint256 id,
     uint256 startSlot,
     uint256 slotsCount
   ) external view returns (bytes32[] memory data, uint256 index) {
-    return
-      ADFS.getLatestDataSliceAndIndex(adfs, stride, id, startSlot, slotsCount);
+    return ADFS.getLatestDataSliceAndIndex(adfs, id, startSlot, slotsCount);
   }
 
   function getEpochSeconds(uint256 id) external view returns (uint64) {

--- a/libs/ts/contracts/contracts/test/examples/BlocksenseADFSConsumer.sol
+++ b/libs/ts/contracts/contracts/test/examples/BlocksenseADFSConsumer.sol
@@ -14,113 +14,87 @@ contract ADFSConsumer {
     adfs = _adfs;
   }
 
-  function getLatestSingleFeedData(uint256 id) external view returns (bytes32) {
-    return ADFS._getLatestSingleFeedData(adfs, id);
+  function getLatestSingleData(uint256 id) external view returns (bytes32) {
+    return ADFS.getLatestSingleData(adfs, id);
   }
 
-  function getLatestFeedData(
+  function getLatestData(
     uint256 stride,
     uint256 id
   ) external view returns (bytes32[] memory) {
-    return ADFS._getLatestFeedData(adfs, stride, id);
+    return ADFS.getLatestData(adfs, stride, id);
   }
 
-  function getLatestSlicedFeedData(
+  function getLatestDataSlice(
     uint256 stride,
     uint256 id,
     uint256 startSlot,
     uint256 slotsCount
   ) external view returns (bytes32[] memory) {
-    return
-      ADFS._getLatestSlicedFeedData(
-        adfs,
-        stride,
-        id,
-        startSlot,
-        slotsCount
-      );
+    return ADFS.getLatestDataSlice(adfs, stride, id, startSlot, slotsCount);
   }
 
-  function getLatestRound(
+  function getLatestIndex(
     uint256 stride,
     uint256 id
   ) external view returns (uint256 round) {
-    return ADFS._getLatestRound(adfs, stride, id);
+    return ADFS.getLatestIndex(adfs, stride, id);
   }
 
-  function getSingleFeedDataAtRound(
+  function getSingleDataAtIndex(
     uint256 id,
-    uint256 round
+    uint256 index
   ) external view returns (bytes32) {
-    return ADFS._getSingleFeedDataAtRound(adfs, id, round);
+    return ADFS.getSingleDataAtIndex(adfs, id, index);
   }
 
-  function getFeedDataAtRound(
+  function getDataAtIndex(
     uint256 stride,
     uint256 id,
-    uint256 round
+    uint256 index
   ) external view returns (bytes32[] memory) {
-    return ADFS._getFeedDataAtRound(adfs, stride, id, round);
+    return ADFS.getDataAtIndex(adfs, stride, id, index);
   }
 
-  function getSlicedFeedDataAtRound(
+  function getDataSliceAtIndex(
     uint256 stride,
     uint256 id,
-    uint256 round,
+    uint256 index,
     uint256 startSlot,
     uint256 slotsCount
   ) external view returns (bytes32[] memory) {
     return
-      ADFS._getSlicedFeedDataAtRound(
-        adfs,
-        stride,
-        id,
-        round,
-        startSlot,
-        slotsCount
-      );
+      ADFS.getDataSliceAtIndex(adfs, stride, id, index, startSlot, slotsCount);
   }
 
-  function getLatestSingleFeedDataAndRound(
+  function getLatestSingleDataAndIndex(
     uint256 id
-  ) external view returns (bytes32 data, uint256 round) {
-    return ADFS._getLatestSingleFeedDataAndRound(adfs, id);
+  ) external view returns (bytes32 data, uint256 index) {
+    return ADFS.getLatestSingleDataAndIndex(adfs, id);
   }
 
-  function getLatestFeedDataAndRound(
+  function getLatestDataAndIndex(
     uint256 stride,
     uint256 id
-  ) external view returns (bytes32[] memory data, uint256 round) {
-    return ADFS._getLatestFeedDataAndRound(adfs, stride, id);
+  ) external view returns (bytes32[] memory data, uint256 index) {
+    return ADFS.getLatestDataAndIndex(adfs, stride, id);
   }
 
-  function getLatestSlicedFeedDataAndRound(
+  function getLatestDataSliceAndIndex(
     uint256 stride,
     uint256 id,
     uint256 startSlot,
     uint256 slotsCount
-  ) external view returns (bytes32[] memory data, uint256 round) {
+  ) external view returns (bytes32[] memory data, uint256 index) {
     return
-      ADFS._getLatestSlicedFeedDataAndRound(
-        adfs,
-        stride,
-        id,
-        startSlot,
-        slotsCount
-      );
+      ADFS.getLatestDataSliceAndIndex(adfs, stride, id, startSlot, slotsCount);
   }
 
   function getEpochSeconds(uint256 id) external view returns (uint64) {
-    return
-      ADFS._getEpochSeconds(
-        ADFS._getLatestSingleFeedData(adfs, id)
-      );
+    return ADFS.getEpochSeconds(ADFS.getLatestSingleData(adfs, id));
   }
 
   function getEpochMilliseconds(uint256 id) external view returns (uint64) {
-    return
-      ADFS._getEpochMilliseconds(
-        ADFS._getLatestSingleFeedData(adfs, id)
-      );
+    return ADFS.getEpochMilliseconds(ADFS.getLatestSingleData(adfs, id));
   }
 }

--- a/libs/ts/contracts/contracts/test/examples/BlocksenseADFSConsumer.sol
+++ b/libs/ts/contracts/contracts/test/examples/BlocksenseADFSConsumer.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {Blocksense} from '../../libraries/Blocksense.sol';
+import {ADFS} from '../../libraries/ADFS.sol';
 
 /**
  * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
  * DO NOT USE THIS CODE IN PRODUCTION.
  */
-contract BlocksenseADFSConsumer {
+contract ADFSConsumer {
   address public immutable adfs;
 
   constructor(address _adfs) {
@@ -15,14 +15,14 @@ contract BlocksenseADFSConsumer {
   }
 
   function getLatestSingleFeedData(uint256 id) external view returns (bytes32) {
-    return Blocksense._getLatestSingleFeedData(adfs, id);
+    return ADFS._getLatestSingleFeedData(adfs, id);
   }
 
   function getLatestFeedData(
     uint256 stride,
     uint256 id
   ) external view returns (bytes32[] memory) {
-    return Blocksense._getLatestFeedData(adfs, stride, id);
+    return ADFS._getLatestFeedData(adfs, stride, id);
   }
 
   function getLatestSlicedFeedData(
@@ -32,7 +32,7 @@ contract BlocksenseADFSConsumer {
     uint256 slotsCount
   ) external view returns (bytes32[] memory) {
     return
-      Blocksense._getLatestSlicedFeedData(
+      ADFS._getLatestSlicedFeedData(
         adfs,
         stride,
         id,
@@ -45,14 +45,14 @@ contract BlocksenseADFSConsumer {
     uint256 stride,
     uint256 id
   ) external view returns (uint256 round) {
-    return Blocksense._getLatestRound(adfs, stride, id);
+    return ADFS._getLatestRound(adfs, stride, id);
   }
 
   function getSingleFeedDataAtRound(
     uint256 id,
     uint256 round
   ) external view returns (bytes32) {
-    return Blocksense._getSingleFeedDataAtRound(adfs, id, round);
+    return ADFS._getSingleFeedDataAtRound(adfs, id, round);
   }
 
   function getFeedDataAtRound(
@@ -60,7 +60,7 @@ contract BlocksenseADFSConsumer {
     uint256 id,
     uint256 round
   ) external view returns (bytes32[] memory) {
-    return Blocksense._getFeedDataAtRound(adfs, stride, id, round);
+    return ADFS._getFeedDataAtRound(adfs, stride, id, round);
   }
 
   function getSlicedFeedDataAtRound(
@@ -71,7 +71,7 @@ contract BlocksenseADFSConsumer {
     uint256 slotsCount
   ) external view returns (bytes32[] memory) {
     return
-      Blocksense._getSlicedFeedDataAtRound(
+      ADFS._getSlicedFeedDataAtRound(
         adfs,
         stride,
         id,
@@ -84,14 +84,14 @@ contract BlocksenseADFSConsumer {
   function getLatestSingleFeedDataAndRound(
     uint256 id
   ) external view returns (bytes32 data, uint256 round) {
-    return Blocksense._getLatestSingleFeedDataAndRound(adfs, id);
+    return ADFS._getLatestSingleFeedDataAndRound(adfs, id);
   }
 
   function getLatestFeedDataAndRound(
     uint256 stride,
     uint256 id
   ) external view returns (bytes32[] memory data, uint256 round) {
-    return Blocksense._getLatestFeedDataAndRound(adfs, stride, id);
+    return ADFS._getLatestFeedDataAndRound(adfs, stride, id);
   }
 
   function getLatestSlicedFeedDataAndRound(
@@ -101,7 +101,7 @@ contract BlocksenseADFSConsumer {
     uint256 slotsCount
   ) external view returns (bytes32[] memory data, uint256 round) {
     return
-      Blocksense._getLatestSlicedFeedDataAndRound(
+      ADFS._getLatestSlicedFeedDataAndRound(
         adfs,
         stride,
         id,
@@ -112,15 +112,15 @@ contract BlocksenseADFSConsumer {
 
   function getEpochSeconds(uint256 id) external view returns (uint64) {
     return
-      Blocksense._getEpochSeconds(
-        Blocksense._getLatestSingleFeedData(adfs, id)
+      ADFS._getEpochSeconds(
+        ADFS._getLatestSingleFeedData(adfs, id)
       );
   }
 
   function getEpochMilliseconds(uint256 id) external view returns (uint64) {
     return
-      Blocksense._getEpochMilliseconds(
-        Blocksense._getLatestSingleFeedData(adfs, id)
+      ADFS._getEpochMilliseconds(
+        ADFS._getLatestSingleFeedData(adfs, id)
       );
   }
 }

--- a/libs/ts/contracts/contracts/test/examples/RawCallADFSConsumer.sol
+++ b/libs/ts/contracts/contracts/test/examples/RawCallADFSConsumer.sol
@@ -12,7 +12,7 @@ contract RawCallADFSConsumer {
     adfs = _adfs;
   }
 
-  function getLatestSingleFeedData(
+  function getLatestSingleData(
     uint256 id
   ) external view returns (bytes32 data) {
     (bool success, bytes memory returnData) = adfs.staticcall(
@@ -23,7 +23,7 @@ contract RawCallADFSConsumer {
     return (bytes32(returnData));
   }
 
-  function getLatestFeedData(
+  function getLatestData(
     uint8 stride,
     uint256 id
   ) external view returns (bytes32[] memory data) {
@@ -35,7 +35,7 @@ contract RawCallADFSConsumer {
     return parseBytesToBytes32Array(returnData);
   }
 
-  function getLatestSlicedFeedData(
+  function getLatestDataSlice(
     uint8 stride,
     uint256 id,
     uint32 startSlot,
@@ -49,9 +49,9 @@ contract RawCallADFSConsumer {
     return parseBytesToBytes32Array(returnData);
   }
 
-  function getSingleFeedDataAtRound(
+  function getSingleDataAtIndex(
     uint256 id,
-    uint256 round
+    uint256 index
   ) external view returns (bytes32 data) {
     (bool success, bytes memory returnData) = adfs.staticcall(
       abi.encodePacked(bytes1(0x86), uint8(0), uint120(id), uint16(round))
@@ -61,23 +61,22 @@ contract RawCallADFSConsumer {
     return (bytes32(returnData));
   }
 
-  function getFeedDataAtRound(
+  function getDataAtIndex(
     uint8 stride,
     uint256 id,
-    uint256 round
+    uint256 index
   ) external view returns (bytes32[] memory data) {
     (bool success, bytes memory returnData) = adfs.staticcall(
-      abi.encodePacked(bytes1(0x86), stride, uint120(id), uint16(round))
+      abi.encodePacked(bytes1(0x86), stride, uint120(id), uint16(index))
     );
     require(success, 'ADFS: call failed');
 
     return parseBytesToBytes32Array(returnData);
   }
 
-  function getSlicedFeedDataAtRound(
-    uint8 stride,
+  function getDataSliceAtIndex(
     uint256 id,
-    uint256 round,
+    uint256 index,
     uint32 startSlot,
     uint32 slotsCount
   ) external view returns (bytes32[] memory data) {
@@ -86,7 +85,7 @@ contract RawCallADFSConsumer {
         bytes1(0x86),
         stride,
         uint120(id),
-        uint16(round),
+        uint16(index),
         startSlot,
         slotsCount
       )
@@ -96,10 +95,10 @@ contract RawCallADFSConsumer {
     return parseBytesToBytes32Array(returnData);
   }
 
-  function getLatestRound(
+  function getLatestIndex(
     uint8 stride,
     uint256 id
-  ) external view returns (uint256 round) {
+  ) external view returns (uint256 index) {
     (bool success, bytes memory returnData) = adfs.staticcall(
       abi.encodePacked(bytes1(0x81), stride, uint120(id))
     );
@@ -108,9 +107,9 @@ contract RawCallADFSConsumer {
     return uint256(bytes32(returnData));
   }
 
-  function getLatestSingleFeedDataAndRound(
+  function getLatestSingleDataAndIndex(
     uint256 id
-  ) external view returns (bytes32 data, uint256 round) {
+  ) external view returns (bytes32 data, uint256 index) {
     (bool success, bytes memory returnData) = adfs.staticcall(
       abi.encodePacked(bytes1(0x83), uint8(0), uint120(id))
     );
@@ -119,16 +118,16 @@ contract RawCallADFSConsumer {
     (round, data) = abi.decode(returnData, (uint256, bytes32));
   }
 
-  function getLatestFeedDataAndRound(
+  function getLatestDataAndIndex(
     uint8 stride,
     uint256 id
-  ) external view returns (bytes32[] memory data, uint256 round) {
+  ) external view returns (bytes32[] memory data, uint256 index) {
     (bool success, bytes memory returnData) = adfs.staticcall(
       abi.encodePacked(bytes1(0x85), stride, uint120(id))
     );
     require(success, 'ADFS: call failed');
 
-    round = uint256(bytes32(returnData));
+    index = uint256(bytes32(returnData));
 
     assembly {
       let len := mload(returnData)
@@ -139,18 +138,18 @@ contract RawCallADFSConsumer {
     data = parseBytesToBytes32Array(returnData);
   }
 
-  function getLatestSlicedFeedDataAndRound(
+  function getLatestDataSliceAndIndex(
     uint8 stride,
     uint256 id,
     uint32 startSlot,
     uint32 slotsCount
-  ) external view returns (bytes32[] memory data, uint256 round) {
+  ) external view returns (bytes32[] memory data, uint256 index) {
     (bool success, bytes memory returnData) = adfs.staticcall(
       abi.encodePacked(bytes1(0x85), stride, uint120(id), startSlot, slotsCount)
     );
     require(success, 'ADFS: call failed');
 
-    round = uint256(bytes32(returnData));
+    index = uint256(bytes32(returnData));
 
     assembly {
       let len := mload(returnData)

--- a/libs/ts/contracts/contracts/test/examples/RawCallADFSConsumer.sol
+++ b/libs/ts/contracts/contracts/test/examples/RawCallADFSConsumer.sol
@@ -16,7 +16,7 @@ contract RawCallADFSConsumer {
     uint256 id
   ) external view returns (bytes32 data) {
     (bool success, bytes memory returnData) = adfs.staticcall(
-      abi.encodePacked(bytes1(0x82), uint8(0), uint120(id))
+      abi.encodePacked(bytes1(0x82), uint128(id))
     );
     require(success, 'ADFS: call failed');
 
@@ -24,11 +24,10 @@ contract RawCallADFSConsumer {
   }
 
   function getLatestData(
-    uint8 stride,
     uint256 id
   ) external view returns (bytes32[] memory data) {
     (bool success, bytes memory returnData) = adfs.staticcall(
-      abi.encodePacked(bytes1(0x84), stride, uint120(id))
+      abi.encodePacked(bytes1(0x84), uint128(id))
     );
     require(success, 'ADFS: call failed');
 
@@ -36,13 +35,12 @@ contract RawCallADFSConsumer {
   }
 
   function getLatestDataSlice(
-    uint8 stride,
     uint256 id,
     uint32 startSlot,
     uint32 slotsCount
   ) external view returns (bytes32[] memory data) {
     (bool success, bytes memory returnData) = adfs.staticcall(
-      abi.encodePacked(bytes1(0x84), stride, uint120(id), startSlot, slotsCount)
+      abi.encodePacked(bytes1(0x84), uint128(id), startSlot, slotsCount)
     );
     require(success, 'ADFS: call failed');
 
@@ -54,7 +52,7 @@ contract RawCallADFSConsumer {
     uint256 index
   ) external view returns (bytes32 data) {
     (bool success, bytes memory returnData) = adfs.staticcall(
-      abi.encodePacked(bytes1(0x86), uint8(0), uint120(id), uint16(round))
+      abi.encodePacked(bytes1(0x86), uint128(id), uint16(index))
     );
     require(success, 'ADFS: call failed');
 
@@ -62,12 +60,11 @@ contract RawCallADFSConsumer {
   }
 
   function getDataAtIndex(
-    uint8 stride,
     uint256 id,
     uint256 index
   ) external view returns (bytes32[] memory data) {
     (bool success, bytes memory returnData) = adfs.staticcall(
-      abi.encodePacked(bytes1(0x86), stride, uint120(id), uint16(index))
+      abi.encodePacked(bytes1(0x86), uint128(id), uint16(index))
     );
     require(success, 'ADFS: call failed');
 
@@ -83,8 +80,7 @@ contract RawCallADFSConsumer {
     (bool success, bytes memory returnData) = adfs.staticcall(
       abi.encodePacked(
         bytes1(0x86),
-        stride,
-        uint120(id),
+        uint128(id),
         uint16(index),
         startSlot,
         slotsCount
@@ -95,12 +91,9 @@ contract RawCallADFSConsumer {
     return parseBytesToBytes32Array(returnData);
   }
 
-  function getLatestIndex(
-    uint8 stride,
-    uint256 id
-  ) external view returns (uint256 index) {
+  function getLatestIndex(uint256 id) external view returns (uint256 index) {
     (bool success, bytes memory returnData) = adfs.staticcall(
-      abi.encodePacked(bytes1(0x81), stride, uint120(id))
+      abi.encodePacked(bytes1(0x81), uint128(id))
     );
     require(success, 'ADFS: call failed');
 
@@ -111,19 +104,18 @@ contract RawCallADFSConsumer {
     uint256 id
   ) external view returns (bytes32 data, uint256 index) {
     (bool success, bytes memory returnData) = adfs.staticcall(
-      abi.encodePacked(bytes1(0x83), uint8(0), uint120(id))
+      abi.encodePacked(bytes1(0x83), uint128(id))
     );
     require(success, 'ADFS: call failed');
 
-    (round, data) = abi.decode(returnData, (uint256, bytes32));
+    (index, data) = abi.decode(returnData, (uint256, bytes32));
   }
 
   function getLatestDataAndIndex(
-    uint8 stride,
     uint256 id
   ) external view returns (bytes32[] memory data, uint256 index) {
     (bool success, bytes memory returnData) = adfs.staticcall(
-      abi.encodePacked(bytes1(0x85), stride, uint120(id))
+      abi.encodePacked(bytes1(0x85), uint128(id))
     );
     require(success, 'ADFS: call failed');
 
@@ -139,13 +131,12 @@ contract RawCallADFSConsumer {
   }
 
   function getLatestDataSliceAndIndex(
-    uint8 stride,
     uint256 id,
     uint32 startSlot,
     uint32 slotsCount
   ) external view returns (bytes32[] memory data, uint256 index) {
     (bool success, bytes memory returnData) = adfs.staticcall(
-      abi.encodePacked(bytes1(0x85), stride, uint120(id), startSlot, slotsCount)
+      abi.encodePacked(bytes1(0x85), uint128(id), startSlot, slotsCount)
     );
     require(success, 'ADFS: call failed');
 

--- a/libs/ts/contracts/tasks/test-multichain-deploy.ts
+++ b/libs/ts/contracts/tasks/test-multichain-deploy.ts
@@ -103,7 +103,7 @@ task(
   const feed: Feed = {
     id: 1n,
     stride: 0n,
-    round: 1n,
+    index: 1n,
     data: encodeDataAndTimestamp(1234),
   };
 
@@ -225,7 +225,7 @@ task(
   const newFeed: Feed = {
     id: 1n,
     stride: 0n,
-    round: 2n,
+    index: 2n,
     data: encodeDataAndTimestamp(5678),
   };
 
@@ -302,7 +302,7 @@ const encodeDataWrite = (feeds: Feed[], blockNumber?: number) => {
   );
 
   const data = feeds.map(feed => {
-    const index = (feed.id * 2n ** 13n + feed.round) * 2n ** feed.stride;
+    const index = (feed.id * 2n ** 13n + feed.index) * 2n ** feed.stride;
     const indexInBytesLength = Math.ceil(index.toString(2).length / 8);
     const bytes = (feed.data.length - 2) / 2;
     const bytesLength = Math.ceil(bytes.toString(2).length / 8);
@@ -333,8 +333,8 @@ const encodeDataWrite = (feeds: Feed[], blockNumber?: number) => {
       batchFeeds[rowIndex] = '0x' + '0'.repeat(64);
     }
 
-    // Convert round to 2b hex and pad if needed
-    const roundHex = feed.round.toString(16).padStart(4, '0');
+    // Convert index to 2b hex and pad if needed
+    const indexHex = feed.index.toString(16).padStart(4, '0');
 
     // Calculate position in the 32b row (64 hex chars)
     const position = slotPosition * 4;
@@ -342,11 +342,11 @@ const encodeDataWrite = (feeds: Feed[], blockNumber?: number) => {
     // Replace the corresponding 2b in the row
     batchFeeds[rowIndex] =
       batchFeeds[rowIndex].slice(0, position + 2) +
-      roundHex +
+      indexHex +
       batchFeeds[rowIndex].slice(position + 6);
   });
 
-  const roundData = Object.keys(batchFeeds)
+  const indexData = Object.keys(batchFeeds)
     .map(index => {
       const indexInBytesLength = Math.ceil(
         BigInt(index).toString(2).length / 8,
@@ -361,5 +361,5 @@ const encodeDataWrite = (feeds: Feed[], blockNumber?: number) => {
     })
     .join('');
 
-  return prefix.concat(data.join('')).concat(roundData);
+  return prefix.concat(data.join('')).concat(indexData);
 };

--- a/libs/ts/contracts/test/CLAggregatorAdapter.test.ts
+++ b/libs/ts/contracts/test/CLAggregatorAdapter.test.ts
@@ -84,7 +84,7 @@ describe('CLAggregatorAdapter', function () {
         await contractWrappers[i].proxy.proxyCall('setFeeds', sequencer, [
           {
             id: BigInt(data.id),
-            round: 2n,
+            index: 2n,
             data: data2,
             stride: 0n,
           },
@@ -106,7 +106,7 @@ describe('CLAggregatorAdapter', function () {
         await contractWrappers[i].proxy.proxyCall('setFeeds', sequencer, [
           {
             id: BigInt(data.id),
-            round: 2n,
+            index: 2n,
             data: data2,
             stride: 0n,
           },
@@ -128,7 +128,7 @@ describe('CLAggregatorAdapter', function () {
         await contractWrappers[i].proxy.proxyCall('setFeeds', sequencer, [
           {
             id: BigInt(data.id),
-            round: 2n,
+            index: 2n,
             data: data2,
             stride: 0n,
           },
@@ -166,7 +166,7 @@ describe('CLAggregatorAdapter', function () {
         await contractWrappers[i].proxy.proxyCall('setFeeds', sequencer, [
           {
             id: BigInt(data.id),
-            round: 3n,
+            index: 3n,
             data: data3,
             stride: 0n,
           },

--- a/libs/ts/contracts/test/UpgradeableProxyADFS.test.ts
+++ b/libs/ts/contracts/test/UpgradeableProxyADFS.test.ts
@@ -22,7 +22,7 @@ import { compareGasUsed } from './utils/helpers/compareGasWithExperiments';
 
 const feed: Feed = {
   id: 0n,
-  round: 1n,
+  index: 1n,
   data: ethers.hexlify(ethers.randomBytes(18)),
   stride: 0n,
 };
@@ -125,7 +125,7 @@ describe('UpgradeableProxyADFS', function () {
 
     const newFeed = {
       ...feed,
-      round: feed.round + 1n,
+      index: feed.index + 1n,
       data: ethers.hexlify(ethers.randomBytes(18)),
     };
 
@@ -151,7 +151,7 @@ describe('UpgradeableProxyADFS', function () {
     // get old value at round 1 and assert that is hasn't changed after upgrade
     const valueV2 = (
       await proxy.proxyCall('getValues', sequencer, [feed], {
-        operations: [ReadOp.GetFeedAtRound],
+        operations: [ReadOp.GetDataAtIndex],
       })
     )[0];
 
@@ -310,7 +310,7 @@ describe('UpgradeableProxyADFS', function () {
           [genericProxy],
           i,
           {
-            round: 1n,
+            index: 1n,
           },
         );
 
@@ -322,7 +322,7 @@ describe('UpgradeableProxyADFS', function () {
           [genericProxy],
           i,
           {
-            round: 2n,
+            index: 2n,
           },
         );
       });
@@ -337,7 +337,7 @@ describe('UpgradeableProxyADFS', function () {
           i,
           {
             skip: 16,
-            round: 1n,
+            index: 1n,
           },
         );
 
@@ -350,7 +350,7 @@ describe('UpgradeableProxyADFS', function () {
           i,
           {
             skip: 16,
-            round: 2n,
+            index: 2n,
           },
         );
       });

--- a/libs/ts/contracts/test/examples/CLFeedRegistryAdapterConsumer.test.ts
+++ b/libs/ts/contracts/test/examples/CLFeedRegistryAdapterConsumer.test.ts
@@ -14,14 +14,14 @@ const aggregatorData = [
   {
     description: 'ETH/USD',
     decimals: 8,
-    key: 3,
+    id: 3,
     base: TOKENS.ETH,
     quote: TOKENS.USD,
   },
   {
     description: 'BTC/USD',
     decimals: 6,
-    key: 132,
+    id: 132,
     base: TOKENS.BTC,
     quote: TOKENS.USD,
   },
@@ -50,10 +50,10 @@ describe('Example: CLFeedRegistryAdapterConsumer', function () {
 
     for (const data of aggregatorData) {
       const newAdapter = new CLAdapterWrapper();
-      await newAdapter.init(data.description, data.decimals, data.key, proxy);
+      await newAdapter.init(data.description, data.decimals, data.id, proxy);
       aggregators.push(newAdapter);
 
-      const value = encodeDataAndTimestamp(data.key * 1000, Date.now());
+      const value = encodeDataAndTimestamp(data.id * 1000, Date.now());
       await newAdapter.setFeed(sequencer, value, 1n);
     }
 

--- a/libs/ts/contracts/test/examples/FeedStoreConsumer.test.ts
+++ b/libs/ts/contracts/test/examples/FeedStoreConsumer.test.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'hardhat';
 import { deployContract } from '../experiments/utils/helpers/common';
-import { BlocksenseADFSConsumer, RawCallADFSConsumer } from '../../typechain';
+import { ADFSConsumer, RawCallADFSConsumer } from '../../typechain';
 import * as utils from './utils/feedStoreConsumer';
 import { expect } from 'chai';
 import { ADFSWrapper } from '../utils/wrappers';
@@ -31,7 +31,7 @@ const feeds: Feed[] = [
 
 describe('Example: ADFSConsumer', function () {
   let dataFeedStore: ADFSWrapper;
-  let blocksenseADFSConsumer: BlocksenseADFSConsumer;
+  let adfsConsumer: ADFSConsumer;
   let rawCallADFSConsumer: RawCallADFSConsumer;
   let sequencer: HardhatEthersSigner;
 
@@ -52,8 +52,8 @@ describe('Example: ADFSConsumer', function () {
 
     await dataFeedStore.setFeeds(sequencer, feeds);
 
-    blocksenseADFSConsumer = await deployContract<BlocksenseADFSConsumer>(
-      'BlocksenseADFSConsumer',
+    adfsConsumer = await deployContract<ADFSConsumer>(
+      'ADFSConsumer',
       dataFeedStore.contract.target,
     );
     rawCallADFSConsumer = await deployContract<RawCallADFSConsumer>(
@@ -156,7 +156,7 @@ describe('Example: ADFSConsumer', function () {
     };
     await dataFeedStore.setFeeds(sequencer, [feed]);
 
-    const timestamp = await blocksenseADFSConsumer.getEpochSeconds(feed.id);
+    const timestamp = await adfsConsumer.getEpochSeconds(feed.id);
     expect(timestamp).to.be.equal(Math.floor(timestampNow / 1000));
   });
 
@@ -171,9 +171,7 @@ describe('Example: ADFSConsumer', function () {
     };
     await dataFeedStore.setFeeds(sequencer, [feed]);
 
-    const timestamp = await blocksenseADFSConsumer.getEpochMilliseconds(
-      feed.id,
-    );
+    const timestamp = await adfsConsumer.getEpochMilliseconds(feed.id);
     expect(timestamp).to.be.equal(timestampNow);
   });
 
@@ -182,12 +180,12 @@ describe('Example: ADFSConsumer', function () {
     functionName: keyof typeof utils,
   ) => {
     const inputsCount =
-      blocksenseADFSConsumer.interface.getFunction(functionName).inputs.length;
+      adfsConsumer.interface.getFunction(functionName).inputs.length;
     const filteredData = data.filter(v => v !== null).slice(0, inputsCount);
 
-    const blocksenseData = await blocksenseADFSConsumer.getFunction(
-      functionName,
-    )(...filteredData);
+    const adfsData = await adfsConsumer.getFunction(functionName)(
+      ...filteredData,
+    );
     const rawCallData = await rawCallADFSConsumer.getFunction(functionName)(
       ...filteredData,
     );
@@ -197,7 +195,7 @@ describe('Example: ADFSConsumer', function () {
       data,
     );
 
-    expect(blocksenseData).to.deep.equal(utilData);
+    expect(adfsData).to.deep.equal(utilData);
     expect(rawCallData).to.deep.equal(utilData);
   };
 });

--- a/libs/ts/contracts/test/examples/FeedStoreConsumer.test.ts
+++ b/libs/ts/contracts/test/examples/FeedStoreConsumer.test.ts
@@ -74,10 +74,7 @@ describe('Example: ADFSConsumer', function () {
     },
   ].forEach(data => {
     it(`Should ${data.title}`, async function () {
-      await getAndCompareData(
-        [null, id, index],
-        data.fnName as keyof typeof utils,
-      );
+      await getAndCompareData([id, index], data.fnName as keyof typeof utils);
     });
   });
 
@@ -99,7 +96,7 @@ describe('Example: ADFSConsumer', function () {
     for (const feed of feedsWithMultipleSlots) {
       it(`Should ${data.title} for stride ${feed.stride}`, async function () {
         await getAndCompareData(
-          [feed.stride, id, index],
+          [mergeStrideAndFeedId(feed.stride, id), index],
           data.fnName as keyof typeof utils,
         );
       });
@@ -126,8 +123,7 @@ describe('Example: ADFSConsumer', function () {
         it(`Should ${data.title} for stride ${feed.stride} and slice(${i}, ${Number(2n ** feed.stride) - i})`, async function () {
           await getAndCompareData(
             [
-              feed.stride,
-              id,
+              mergeStrideAndFeedId(feed.stride, id),
               data.fnName === 'getDataSliceAtIndex' ? index : null,
               i,
               Number(2n ** feed.stride) - i,
@@ -141,7 +137,10 @@ describe('Example: ADFSConsumer', function () {
 
   for (const feed of feeds) {
     it(`Should get latest index for stride ${feed.stride}`, async function () {
-      await getAndCompareData([feed.stride, feed.id], 'getLatestIndex');
+      await getAndCompareData(
+        [mergeStrideAndFeedId(feed.stride, feed.id)],
+        'getLatestIndex',
+      );
     });
   }
 
@@ -174,6 +173,12 @@ describe('Example: ADFSConsumer', function () {
     const timestamp = await adfsConsumer.getEpochMilliseconds(feed.id);
     expect(timestamp).to.be.equal(timestampNow);
   });
+
+  const mergeStrideAndFeedId = (stride: bigint, feedId: bigint) => {
+    stride = stride << 120n;
+    const id = stride | feedId;
+    return id;
+  };
 
   const getAndCompareData = async (
     data: any[],

--- a/libs/ts/contracts/test/examples/FeedStoreConsumer.test.ts
+++ b/libs/ts/contracts/test/examples/FeedStoreConsumer.test.ts
@@ -11,19 +11,19 @@ import { Feed } from '../utils/wrappers/types';
 const feeds: Feed[] = [
   {
     id: 1n,
-    round: 1n,
+    index: 1n,
     stride: 0n,
     data: ethers.hexlify(ethers.randomBytes(32)),
   },
   {
     id: 1n,
-    round: 8191n,
+    index: 8191n,
     stride: 0n,
     data: ethers.hexlify(ethers.randomBytes(32)),
   },
   {
     id: 1n,
-    round: 1n,
+    index: 1n,
     stride: 4n,
     data: ethers.hexlify(ethers.randomBytes(2 ** 4 * 32)),
   },
@@ -35,8 +35,8 @@ describe('Example: ADFSConsumer', function () {
   let rawCallADFSConsumer: RawCallADFSConsumer;
   let sequencer: HardhatEthersSigner;
 
-  const key = 1;
-  const round = 1n;
+  const id = 1n;
+  const index = 1n;
 
   beforeEach(async function () {
     sequencer = (await ethers.getSigners())[0];
@@ -63,19 +63,19 @@ describe('Example: ADFSConsumer', function () {
   });
 
   [
-    { title: 'get latest single feed', fnName: 'getLatestSingleFeedData' },
+    { title: 'get latest single data', fnName: 'getLatestSingleData' },
     {
-      title: 'get latest single feed and round',
-      fnName: 'getLatestSingleFeedDataAndRound',
+      title: 'get latest single data and index',
+      fnName: 'getLatestSingleDataAndIndex',
     },
     {
-      title: 'get single feed data at round',
-      fnName: 'getSingleFeedDataAtRound',
+      title: 'get single data at index',
+      fnName: 'getSingleDataAtIndex',
     },
   ].forEach(data => {
     it(`Should ${data.title}`, async function () {
       await getAndCompareData(
-        [null, key, round],
+        [null, id, index],
         data.fnName as keyof typeof utils,
       );
     });
@@ -83,23 +83,23 @@ describe('Example: ADFSConsumer', function () {
 
   [
     {
-      title: 'get latest feed',
-      fnName: 'getLatestFeedData',
+      title: 'get latest data',
+      fnName: 'getLatestData',
     },
     {
-      title: 'get latest feed and round',
-      fnName: 'getLatestFeedDataAndRound',
+      title: 'get latest data and index',
+      fnName: 'getLatestDataAndIndex',
     },
     {
-      title: 'get feed data at round',
-      fnName: 'getFeedDataAtRound',
+      title: 'get data at index',
+      fnName: 'getDataAtIndex',
     },
   ].forEach(data => {
     const feedsWithMultipleSlots = feeds.filter(feed => feed.stride > 0);
     for (const feed of feedsWithMultipleSlots) {
       it(`Should ${data.title} for stride ${feed.stride}`, async function () {
         await getAndCompareData(
-          [feed.stride, key, round],
+          [feed.stride, id, index],
           data.fnName as keyof typeof utils,
         );
       });
@@ -108,16 +108,16 @@ describe('Example: ADFSConsumer', function () {
 
   [
     {
-      title: 'get latest sliced feed',
-      fnName: 'getLatestSlicedFeedData',
+      title: 'get latest sliced data',
+      fnName: 'getLatestDataSlice',
     },
     {
-      title: 'get latest sliced feed and round',
-      fnName: 'getLatestSlicedFeedDataAndRound',
+      title: 'get latest data slice and index',
+      fnName: 'getLatestDataSliceAndIndex',
     },
     {
-      title: 'get sliced feed data at round',
-      fnName: 'getSlicedFeedDataAtRound',
+      title: 'get data slice at index',
+      fnName: 'getDataSliceAtIndex',
     },
   ].forEach(data => {
     const feedsWithMultipleSlots = feeds.filter(feed => feed.stride > 0);
@@ -127,8 +127,8 @@ describe('Example: ADFSConsumer', function () {
           await getAndCompareData(
             [
               feed.stride,
-              key,
-              data.fnName === 'getSlicedFeedDataAtRound' ? round : null,
+              id,
+              data.fnName === 'getDataSliceAtIndex' ? index : null,
               i,
               Number(2n ** feed.stride) - i,
             ],
@@ -140,8 +140,8 @@ describe('Example: ADFSConsumer', function () {
   });
 
   for (const feed of feeds) {
-    it(`Should get latest round for stride ${feed.stride}`, async function () {
-      await getAndCompareData([feed.stride, feed.id], 'getLatestRound');
+    it(`Should get latest index for stride ${feed.stride}`, async function () {
+      await getAndCompareData([feed.stride, feed.id], 'getLatestIndex');
     });
   }
 
@@ -150,7 +150,7 @@ describe('Example: ADFSConsumer', function () {
     const feedData = encodeDataAndTimestamp(1234, timestampNow);
     const feed = {
       id: 1n,
-      round: 1n,
+      index: 1n,
       stride: 0n,
       data: feedData,
     };
@@ -165,7 +165,7 @@ describe('Example: ADFSConsumer', function () {
     const feedData = encodeDataAndTimestamp(1234, timestampNow);
     const feed = {
       id: 1n,
-      round: 1n,
+      index: 1n,
       stride: 0n,
       data: feedData,
     };

--- a/libs/ts/contracts/test/examples/utils/feedStoreConsumer.ts
+++ b/libs/ts/contracts/test/examples/utils/feedStoreConsumer.ts
@@ -6,10 +6,7 @@ export const getLatestSingleData = async (
 ) => {
   const [, id] = feedData;
 
-  const data = ethers.solidityPacked(
-    ['bytes1', 'uint8', 'uint120'],
-    ['0x82', 0, id],
-  );
+  const data = ethers.solidityPacked(['bytes1', 'uint128'], ['0x82', id]);
 
   return ethers.provider.call!({
     to: adfsAddress,
@@ -21,11 +18,8 @@ export const getLatestData = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [stride, id] = feedData;
-  const data = ethers.solidityPacked(
-    ['bytes1', 'uint8', 'uint120'],
-    ['0x84', stride, id],
-  );
+  const [id] = feedData;
+  const data = ethers.solidityPacked(['bytes1', 'uint128'], ['0x84', id]);
 
   const res = await ethers.provider.call!({
     to: adfsAddress,
@@ -39,10 +33,10 @@ export const getLatestDataSlice = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [stride, id, , startSlot, slots] = feedData;
+  const [id, , startSlot, slots] = feedData;
   const data = ethers.solidityPacked(
-    ['bytes1', 'uint8', 'uint120', 'uint32', 'uint32'],
-    ['0x84', stride, id, startSlot, slots],
+    ['bytes1', 'uint128', 'uint32', 'uint32'],
+    ['0x84', id, startSlot, slots],
   );
 
   const res = await ethers.provider.call!({
@@ -60,8 +54,8 @@ export const getSingleDataAtIndex = async (
   const [id, indexId] = feedData;
 
   const data = ethers.solidityPacked(
-    ['bytes1', 'uint8', 'uint120', 'uint16'],
-    ['0x86', 0, id, indexId],
+    ['bytes1', 'uint128', 'uint16'],
+    ['0x86', id, indexId],
   );
 
   return ethers.provider.call!({
@@ -74,11 +68,11 @@ export const getDataAtIndex = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [stride, id, indexId] = feedData;
+  const [id, indexId] = feedData;
 
   const data = ethers.solidityPacked(
-    ['bytes1', 'uint8', 'uint120', 'uint16'],
-    ['0x86', stride, id, indexId],
+    ['bytes1', 'uint128', 'uint16'],
+    ['0x86', id, indexId],
   );
 
   const res = await ethers.provider.call!({
@@ -93,10 +87,10 @@ export const getDataSliceAtIndex = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [stride, id, indexId, startSlot, slots] = feedData;
+  const [id, indexId, startSlot, slots] = feedData;
   const data = ethers.solidityPacked(
-    ['bytes1', 'uint8', 'uint120', 'uint16', 'uint32', 'uint32'],
-    ['0x86', stride, id, indexId, startSlot, slots],
+    ['bytes1', 'uint128', 'uint16', 'uint32', 'uint32'],
+    ['0x86', id, indexId, startSlot, slots],
   );
 
   const res = await ethers.provider.call!({
@@ -111,12 +105,9 @@ export const getLatestIndex = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [stride, id] = feedData;
+  const [id] = feedData;
 
-  const data = ethers.solidityPacked(
-    ['bytes1', 'uint8', 'uint120'],
-    ['0x81', stride ?? 0n, id],
-  );
+  const data = ethers.solidityPacked(['bytes1', 'uint128'], ['0x81', id]);
 
   return ethers.provider.call!({
     to: adfsAddress,
@@ -128,12 +119,9 @@ export const getLatestSingleDataAndIndex = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [, id] = feedData;
+  const [id] = feedData;
 
-  const data = ethers.solidityPacked(
-    ['bytes1', 'uint8', 'uint120'],
-    ['0x83', 0, id],
-  );
+  const data = ethers.solidityPacked(['bytes1', 'uint128'], ['0x83', id]);
 
   const res = await ethers.provider.call!({
     to: adfsAddress,
@@ -149,12 +137,9 @@ export const getLatestDataAndIndex = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [stride, id] = feedData;
+  const [id] = feedData;
 
-  const data = ethers.solidityPacked(
-    ['bytes1', 'uint8', 'uint120'],
-    ['0x85', stride, id],
-  );
+  const data = ethers.solidityPacked(['bytes1', 'uint128'], ['0x85', id]);
 
   const res = await ethers.provider.call!({
     to: adfsAddress,
@@ -170,10 +155,10 @@ export const getLatestDataSliceAndIndex = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [stride, id, , startSlot, slots] = feedData;
+  const [id, , startSlot, slots] = feedData;
   const data = ethers.solidityPacked(
-    ['bytes1', 'uint8', 'uint120', 'uint32', 'uint32'],
-    ['0x85', stride, id, startSlot, slots],
+    ['bytes1', 'uint128', 'uint32', 'uint32'],
+    ['0x85', id, startSlot, slots],
   );
 
   const res = await ethers.provider.call!({

--- a/libs/ts/contracts/test/examples/utils/feedStoreConsumer.ts
+++ b/libs/ts/contracts/test/examples/utils/feedStoreConsumer.ts
@@ -1,14 +1,14 @@
 import { ethers } from 'hardhat';
 
-export const getLatestSingleFeedData = async (
+export const getLatestSingleData = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [, key] = feedData;
+  const [, id] = feedData;
 
   const data = ethers.solidityPacked(
     ['bytes1', 'uint8', 'uint120'],
-    ['0x82', 0, key],
+    ['0x82', 0, id],
   );
 
   return ethers.provider.call!({
@@ -17,14 +17,14 @@ export const getLatestSingleFeedData = async (
   });
 };
 
-export const getLatestFeedData = async (
+export const getLatestData = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [stride, key] = feedData;
+  const [stride, id] = feedData;
   const data = ethers.solidityPacked(
     ['bytes1', 'uint8', 'uint120'],
-    ['0x84', stride, key],
+    ['0x84', stride, id],
   );
 
   const res = await ethers.provider.call!({
@@ -35,14 +35,14 @@ export const getLatestFeedData = async (
   return splitInto32bChunks(res);
 };
 
-export const getLatestSlicedFeedData = async (
+export const getLatestDataSlice = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [stride, key, , startSlot, slots] = feedData;
+  const [stride, id, , startSlot, slots] = feedData;
   const data = ethers.solidityPacked(
     ['bytes1', 'uint8', 'uint120', 'uint32', 'uint32'],
-    ['0x84', stride, key, startSlot, slots],
+    ['0x84', stride, id, startSlot, slots],
   );
 
   const res = await ethers.provider.call!({
@@ -53,15 +53,15 @@ export const getLatestSlicedFeedData = async (
   return splitInto32bChunks(res);
 };
 
-export const getSingleFeedDataAtRound = async (
+export const getSingleDataAtIndex = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [, key, roundId] = feedData;
+  const [id, indexId] = feedData;
 
   const data = ethers.solidityPacked(
     ['bytes1', 'uint8', 'uint120', 'uint16'],
-    ['0x86', 0, key, roundId],
+    ['0x86', 0, id, indexId],
   );
 
   return ethers.provider.call!({
@@ -70,15 +70,15 @@ export const getSingleFeedDataAtRound = async (
   });
 };
 
-export const getFeedDataAtRound = async (
+export const getDataAtIndex = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [stride, key, roundId] = feedData;
+  const [stride, id, indexId] = feedData;
 
   const data = ethers.solidityPacked(
     ['bytes1', 'uint8', 'uint120', 'uint16'],
-    ['0x86', stride, key, roundId],
+    ['0x86', stride, id, indexId],
   );
 
   const res = await ethers.provider.call!({
@@ -89,14 +89,14 @@ export const getFeedDataAtRound = async (
   return splitInto32bChunks(res);
 };
 
-export const getSlicedFeedDataAtRound = async (
+export const getDataSliceAtIndex = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [stride, key, roundId, startSlot, slots] = feedData;
+  const [stride, id, indexId, startSlot, slots] = feedData;
   const data = ethers.solidityPacked(
     ['bytes1', 'uint8', 'uint120', 'uint16', 'uint32', 'uint32'],
-    ['0x86', stride, key, roundId, startSlot, slots],
+    ['0x86', stride, id, indexId, startSlot, slots],
   );
 
   const res = await ethers.provider.call!({
@@ -107,15 +107,15 @@ export const getSlicedFeedDataAtRound = async (
   return splitInto32bChunks(res);
 };
 
-export const getLatestRound = async (
+export const getLatestIndex = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [stride, key] = feedData;
+  const [stride, id] = feedData;
 
   const data = ethers.solidityPacked(
     ['bytes1', 'uint8', 'uint120'],
-    ['0x81', stride ?? 0n, key],
+    ['0x81', stride ?? 0n, id],
   );
 
   return ethers.provider.call!({
@@ -124,15 +124,15 @@ export const getLatestRound = async (
   });
 };
 
-export const getLatestSingleFeedDataAndRound = async (
+export const getLatestSingleDataAndIndex = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [, key] = feedData;
+  const [, id] = feedData;
 
   const data = ethers.solidityPacked(
     ['bytes1', 'uint8', 'uint120'],
-    ['0x83', 0, key],
+    ['0x83', 0, id],
   );
 
   const res = await ethers.provider.call!({
@@ -140,20 +140,20 @@ export const getLatestSingleFeedDataAndRound = async (
     data,
   });
 
-  const round = Number(res.slice(0, 66));
+  const index = Number(res.slice(0, 66));
   const value = '0x' + res.slice(66);
-  return [value, round];
+  return [value, index];
 };
 
-export const getLatestFeedDataAndRound = async (
+export const getLatestDataAndIndex = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [stride, key] = feedData;
+  const [stride, id] = feedData;
 
   const data = ethers.solidityPacked(
     ['bytes1', 'uint8', 'uint120'],
-    ['0x85', stride, key],
+    ['0x85', stride, id],
   );
 
   const res = await ethers.provider.call!({
@@ -161,19 +161,19 @@ export const getLatestFeedDataAndRound = async (
     data,
   });
 
-  const round = Number(res.slice(0, 66));
+  const index = Number(res.slice(0, 66));
   const value = splitInto32bChunks('0x' + res.slice(66));
-  return [value, round];
+  return [value, index];
 };
 
-export const getLatestSlicedFeedDataAndRound = async (
+export const getLatestDataSliceAndIndex = async (
   adfsAddress: string,
   feedData: number[],
 ) => {
-  const [stride, key, , startSlot, slots] = feedData;
+  const [stride, id, , startSlot, slots] = feedData;
   const data = ethers.solidityPacked(
     ['bytes1', 'uint8', 'uint120', 'uint32', 'uint32'],
-    ['0x85', stride, key, startSlot, slots],
+    ['0x85', stride, id, startSlot, slots],
   );
 
   const res = await ethers.provider.call!({
@@ -181,9 +181,9 @@ export const getLatestSlicedFeedDataAndRound = async (
     data,
   });
 
-  const round = Number(res.slice(0, 66));
+  const index = Number(res.slice(0, 66));
   const value = splitInto32bChunks('0x' + res.slice(66));
-  return [value, round];
+  return [value, index];
 };
 
 const splitInto32bChunks = (value: string) => {

--- a/libs/ts/contracts/test/utils/helpers/common.ts
+++ b/libs/ts/contracts/test/utils/helpers/common.ts
@@ -10,8 +10,8 @@ export const setFeeds = async (
   contractWrappers: IADFSWrapper[] | IUpgradeableProxyADFSWrapper[],
   valuesCount: number,
   adfsData?: {
-    skip?: number; // used to skip feeds so to make testing round table write
-    round?: bigint;
+    skip?: number; // used to skip feeds so to make testing ring buffer index table write
+    index?: bigint;
     stride?: bigint;
   },
   start: number = 0,
@@ -21,7 +21,7 @@ export const setFeeds = async (
   for (let i = start; i < valuesCount; i++) {
     feeds.push({
       id: BigInt(i * (adfsData?.skip ?? 1)),
-      round: adfsData?.round ?? 1n,
+      index: adfsData?.index ?? 1n,
       stride: adfsData?.stride ?? 0n,
       data: ethers.hexlify(ethers.randomBytes(24)),
     });
@@ -77,7 +77,7 @@ export const generateRandomFeeds = (count: number): Feed[] => {
       // random number between 0 and 2**115
       id: BigInt(Math.floor(Math.random() * (2 ** 115 + 1))),
       // random number between 0 and 2**13
-      round: BigInt(Math.floor(Math.random() * 2 ** 13 + 1)),
+      index: BigInt(Math.floor(Math.random() * 2 ** 13 + 1)),
       // random number between 0 and 31
       stride,
       // random bytes depending on the stride (here we won't use max numbers to avoid overflow)

--- a/libs/ts/contracts/test/utils/helpers/compareGasWithExperiments.ts
+++ b/libs/ts/contracts/test/utils/helpers/compareGasWithExperiments.ts
@@ -21,8 +21,8 @@ export const compareGasUsed = async <
   adfsGenericContractWrappers: IADFSWrapper[] | IUpgradeableProxyADFSWrapper[],
   valuesCount: number,
   adfsData?: {
-    skip?: number; // used to skip feeds so to make testing round table write
-    round?: bigint;
+    skip?: number; // used to skip feeds so to make testing ring buffer index table write
+    index?: bigint;
     stride?: bigint;
   },
   start: number = 0,
@@ -51,9 +51,9 @@ export const compareGasUsed = async <
     ...adfsGenericContractWrappers,
   ]) {
     if (isUpgradeableProxy(wrapper)) {
-      await wrapper.proxyCall('checkLatestValue', sequencer, data.feeds);
+      await wrapper.proxyCall('checkLatestData', sequencer, data.feeds);
     } else {
-      await wrapper.checkLatestValue(sequencer, data.feeds);
+      await wrapper.checkLatestData(sequencer, data.feeds);
     }
   }
 

--- a/libs/ts/contracts/test/utils/wrappers/chainlink/Base.ts
+++ b/libs/ts/contracts/test/utils/wrappers/chainlink/Base.ts
@@ -13,7 +13,7 @@ export abstract class CLBaseWrapper {
   public async setFeed(
     sequencer: HardhatEthersSigner,
     data: string,
-    round: bigint,
+    index: bigint,
     blockNumber?: number,
   ): Promise<any> {
     return this.proxy.proxyCall(
@@ -22,7 +22,7 @@ export abstract class CLBaseWrapper {
       [
         {
           id: this.id,
-          round,
+          index,
           data,
           stride: this.stride,
         },
@@ -37,26 +37,26 @@ export abstract class CLBaseWrapper {
     caller: HardhatEthersSigner,
     data: string,
   ): Promise<void> {
-    return this.proxy.proxyCall('checkLatestValue', caller, [
+    return this.proxy.proxyCall('checkLatestData', caller, [
       {
         id: this.id,
         data: data,
         stride: 0n,
-        round: 0n, // this is not used in this test
+        index: 0n, // this is not used in this test
       },
     ]);
   }
 
   public async checkLatestRoundId(
     caller: HardhatEthersSigner,
-    round: bigint,
+    index: bigint,
   ): Promise<void> {
     const latestRoundId = await this.contract.latestRound();
-    expect(latestRoundId).to.be.eq(round);
+    expect(latestRoundId).to.be.eq(index);
 
-    await this.proxy.proxyCall('checkLatestRound', caller, [
+    await this.proxy.proxyCall('checkLatestIndex', caller, [
       {
-        round,
+        index,
         data: '', // this is not used in this test
         id: this.id,
         stride: this.stride,
@@ -81,7 +81,7 @@ export abstract class CLBaseWrapper {
     answer: string,
   ): Promise<void> {
     const feed: Feed = {
-      round: 0n, // this is not used in this test
+      index: 0n, // this is not used in this test
       data: answer,
       id: this.id,
       stride: this.stride,
@@ -98,10 +98,10 @@ export abstract class CLBaseWrapper {
   public async checkLatestRoundData(
     caller: HardhatEthersSigner,
     answer: string,
-    round: bigint,
+    index: bigint,
   ): Promise<void> {
     const feed: Feed = {
-      round,
+      index,
       data: answer,
       id: this.id,
       stride: this.stride,
@@ -111,14 +111,14 @@ export abstract class CLBaseWrapper {
     const counter = BigInt(
       (
         await this.proxy.proxyCall('getValues', caller, [feed], {
-          operations: [ReadOp.GetLatestRound],
+          operations: [ReadOp.GetLatestIndex],
         })
       )[0],
     );
     const parsedData = this.getParsedData(data);
     const parsedDataRes = this.getParsedData(feed.data);
 
-    expect(roundData[0]).to.be.eq(feed.round);
+    expect(roundData[0]).to.be.eq(feed.index);
     expect(roundData[1]).to.be.eq(parsedDataRes.decimal);
     expect(roundData[2]).to.be.eq(parsedData.timestamp);
 
@@ -132,18 +132,18 @@ export abstract class CLBaseWrapper {
   public async checkRoundData(
     caller: HardhatEthersSigner,
     answer: string,
-    round: bigint,
+    index: bigint,
   ): Promise<void> {
     const feed: Feed = {
-      round,
+      index,
       data: answer,
       id: this.id,
       stride: this.stride,
     };
-    const roundData = await this.contract.getRoundData(feed.round);
+    const roundData = await this.contract.getRoundData(feed.index);
     const data = (
       await this.proxy.proxyCall('getValues', caller, [feed], {
-        operations: [ReadOp.GetFeedAtRound],
+        operations: [ReadOp.GetDataAtIndex],
       })
     )[0];
     const parsedData = this.getParsedData(data);
@@ -152,11 +152,11 @@ export abstract class CLBaseWrapper {
     expect(roundData[1]).to.be.eq(parsedDataRes.decimal);
     expect(roundData[2]).to.be.eq(parsedData.timestamp);
 
-    expect(roundData[0]).to.be.eq(feed.round);
+    expect(roundData[0]).to.be.eq(feed.index);
     expect(roundData[1]).to.be.eq(parsedData.decimal);
     expect(roundData[2].toString()).to.be.eq(parsedData.timestamp);
     expect(roundData[3].toString()).to.be.eq(parsedData.timestamp);
-    expect(roundData[4]).to.be.eq(feed.round);
+    expect(roundData[4]).to.be.eq(feed.index);
   }
 
   public getHexAnswer(value: bigint): string {

--- a/libs/ts/contracts/test/utils/wrappers/interfaces/IADFSWrapper.ts
+++ b/libs/ts/contracts/test/utils/wrappers/interfaces/IADFSWrapper.ts
@@ -22,7 +22,7 @@ export interface IADFSWrapper extends IBaseWrapper<AggregatedDataFeedStore> {
 
   getEventFragment(): EventFragment;
 
-  checkLatestValue(
+  checkLatestData(
     caller: HardhatEthersSigner,
     feeds: Feed[],
     opts?: {
@@ -30,7 +30,7 @@ export interface IADFSWrapper extends IBaseWrapper<AggregatedDataFeedStore> {
     },
   ): Promise<void>;
 
-  checkLatestRound(
+  checkLatestIndex(
     caller: HardhatEthersSigner,
     feeds: Feed[],
     opts?: {
@@ -38,7 +38,7 @@ export interface IADFSWrapper extends IBaseWrapper<AggregatedDataFeedStore> {
     },
   ): Promise<void>;
 
-  checkValueAtRound(
+  checkDataAtIndex(
     caller: HardhatEthersSigner,
     feeds: Feed[],
     opts?: {
@@ -46,7 +46,7 @@ export interface IADFSWrapper extends IBaseWrapper<AggregatedDataFeedStore> {
     },
   ): Promise<void>;
 
-  checkLatestFeedAndRound(
+  checkLatestDataAndIndex(
     caller: HardhatEthersSigner,
     feeds: Feed[],
     opts?: {

--- a/libs/ts/contracts/test/utils/wrappers/types.ts
+++ b/libs/ts/contracts/test/utils/wrappers/types.ts
@@ -6,12 +6,12 @@ import {
 import { IADFSWrapper } from './interfaces/IADFSWrapper';
 
 export enum ReadOp {
-  GetFeedAtRound = 0x06,
-  GetLatestFeed = 0x04,
-  GetLatestRound = 0x01,
-  GetLatestFeedAndRound = 0x05,
+  GetDataAtIndex = 0x06,
+  GetLatestData = 0x04,
+  GetLatestIndex = 0x01,
+  GetLatestDataAndIndex = 0x05,
   GetLatestSingleFeed = 0x02,
-  GetLatestSingleFeedAndRound = 0x03,
+  GetLatestSingleDataAndIndex = 0x03,
 }
 
 export enum WriteOp {
@@ -32,7 +32,7 @@ export type ReadFeed = Omit<Feed, 'data' | 'slotsToRead'> &
 
 export interface Feed {
   id: bigint;
-  round: bigint;
+  index: bigint;
   stride: bigint;
   data: string;
   startSlotToReadFrom?: number;
@@ -42,10 +42,10 @@ export interface Feed {
 export type UpgradeableProxyCallMethods = Pick<
   IADFSWrapper,
   | 'setFeeds'
-  | 'checkLatestValue'
-  | 'checkLatestRound'
-  | 'checkValueAtRound'
-  | 'checkLatestFeedAndRound'
+  | 'checkLatestData'
+  | 'checkLatestIndex'
+  | 'checkDataAtIndex'
+  | 'checkLatestDataAndIndex'
   | 'getValues'
 >;
 


### PR DESCRIPTION
- Refactor `round` to become `index` (everywhere except CL compatibility naming)
- Optimise assembly code in libs
- Rename Blocksense lib to ADFS lib and refactor examples to combine `stride` and `feedId` so that there is no stride variable