### PR TITLE
build(blocksense): Enable force-frame-pointers=yes by default

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 
 [build]
-rustflags = ["--cfg", "tokio_unstable"]
+rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes"]


### PR DESCRIPTION
Since the performance cost of enforcing frame pointers is not significant and is beneficial for debugging and perf monitoring we enable it by default.