### PR TITLE
feat: convenient scripts for changing the current devshell (see SETUP.md)

### DIFF
--- a/.github/SETUP.md
+++ b/.github/SETUP.md
@@ -15,6 +15,47 @@ nix develop --impure
 direnv allow
 ```
 
+## 🎛️ Customizing Your Dev Environment
+
+By default, you'll enter the **full development shell** with all tools. You can customize which dev shell to use by creating a local `.env` file.
+
+**Available dev shells:**
+
+- `default` - Full development environment (all tools)
+- `rust` - Rust-specific development environment
+- `js` - JavaScript/TypeScript development environment
+- `pre-commit` - Linting and code quality tools (mostly useful for CI jobs)
+
+### Quick Method (Recommended)
+
+Use the `just` command to easily switch between dev shells:
+
+```sh
+# Switch to Rust-only environment
+just change-devshell rust
+
+# Switch to JavaScript/TypeScript environment
+just change-devshell js
+
+# Switch to pre-commit tools only
+just change-devshell pre-commit
+
+# Switch back to the full development environment
+just change-devshell default
+```
+
+The command will automatically create or update your `.env` file and reload direnv for you.
+
+### Manual Method
+
+If you prefer to manage the `.env` file manually, just set the ENV var `DEV_SHELL` within it.
+
+```sh
+DEV_SHELL=rust
+```
+
+> The change in `.env` will trigger direnv to reload your environment automatically once you enter your terminal.
+
 ---
 
 # ⚡ Running the System

--- a/Justfile
+++ b/Justfile
@@ -4,6 +4,14 @@ spin-data-dir := root-dir + "/target/spin-artifacts"
 default:
   @just --list
 
+# Switch to a different dev shell environment
+change-devshell shell="default":
+  @{{root-dir}}/scripts/dev-shell/change-devshell.sh {{shell}}
+
+# List available dev shell environments
+list-devshells:
+  @{{root-dir}}/scripts/dev-shell/list-devshells.sh
+
 build-ts package="all":
   #!/usr/bin/env bash
   set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## 🚀 Overview
 
-Blocksense is a **permissionless oracle network** that enables builders to bring **real-world data on-chain** with maximum flexibility and efficiency. Designed for **ZK-enabled applications** and decentralized compute, Blocksense offers:
+Blocksense is a **permissionless oracle network** that enables builders to bring **real-world data on-chain** with maximum flexibility and efficiency. Our WebAssembly-based [SDK](libs/sdk/README.md) enables the seamless creation of blockchain oracles that can leverage both CPU and GPU computations.
 
 - ✅ **Cost-effective, verifiable data feeds** for DeFi, prediction markets, and beyond.
 - 🔒 **SchellingCoin-based consensus & ZK-proof-secured reporting.**

--- a/scripts/dev-shell/change-devshell.sh
+++ b/scripts/dev-shell/change-devshell.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source "${BASH_SOURCE%/*}/../utils/ansi.sh"
+
 # Script to change dev shell environment
 # Usage: change-devshell.sh [shell-name]
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ENV_FILE="$ROOT_DIR/.env"
 SHELL_NAME="${1:-default}"
+SHELL_NAME_STYLED="${BOLD}${SHELL_NAME}${RESET}"
 
 # Get available shells
 AVAILABLE_SHELLS=$("$ROOT_DIR/scripts/dev-shell/get-available-shells.sh")
@@ -14,7 +17,7 @@ SHELLS_LIST=$(echo "$AVAILABLE_SHELLS" | tr '\n' ' ')
 
 # Validate shell option
 if ! echo "$SHELLS_LIST" | grep -q "\b$SHELL_NAME\b"; then
-    echo "Error: Invalid shell '$SHELL_NAME'. Available options: $(echo "$SHELLS_LIST" | sed 's/ /, /g' | sed 's/, $//')"
+    echo  -e "Error: Invalid shell $SHELL_NAME_STYLED. Available options: $(echo "${BOLD}$SHELLS_LIST${RESET}" | sed 's/ /, /g' | sed 's/, $//')"
     exit 1
 fi
 
@@ -22,12 +25,12 @@ fi
 if [[ -f "$ENV_FILE" && $(grep -q "^DEV_SHELL=" "$ENV_FILE") ]]; then
     CURRENT_SHELL=$(grep "^DEV_SHELL=" "$ENV_FILE" | cut -d'=' -f2-)
     if [[ "$CURRENT_SHELL" == "$SHELL_NAME" ]]; then
-        echo "✅ Already using the $SHELL_NAME dev shell. No changes made."
+        echo -e "✅ Already using the $SHELL_NAME_STYLED dev shell. No changes made."
         exit 0
     fi
 fi
 
-echo "🔄 Switching to $SHELL_NAME dev shell..."
+echo -e "🔄 Switching to $SHELL_NAME_STYLED dev shell..."
 
 # Update or create .env file
 if [[ -f "$ENV_FILE" ]]; then

--- a/scripts/dev-shell/change-devshell.sh
+++ b/scripts/dev-shell/change-devshell.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Script to change dev shell environment
+# Usage: change-devshell.sh [shell-name]
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENV_FILE="$ROOT_DIR/.env"
+SHELL_NAME="${1:-default}"
+
+# Get available shells
+AVAILABLE_SHELLS=$("$ROOT_DIR/scripts/dev-shell/get-available-shells.sh")
+SHELLS_LIST=$(echo "$AVAILABLE_SHELLS" | tr '\n' ' ')
+
+# Validate shell option
+if ! echo "$SHELLS_LIST" | grep -q "\b$SHELL_NAME\b"; then
+    echo "Error: Invalid shell '$SHELL_NAME'. Available options: $(echo "$SHELLS_LIST" | sed 's/ /, /g' | sed 's/, $//')"
+    exit 1
+fi
+
+# Check if the current shell is already the requested one
+if [[ -f "$ENV_FILE" && $(grep -q "^DEV_SHELL=" "$ENV_FILE") ]]; then
+    CURRENT_SHELL=$(grep "^DEV_SHELL=" "$ENV_FILE" | cut -d'=' -f2-)
+    if [[ "$CURRENT_SHELL" == "$SHELL_NAME" ]]; then
+        echo "✅ Already using the $SHELL_NAME dev shell. No changes made."
+        exit 0
+    fi
+fi
+
+echo "🔄 Switching to $SHELL_NAME dev shell..."
+
+# Update or create .env file
+if [[ -f "$ENV_FILE" ]]; then
+    # Update existing .env file
+    if grep -q "^DEV_SHELL=" "$ENV_FILE"; then
+        sed -i "s/^DEV_SHELL=.*/DEV_SHELL=$SHELL_NAME/" "$ENV_FILE"
+    else
+        echo "DEV_SHELL=$SHELL_NAME" >> "$ENV_FILE"
+    fi
+else
+    # Create new .env file
+    echo "DEV_SHELL=$SHELL_NAME" > "$ENV_FILE"
+fi
+
+# Reload direnv
+echo "Reloading direnv..."
+direnv reload

--- a/scripts/dev-shell/get-available-shells.sh
+++ b/scripts/dev-shell/get-available-shells.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+# Get the current `system` (e.g., `x86_64-linux`, `aarch64-darwin`)
+SYSTEM=$(nix eval --raw --impure --expr 'builtins.currentSystem')
+# Use `nix eval` to get the names of the devShells for said `system`
+# Output is a newline-separated list of the names
+nix eval --json ".#devShells.${SYSTEM}" --apply builtins.attrNames 2>/dev/null | jq -r '.[]'

--- a/scripts/dev-shell/list-devshells.sh
+++ b/scripts/dev-shell/list-devshells.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Script to list available dev shell environments
+# Shows which shell is currently active
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENV_FILE="$ROOT_DIR/.env"
+
+echo "🐚 Available dev shell environments:"
+echo
+
+# Get available shells using helper script
+AVAILABLE_SHELLS=$("$ROOT_DIR/scripts/dev-shell/get-available-shells.sh")
+
+echo "$AVAILABLE_SHELLS" | while read -r shell; do
+    if [[ -f "$ENV_FILE" ]] && grep -q "^DEV_SHELL=$shell$" "$ENV_FILE"; then
+        echo "  • $shell (currently active)"
+    else
+        echo "  • $shell"
+    fi
+done
+
+echo
+echo "💡 Switch to a shell with: just change-devshell <shell-name>"

--- a/scripts/dev-shell/list-devshells.sh
+++ b/scripts/dev-shell/list-devshells.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source "${BASH_SOURCE%/*}/../utils/ansi.sh"
+
 # Script to list available dev shell environments
 # Shows which shell is currently active
 
@@ -15,9 +17,9 @@ AVAILABLE_SHELLS=$("$ROOT_DIR/scripts/dev-shell/get-available-shells.sh")
 
 echo "$AVAILABLE_SHELLS" | while read -r shell; do
     if [[ -f "$ENV_FILE" ]] && grep -q "^DEV_SHELL=$shell$" "$ENV_FILE"; then
-        echo "  • $shell (currently active)"
+        echo -e "  • ${BOLD}$shell${RESET} (currently active)"
     else
-        echo "  • $shell"
+        echo -e "  • ${BOLD}$shell${RESET}"
     fi
 done
 

--- a/scripts/utils/ansi.sh
+++ b/scripts/utils/ansi.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# ANSI styles
+export RESET="\e[0m"
+export BOLD="\e[1m"
+export DIM="\e[2m"
+export GREEN="\e[32m"
+export YELLOW="\e[33m"
+export RED="\e[31m"
+export BLUE="\e[34m"
+export UNDERLINE="\e[4m"


### PR DESCRIPTION
### Add Convenient Scripts for Switching Between Dev Shells

This PR introduces a more ergonomic developer experience for working with multiple `nix` dev shell environments:

#### What's New

* **`change-devshell.sh`**: Switch between shell variants (`default`, `rust`, `js`, etc.) by updating `.env` and triggering `direnv reload`.
* **`get-available-shells.sh`**: Robust detection of available shells (via `nix develop`, fallback to flake parsing).
* **`list-devshells.sh`**: Lists all available shells, highlighting the currently active one.
* **Justfile integration**:

  * `just change-devshell rust`
  * `just list-devshells`
