### PR TITLE
[nix/example-setup-01]: Update `eth-rpc` oracle `allowed-outbound-hosts`

### DIFF
--- a/nix/test-environments/example-setup-01.nix
+++ b/nix/test-environments/example-setup-01.nix
@@ -190,6 +190,10 @@ in
         allowed-outbound-hosts = [
           "https://eth.llamarpc.com"
           "https://rpc.eth.gateway.fm"
+          "https://ethereum-rpc.publicnode.com"
+          "https://binance.llamarpc.com"
+          "https://bsc.meowrpc.com"
+          "https://bsc.drpc.org"
         ];
       };
 


### PR DESCRIPTION
### How to test:
1. Once on branch run: 
```
direnv reload 
```
2. Run Blocksense:
```
just start-blocksense
```
3. Examine the logs of the reporter.
Look for something like: 
<img width="1062" alt="Screenshot 2025-05-27 at 15 41 39" src="https://github.com/user-attachments/assets/5faad738-cc77-4b5e-8e71-fe43b92cf7b7" />
