### PR TITLE
feat(oracles/gecko-terminal): Add oLP price from Arbitrum

### DIFF
--- a/apps/oracles/gecko-terminal/spin.toml
+++ b/apps/oracles/gecko-terminal/spin.toml
@@ -58,6 +58,12 @@ stride = 0
 decimals = 8
 data = '{"pair":{"base":"YUSD","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":[{"min_volume_usd":10000,"network":"bsc","pool":"0x7f1c018f4ed5a424f620300535e789d7dc0290d81d357638cd15a3005911d00f","reverse":false},{"min_volume_usd":10000,"network":"bsc","pool":"0x5006ef6c1a986d214f8c24244b965bc6a3706b88827f94c2270b332170cf0523","reverse":false},{"min_volume_usd":10000,"network":"bsc","pool":"0xef802fff6a683d8b1107dcd7ffbba3ce346a9c20155ad5044955c48aedd01f3b","reverse":false},{"min_volume_usd":10000,"network":"eth","pool":"0xda4a305e8b85194ff5cb70577824cf1f03fb408257b621b82350423cc752ddab","reverse":false},{"min_volume_usd":10000,"network":"eth","pool":"0xa9eeccbfde38d8f6a5bea63564f33a984cd7561930ee86666f4a54d52b3a6e12","reverse":false},{"min_volume_usd":10000,"network":"eth","pool":"0xdfce55c1cc365d3cb2fb475a4762d34ef0bf6c0d","reverse":false},{"min_volume_usd":10000,"network":"eth","pool":"0x9804c30875127246ac92d72d5cdf0630aa356861","reverse":false},{"min_volume_usd":10000,"network":"eth","pool":"0xcf908d925b21594f9a92b264167a85b0649051a8","reverse":false},{"min_volume_usd":10000,"network":"eth","pool":"0x2309d4c880ab017f4372a0f8e0d31c31e97fec44948503d622d10d81229d883d","reverse":false}]}'
 
+[[trigger.oracle.data_feeds]]
+id = "1000007"
+stride = 0
+decimals = 8
+data = '{"pair":{"base":"oLP","quote":"USD"},"decimals":8,"category":"Crypto","market_hours":"Crypto","arguments":[{"network":"arbitrum","pool":"0x09e6a7adfb8c06f22adfefd872de73059d955be3","reverse":false}]}'
+
 [component.gecko-terminal]
 source = "../../../target/wasm32-wasip1/release/gecko_terminal.wasm"
 allowed_outbound_hosts = ["https://api.geckoterminal.com"]

--- a/config/feeds_config_v2.json
+++ b/config/feeds_config_v2.json
@@ -41670,6 +41670,42 @@
       }
     },
     {
+      "id": "1000007",
+      "full_name": "oLP / USD",
+      "description": "Price of ostiumLP (oLP) in USD on Arbitrum (0x20d419a8e12c45f88fda7c5760bb6923cee27f98)",
+      "type": "price-feed",
+      "oracle_id": "gecko-terminal",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 100,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "oLP",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": [
+          {
+            "network": "arbitrum",
+            "pool": "0x09e6a7adfb8c06f22adfefd872de73059d955be3",
+            "reverse": false,
+            "min_volume_usd": 0
+          }
+        ]
+      }
+    },
+    {
       "id": "2000000",
       "full_name": "IBIT / USD",
       "description": "Price of iShares Bitcoin Trust ETF ($IBIT) in USD",


### PR DESCRIPTION
To test it run the gecko terminal oracle

`cd apps/oracles/gecko-terminal && spin up --build`


Example output:


```bash
+---------+---------------+--------------------+---------+---------------------+------------------+---------------+--------------------------------------------------------------------+
| Feed ID |    Network    |        Name        | Reverse |     Price[USD]      |   Volume[USD]    | Enough volume |                                Pool                                |
+---------+---------------+--------------------+---------+---------------------+------------------+---------------+--------------------------------------------------------------------+
| 1000007 | arbitrum      | oLP / USDC 0.424%  | false   |    1.05676688718824 |                0 |           Yes | 0x09e6a7adfb8c06f22adfefd872de73059d955be3                         |
+---------+---------------+--------------------+---------+---------------------+------------------+---------------+--------------------------------------------------------------------+
+---------+----------+-------------------------------------------------------+------------+
| Feed ID |   Name   |                         Value                         | Used Pools |
+---------+----------+-------------------------------------------------------+------------+
| 1000007 | oLP/USD  |                           Numerical(1.05676688718824) |          1 |
+---------+----------+-------------------------------------------------------+------------+
```

Corresponding Infra PR to enable this changes 
https://github.com/blocksense-network/infra/pull/314/