### PR TITLE
feat(base-utils): Add type-safe, layered environment variable parser for deployments

### DIFF
--- a/apps/docs.blocksense.network/components/DeployedContracts/DeployedContracts.tsx
+++ b/apps/docs.blocksense.network/components/DeployedContracts/DeployedContracts.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { Callout } from '@blocksense/ui/Callout';
-import { parseNetworkName } from '@blocksense/base-utils/evm';
+import { parseNetworkName } from '@blocksense/base-utils/evm/networks';
 
 import { capitalizeWords } from '@/src/utils';
 import {

--- a/apps/docs.blocksense.network/scripts/collect-deployment-artifacts.ts
+++ b/apps/docs.blocksense.network/scripts/collect-deployment-artifacts.ts
@@ -1,7 +1,8 @@
 import { readdir } from 'fs/promises';
 
 import { artifactsFolder } from '@/src/constants';
-import { selectDirectory, parseNetworkName } from '@blocksense/base-utils';
+import { selectDirectory } from '@blocksense/base-utils/fs';
+import { parseNetworkName } from '@blocksense/base-utils/evm';
 import { configDirs, readEvmDeployment } from '@blocksense/config-types';
 
 export async function collectDeploymentData() {

--- a/apps/docs.blocksense.network/src/data-feeds/utils.ts
+++ b/apps/docs.blocksense.network/src/data-feeds/utils.ts
@@ -1,4 +1,4 @@
-import { keysOf } from '@blocksense/base-utils';
+import { keysOf } from '@blocksense/base-utils/array-iter';
 import { decodeNewFeedsConfig, NewFeed } from '@blocksense/config-types';
 import DATA_FEEDS from '@blocksense/data-feeds-config-generator/feeds_config';
 

--- a/apps/docs.blocksense.network/src/utils-fs.ts
+++ b/apps/docs.blocksense.network/src/utils-fs.ts
@@ -1,4 +1,4 @@
-import { selectDirectory } from '@blocksense/base-utils';
+import { selectDirectory } from '@blocksense/base-utils/fs';
 
 export async function updateMetaJsonFile(fileDir: string, newContent: any) {
   const { writeJSON, readJSON } = selectDirectory(fileDir);

--- a/libs/ts/base-utils/package.json
+++ b/libs/ts/base-utils/package.json
@@ -42,6 +42,11 @@
       "import": "./dist/esm/evm/index.mjs",
       "types": "./src/evm/index.ts"
     },
+    "./evm/networks": {
+      "require": "./dist/cjs/evm/networks.cjs",
+      "import": "./dist/esm/evm/networks.mjs",
+      "types": "./src/evm/networks.ts"
+    },
     "./env": {
       "require": "./dist/cjs/env/index.cjs",
       "import": "./dist/esm/env/index.mjs",

--- a/libs/ts/base-utils/package.json
+++ b/libs/ts/base-utils/package.json
@@ -67,6 +67,11 @@
       "import": "./dist/esm/string.mjs",
       "types": "./src/string.ts"
     },
+    "./tty": {
+      "require": "./dist/cjs/tty.cjs",
+      "import": "./dist/esm/tty.mjs",
+      "types": "./src/tty.ts"
+    },
     "./type-level": {
       "require": "./dist/cjs/type-level.cjs",
       "import": "./dist/esm/type-level.mjs",

--- a/libs/ts/base-utils/src/array-iter.spec-d.ts
+++ b/libs/ts/base-utils/src/array-iter.spec-d.ts
@@ -1,0 +1,67 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import { tuple } from './array-iter';
+
+describe('`base-utils/array-iter` tests', () => {
+  describe('`tuple`', () => {
+    it('should preserve literal types', () => {
+      const x = tuple('a', 'b', 'c');
+      const y = tuple('a', true, false, 5n, `${6n}`);
+      const z = tuple('a', true, false, 5n, `${6n}`, ['a', 'b', 'c'], {
+        a: 'a',
+        b: 1,
+        c: true,
+      });
+      expectTypeOf(x).toEqualTypeOf<['a', 'b', 'c']>();
+      expectTypeOf(y).toEqualTypeOf<['a', true, false, 5n, '6']>();
+      expectTypeOf(z).toEqualTypeOf<
+        [
+          'a',
+          true,
+          false,
+          5n,
+          '6',
+          [string, string, string],
+          {
+            a: string;
+            b: number;
+            c: true;
+          },
+        ]
+      >();
+    });
+
+    it('should preserve literal types when nested in object', () => {
+      const x = {
+        a: tuple('a', 'b', 'c'),
+        b: tuple('a', true, false, 5n, `${6n}`),
+        c: tuple('a', true, false, 5n, `${6n}`, ['a', 'b', 'c'], {
+          a: 'a',
+          b: 1,
+          c: true,
+        }),
+      } satisfies {
+        a: string[];
+        b: unknown[];
+        c: unknown[];
+      };
+      expectTypeOf(x).toEqualTypeOf<{
+        a: ['a', 'b', 'c'];
+        b: ['a', true, false, 5n, '6'];
+        c: [
+          'a',
+          true,
+          false,
+          5n,
+          '6',
+          [string, string, string],
+          {
+            a: string;
+            b: number;
+            c: true;
+          },
+        ];
+      }>();
+    });
+  });
+});

--- a/libs/ts/base-utils/src/array-iter.ts
+++ b/libs/ts/base-utils/src/array-iter.ts
@@ -1,3 +1,5 @@
+import { Literal, LiteralTuple, NonEmptyTuple } from './type-level';
+
 export function keysOf<K extends string>(obj: Record<K, unknown>): K[] {
   return Object.keys(obj) as K[];
 }
@@ -16,6 +18,9 @@ export function fromEntries<K extends string, V>(
   return Object.fromEntries(entries) as Record<K, V>;
 }
 
-export function tuple<Args extends any[]>(...args: Args): Args {
+export function tuple<Args extends NonEmptyTuple<T>, T extends Literal>(
+  ...args: Args
+): Args;
+export function tuple<Args extends LiteralTuple>(...args: Args): Args {
   return args;
 }

--- a/libs/ts/base-utils/src/env/functions.spec.ts
+++ b/libs/ts/base-utils/src/env/functions.spec.ts
@@ -1,17 +1,305 @@
 import { describe, expect, test } from 'vitest';
 
-import { getEnvString } from './functions';
+import { Schema as S } from 'effect';
 
-describe('getEnvString', () => {
-  test('returns the value of an existing environment variable', () => {
-    process.env.TEST_VAR = 'test value';
-    expect(getEnvString('TEST_VAR')).toBe('test value');
+import {
+  asVarSchema,
+  EnvSchema,
+  getEnvString,
+  parseEnvVar,
+  parseEnvConfig,
+  parseOptionalEnvVar,
+  parseRequiredEnvVar,
+  VarSchema,
+} from './functions';
+import { NetworkName, networkName } from '../evm';
+import { fromCommaSeparatedString } from '../schemas';
+import { kebabToScreamingSnakeCase } from '../string';
+
+describe('env', () => {
+  describe('getEnvString', () => {
+    test('returns the value of an existing environment variable', () => {
+      process.env.TEST_VAR = 'test value';
+      expect(getEnvString('TEST_VAR')).toBe('test value');
+    });
+
+    test('throws an error if the environment variable is not set', () => {
+      delete process.env.TEST_VAR;
+      expect(() => getEnvString('TEST_VAR')).toThrowError(
+        "Env variable 'TEST_VAR' is missing.",
+      );
+    });
   });
 
-  test('throws an error if the environment variable is not set', () => {
-    delete process.env.TEST_VAR;
-    expect(() => getEnvString('TEST_VAR')).toThrowError(
-      "Env variable 'TEST_VAR' is missing.",
-    );
+  describe('parseEnvVar', () => {
+    test('should parse string', () => {
+      {
+        const parsed = parseEnvVar('HELLO', S.String, false, {
+          HELLO: 'world',
+        });
+        expect(parsed).toEqual('world');
+      }
+
+      {
+        const parsed = parseOptionalEnvVar('HELLO', S.String, {
+          HELLO: 'world',
+        });
+        expect(parsed).toEqual('world');
+      }
+
+      {
+        const parsed = parseRequiredEnvVar('HELLO', S.String, {
+          HELLO: 'world',
+        });
+        expect(parsed).toEqual('world');
+      }
+    });
+
+    test('should throw an error if the variable is not set', () => {
+      expect(() => parseEnvVar('HELLO', S.String, false)).toThrowError(
+        "Env variable 'HELLO' is missing.",
+      );
+
+      expect(() => parseRequiredEnvVar('HELLO', S.String)).toThrowError(
+        "Env variable 'HELLO' is missing.",
+      );
+    });
+
+    test('should parse string with validation', () => {
+      const parsed = parseRequiredEnvVar(
+        'HELLO',
+        S.NonEmptyTrimmedString.pipe(S.uppercased()),
+        {
+          HELLO: 'WORLD',
+        },
+      );
+      expect(parsed).toEqual('WORLD');
+    });
+
+    test('should throw an error if the variable is not valid', () => {
+      expect(() =>
+        parseRequiredEnvVar(
+          'HELLO',
+          S.NonEmptyTrimmedString.pipe(S.uppercased()),
+          {
+            HELLO: ' ',
+          },
+        ),
+      ).toThrowError();
+
+      expect(() =>
+        parseRequiredEnvVar(
+          'HELLO',
+          S.NonEmptyTrimmedString.pipe(S.uppercased()),
+          {
+            HELLO: 'hello',
+          },
+        ),
+      ).toThrowError();
+    });
+
+    test('should parse comma-separated list of numbers', () => {
+      const parsed = parseRequiredEnvVar(
+        'NUMBERS',
+        fromCommaSeparatedString(S.NumberFromString),
+        { NUMBERS: '1,2,3' },
+      );
+      expect(parsed).toEqual([1, 2, 3]);
+    });
+
+    test('should parse comma-separated list of bigints', () => {
+      const parsed = parseRequiredEnvVar(
+        'NUMBERS',
+        fromCommaSeparatedString(S.BigInt),
+        {
+          NUMBERS: '1,2,3,36893488147419103000',
+        },
+      );
+      expect(parsed).toEqual([1n, 2n, 3n, 36893488147419103000n]);
+    });
+
+    // test commaSeparated list of network names
+    test('should parse comma-separated list of network names', () => {
+      const parsed = parseRequiredEnvVar(
+        'NETWORKS',
+        fromCommaSeparatedString(networkName),
+        { NETWORKS: 'ethereum-mainnet,arbitrum-sepolia' },
+      );
+      expect(parsed).toEqual(['ethereum-mainnet', 'arbitrum-sepolia']);
+    });
+
+    describe('parsePerNetworkEnv', () => {
+      const parsePerNetworkEnv = <T, S extends string>(
+        varName: string,
+        networkName: NetworkName,
+        schema: VarSchema<T, S>,
+        env: NodeJS.ProcessEnv = process.env,
+      ): T =>
+        parseRequiredEnvVar(
+          kebabToScreamingSnakeCase(`${varName}_${networkName}`),
+          schema,
+          env,
+        );
+
+      test('should parse environment variable for a specific network', () => {
+        expect(
+          parsePerNetworkEnv('HELLO', 'ethereum-mainnet', S.String, {
+            HELLO_ETHEREUM_MAINNET: 'world',
+          }),
+        ).toEqual('world');
+
+        expect(
+          parsePerNetworkEnv('hello', 'ethereum-mainnet', S.String, {
+            HELLO_ETHEREUM_MAINNET: 'world',
+          }),
+        ).toEqual('world');
+
+        expect(
+          parsePerNetworkEnv('HELLO', 'arbitrum-sepolia', S.String, {
+            HELLO_ARBITRUM_SEPOLIA: 'world',
+          }),
+        ).toEqual('world');
+
+        expect(
+          parsePerNetworkEnv('HELLO', 'arbitrum-sepolia', S.String, {
+            HELLO_ARBITRUM_SEPOLIA: 'arbitrum',
+            HELLO_ETHEREUM_MAINNET: 'ethereum',
+          }),
+        ).toEqual('arbitrum');
+
+        expect(
+          parsePerNetworkEnv('HELLO', 'ethereum-mainnet', S.String, {
+            HELLO_ARBITRUM_SEPOLIA: 'arbitrum',
+            HELLO_ETHEREUM_MAINNET: 'ethereum',
+          }),
+        ).toEqual('ethereum');
+      });
+
+      test('should throw an error if the variable is not set', () => {
+        expect(() =>
+          parsePerNetworkEnv('HELLO', 'ethereum-mainnet', S.String),
+        ).toThrowError("Env variable 'HELLO_ETHEREUM_MAINNET' is missing.");
+      });
+    });
+  });
+
+  describe('parseEnvConfig', () => {
+    const testSchema1 = {
+      NAME: asVarSchema(S.NonEmptyTrimmedString),
+      AMOUNT: asVarSchema(S.NumberFromString),
+    } satisfies EnvSchema;
+
+    test('should parse environment variables correctly', () => {
+      const parsed = parseEnvConfig(testSchema1, '', {
+        NAME: 'Alice',
+        AMOUNT: '100',
+      });
+
+      expect(parsed).toEqual({
+        NAME: 'Alice',
+        AMOUNT: 100,
+      });
+    });
+
+    test('should set to null fields whose env var is missing', () => {
+      {
+        const parsed = parseEnvConfig(testSchema1, '', {
+          NAME: 'Alice',
+        });
+
+        expect(parsed).toEqual({
+          NAME: 'Alice',
+          AMOUNT: null,
+        });
+      }
+
+      {
+        const parsed = parseEnvConfig(testSchema1, '', {
+          NAME: 'Alice',
+          AMOUNT: undefined,
+        });
+
+        expect(parsed).toEqual({
+          NAME: 'Alice',
+          AMOUNT: null,
+        });
+      }
+    });
+
+    test('should throw an error for invalid variable types', () => {
+      expect(() =>
+        parseEnvConfig(testSchema1, '', {
+          NAME: 'Alice',
+          AMOUNT: 'invalid',
+        }),
+      ).toThrowError();
+    });
+
+    test('should throw an error for empty string', () => {
+      expect(() =>
+        parseEnvConfig(testSchema1, '', {
+          NAME: '',
+          AMOUNT: '100',
+        }),
+      ).toThrowError();
+    });
+
+    test('should throw an error for non-string values', () => {
+      expect(() =>
+        parseEnvConfig(testSchema1, '', {
+          NAME: 'Alice',
+          AMOUNT: 100 as any,
+        }),
+      ).toThrowError();
+    });
+
+    const testSchema2 = {
+      MAIN_NETWORK: asVarSchema(networkName),
+      EXTRA_NETWORKS: fromCommaSeparatedString(networkName),
+      BLOCK_NUMBER: S.BigInt,
+      RPC_URL: S.URL,
+    } satisfies EnvSchema;
+
+    test('should parse environment variables with custom schema', () => {
+      const parsed = parseEnvConfig(testSchema2, '', {
+        MAIN_NETWORK: 'ethereum-mainnet',
+        EXTRA_NETWORKS:
+          ' arbitrum-sepolia ,   optimism-sepolia,ethereum-sepolia',
+        BLOCK_NUMBER: `${2n ** 128n}`,
+        RPC_URL: 'https://example.com',
+      });
+
+      expect(parsed).toEqual({
+        MAIN_NETWORK: 'ethereum-mainnet',
+        EXTRA_NETWORKS: [
+          'arbitrum-sepolia',
+          'optimism-sepolia',
+          'ethereum-sepolia',
+        ],
+        RPC_URL: new URL('https://example.com'),
+        BLOCK_NUMBER: 2n ** 128n,
+      });
+    });
+
+    test('should parse suffixed environment variables with custom schema', () => {
+      const parsed = parseEnvConfig(testSchema2, 'SHARED', {
+        MAIN_NETWORK_SHARED: 'ethereum-mainnet',
+        EXTRA_NETWORKS_SHARED:
+          ' arbitrum-sepolia ,   optimism-sepolia,ethereum-sepolia',
+        BLOCK_NUMBER_SHARED: `${2n ** 128n}`,
+        RPC_URL_SHARED: 'https://example.com',
+      });
+
+      expect(parsed).toEqual({
+        MAIN_NETWORK: 'ethereum-mainnet',
+        EXTRA_NETWORKS: [
+          'arbitrum-sepolia',
+          'optimism-sepolia',
+          'ethereum-sepolia',
+        ],
+        RPC_URL: new URL('https://example.com'),
+        BLOCK_NUMBER: 2n ** 128n,
+      });
+    });
   });
 });

--- a/libs/ts/base-utils/src/env/functions.ts
+++ b/libs/ts/base-utils/src/env/functions.ts
@@ -1,4 +1,7 @@
+import { Either, Schema as S } from 'effect';
+
 import { assertNotNull } from '../assert';
+import { envVarNameJoin } from '../string';
 
 /**
  * Retrieves the value of an environment variable.
@@ -28,4 +31,86 @@ export function getEnvStringNotAssert(varName: string): string {
     return '';
   }
   return value;
+}
+
+export function parseRequiredEnvVar<T, S extends string>(
+  varName: string,
+  schema: VarSchema<T, S>,
+  env: NodeJS.ProcessEnv = process.env,
+): T {
+  return parseEnvVar(varName, schema, false, env)!;
+}
+
+export function parseOptionalEnvVar<T, S extends string>(
+  varName: string,
+  schema: VarSchema<T, S>,
+  env: NodeJS.ProcessEnv = process.env,
+): T | null {
+  return parseEnvVar(varName, schema, true, env);
+}
+
+export function parseEnvVar<T, S extends string>(
+  varName: string,
+  schema: VarSchema<T, S>,
+  optional: boolean = false,
+  env: NodeJS.ProcessEnv = process.env,
+): T | null {
+  const value = S.decodeUnknownEither(schema)(env[varName]);
+
+  if (Either.isLeft(value)) {
+    if (env[varName] == null) {
+      if (optional) {
+        return null;
+      }
+      throw new Error(`Env variable '${varName}' is missing.`);
+    }
+
+    throw new Error(`Env variable '${varName}' is invalid`, {
+      cause: value.left,
+    });
+  } else {
+    return value.right;
+  }
+}
+
+export type VarSchema<T = any, S extends string = string> = S.Schema<T, S>;
+
+export function asVarSchema<T, S extends string>(
+  schema: S.Schema<T, S>,
+): VarSchema<T> {
+  return schema as S.Any as VarSchema<T>;
+}
+
+export type EnvSchema = {
+  [key: string]: VarSchema;
+};
+
+export type EnvTypeFromSchema<
+  T extends EnvSchema,
+  VarsAreOptional extends boolean = true,
+> = {
+  [K in keyof T]: T[K] extends VarSchema<infer U>
+    ? VarsAreOptional extends true
+      ? U | null
+      : U
+    : never;
+};
+
+export function parseEnvConfig<Env$ extends EnvSchema>(
+  config: Env$,
+  suffix?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): EnvTypeFromSchema<Env$> {
+  const res = {} as EnvTypeFromSchema<Env$>;
+
+  for (const key in config) {
+    const varName = envVarNameJoin(key, suffix);
+    const schema = assertNotNull(
+      config[key],
+      `Schema at '${key}' is missing for '${varName}' env variable`,
+    );
+    res[key] = parseOptionalEnvVar(varName, schema, env);
+  }
+
+  return res;
 }

--- a/libs/ts/base-utils/src/env/index.ts
+++ b/libs/ts/base-utils/src/env/index.ts
@@ -1,2 +1,4 @@
-export * from './functions';
 export * from './constants';
+export * from './functions';
+
+// layered-config is not exported here, as it is not browser-compatible

--- a/libs/ts/base-utils/src/env/layered-config.ts
+++ b/libs/ts/base-utils/src/env/layered-config.ts
@@ -1,0 +1,241 @@
+import { Schema as S, Either, Pretty } from 'effect';
+
+import { fromEntries, entriesOf, keysOf } from '../array-iter';
+import { assert, assertNotNull } from '../assert';
+import { envVarNameJoin } from '../string';
+import { RenderArgs, alignRight, color, renderToString, drawBox } from '../tty';
+import { UnionToIntersection } from '../type-level';
+
+import {
+  EnvSchema,
+  EnvTypeFromSchema,
+  parseEnvConfig,
+  VarSchema,
+} from './functions';
+
+export type { EnvSchema, VarSchema, EnvTypeFromSchema } from './functions';
+
+export type LayeredEnvSchema<
+  LayerNames extends readonly [string, ...string[]],
+  Layers extends Record<LayerNames[number], EnvSchema>,
+> = {
+  priority: LayerNames;
+  suffixes: Record<LayerNames[number], string>;
+  layers: Layers;
+};
+
+export type LayeredEnvSchemaToConfig<
+  LayerNames extends readonly [string, ...string[]],
+  Layers extends Record<LayerNames[number], EnvSchema>,
+  VarsAreOptional extends boolean = true,
+> = {
+  priority: LayerNames;
+  suffixes: Record<LayerNames[number], string>;
+  layers: {
+    [key in LayerNames[number]]: EnvTypeFromSchema<
+      Layers[key],
+      VarsAreOptional
+    >;
+  };
+  mergedConfig: UnionToIntersection<
+    {
+      [L in keyof LayerNames]: EnvTypeFromSchema<
+        Layers[LayerNames[L]],
+        VarsAreOptional
+      >;
+    }[number]
+  >;
+  mergedConfigSchema: UnionToIntersection<
+    {
+      [L in keyof LayerNames]: { layer: string; schema: Layers[LayerNames[L]] };
+    }[number]
+  >;
+};
+
+export function parseLayeredEnvConfig<
+  LayerNames extends readonly [string, ...string[]],
+  Layers extends Record<LayerNames[number], EnvSchema>,
+>(
+  config: LayeredEnvSchema<LayerNames, Layers>,
+  env: NodeJS.ProcessEnv = process.env,
+): LayeredEnvSchemaToConfig<LayerNames, Layers> {
+  // order schema layers by priority
+  const schemaLayers = config.priority.map(
+    (layerName: LayerNames[number]) =>
+      [layerName, config.layers[layerName]] as const,
+  );
+  const mergedConfigSchema = mergeSchemaLayers(schemaLayers);
+
+  const mergeSchemaWithoutLayerAnnotations = fromEntries(
+    entriesOf(mergedConfigSchema).map(
+      ([key, { schema }]) => [key, S.NullOr(schema)] as const,
+    ),
+  );
+
+  const result = {
+    mergedConfigSchema,
+    suffixes: config.suffixes,
+    priority: config.priority,
+    layers: {},
+    mergedConfig: {},
+  } as LayeredEnvSchemaToConfig<LayerNames, Layers>;
+
+  const mergedConfig = result.mergedConfig as Record<string, any>;
+  for (const layerName_ of config.priority) {
+    const layerName = layerName_ as LayerNames[number];
+    const layer = config.layers[layerName];
+    const parsedLayer = parseEnvConfig(layer, config.suffixes[layerName], env);
+    result.layers[layerName] = parsedLayer;
+
+    for (const key of keysOf(layer)) {
+      if (mergedConfig[key] == null) {
+        (result.mergedConfig as any)[key] = parsedLayer[key];
+      }
+    }
+  }
+
+  // Validate the merged configuration against the schema
+  const validationResult = S.validateEither(
+    S.Struct(mergeSchemaWithoutLayerAnnotations),
+  )(result.mergedConfig);
+
+  if (Either.isLeft(validationResult)) {
+    throw new Error(
+      'Merged configuration is invalid:\n' + validationResult.left,
+    );
+  }
+
+  return result;
+}
+
+export type MergedConfigSchema = Record<
+  string,
+  { layer: string; schema: VarSchema }
+>;
+
+function mergeSchemaLayers(
+  layers: Iterable<readonly [string, EnvSchema]>,
+): MergedConfigSchema {
+  const mergedConfigSchema = {} as MergedConfigSchema;
+  for (const [layerName, layer] of layers) {
+    for (const key of keysOf(layer)) {
+      const schema = layer[key];
+      if (!(key in mergedConfigSchema)) {
+        mergedConfigSchema[key] = {
+          layer: layerName,
+          schema: schema as VarSchema,
+        };
+      } else {
+        const schemaToJSON = (schema: S.Schema.All) =>
+          JSON.stringify(schema.ast.toJSON(), null, 2);
+        // TODO: find a more performant way to check for schema equality
+        const s1 = schema;
+        const s2 = mergedConfigSchema[key].schema;
+        const s1JSON = schemaToJSON(s1);
+        const s2JSON = schemaToJSON(s2);
+        assert(
+          s1JSON === s2JSON,
+          `Schema for '${key}' is different at different layers:` +
+            `\n  at '${layerName}': '${s1}'` +
+            `\n  at '${mergedConfigSchema[key].layer}': '${s2}'` +
+            (`${s1}` === `${s2}` ? `\n  ${s1JSON}` + `\n  ${s2JSON}` : ''),
+        );
+      }
+    }
+  }
+
+  return mergedConfigSchema;
+}
+
+export function reportParsedEnvConfig<
+  LayerNames extends readonly [string, ...string[]],
+  Layers extends Record<LayerNames[number], EnvSchema>,
+>(
+  config: LayeredEnvSchemaToConfig<LayerNames, Layers>,
+  tty = true,
+): {
+  missingEnvVariables: string[];
+  validationMessage: string;
+  isValid: boolean;
+} {
+  const getColumnWidth = <Str extends string>(cells: Str[]) =>
+    cells.reduce((max, cell) => Math.max(max, cell.length), 0);
+
+  const mergedConfigSchema = config.mergedConfigSchema as MergedConfigSchema;
+  const mergedConfig = config.mergedConfig as Record<string, unknown>;
+  const keys = keysOf(mergedConfigSchema);
+  const groupedKeys = entriesOf(
+    Object.groupBy(keys, key => mergedConfigSchema[key].layer),
+  ).sort(([layerA], [layerB]) => {
+    const indexA = config.priority.indexOf(layerA as LayerNames[number]);
+    const indexB = config.priority.indexOf(layerB as LayerNames[number]);
+    return indexB - indexA;
+  });
+
+  const getVarInfo = (key: string) => {
+    const { layer: layer_, schema } = mergedConfigSchema[key];
+    assert(
+      S.isSchema(schema),
+      `Expected schema for '${key}' but got '${schema}'`,
+    );
+    const layer = layer_ as LayerNames[number];
+    const suffix = config.suffixes[layer];
+    const envVarName = envVarNameJoin(key, suffix);
+    const value = mergedConfig[key];
+    return { key, value, layer, envVarName, schema };
+  };
+
+  const longestKeyLength = getColumnWidth(keys);
+  const longestLayerLength = getColumnWidth(
+    groupedKeys.map(([layer]) => layer),
+  );
+  const columnWidth = Math.max(longestKeyLength, longestLayerLength);
+
+  const missingEnvVariables: string[] = [];
+  const formatLayerKeys = (layerKeys: string[]) => (args: RenderArgs) => {
+    let layerText = [];
+    for (const key of layerKeys) {
+      const { envVarName, value, layer, schema } = getVarInfo(key);
+      const keyFormatted = `${alignRight(key, columnWidth + 2, ' ')}: `;
+      const envVarFormatted = color`({bold ${layer}} env var {bold ${envVarName}})`;
+
+      if (value != null) {
+        const prettyPrint = Pretty.make(schema);
+        layerText.push(
+          keyFormatted +
+            color`✅ {bold ${prettyPrint(value)}} {green ${envVarFormatted}}`,
+        );
+      } else {
+        missingEnvVariables.push(envVarName);
+        layerText.push(
+          keyFormatted + color`❌ {red {underline missing} ${envVarFormatted}}`,
+        );
+      }
+    }
+    return layerText;
+  };
+
+  const text = renderToString(
+    { maxWidth: process.stdout.columns ?? 120 },
+    drawBox(
+      'Env config',
+      ...groupedKeys.map(([layer, layerKeys_]) =>
+        drawBox(layer, formatLayerKeys(assertNotNull(layerKeys_))),
+      ),
+      drawBox('Summary', () =>
+        missingEnvVariables.length === 0
+          ? [color`{green {bold All env variables are set.}}`]
+          : [
+              color`{red {bold Missing env variables:}}`,
+              ...missingEnvVariables,
+            ],
+      ),
+    ),
+  );
+
+  return {
+    missingEnvVariables,
+    validationMessage: text,
+    isValid: missingEnvVariables.length === 0,
+  };
+}

--- a/libs/ts/base-utils/src/evm/functions.spec-d.ts
+++ b/libs/ts/base-utils/src/evm/functions.spec-d.ts
@@ -1,0 +1,100 @@
+import { describe, expectTypeOf, test } from 'vitest';
+
+import { Schema as S } from 'effect';
+
+import { asVarSchema } from '../env/functions';
+import { fromCommaSeparatedString } from '../schemas';
+import { EthereumAddress, ethereumAddress } from './hex-types';
+import { networkName, NetworkName } from './networks';
+import { DeploymentEnvSchema, parseDeploymentEnvConfig } from './functions';
+
+describe('evm/functions', () => {
+  describe('parseDeploymentEnvConfig', () => {
+    const deploymentTestSchema = {
+      global: {
+        NETWORKS: fromCommaSeparatedString(networkName),
+        RETRIES: S.NumberFromString,
+        GAS_LIMIT: S.NumberFromString,
+      },
+      perNetworkKind: {
+        GAS_LIMIT: S.NumberFromString,
+        USE_HW_WALLET: asVarSchema(S.BooleanFromString),
+        DEPLOYER: ethereumAddress,
+        THRESHOLD: S.NumberFromString,
+      },
+      perNetworkName: {
+        GAS_LIMIT: S.NumberFromString,
+        USE_HW_WALLET: asVarSchema(S.BooleanFromString),
+        DEPLOYER: ethereumAddress,
+        THRESHOLD: S.NumberFromString,
+      },
+    } satisfies DeploymentEnvSchema;
+
+    const deploymentTestEnv = {
+      NETWORKS:
+        'local, ethereum-sepolia, ethereum-mainnet, arbitrum-sepolia, arbitrum-mainnet',
+      RETRIES: '3',
+
+      GAS_LIMIT: `${10e9}`,
+      GAS_LIMIT_LOCAL: `${15e9}`,
+      GAS_LIMIT_MAINNET: `${10e9}`,
+      GAS_LIMIT_ETHEREUM_MAINNET: `${7.5e9}`,
+      GAS_LIMIT_ARBITRUM_SEPOLIA: `${25e9}`,
+
+      USE_HW_WALLET_LOCAL: 'true',
+      USE_HW_WALLET_TESTNET: 'false',
+      USE_HW_WALLET_ETHEREUM_MAINNET: 'true',
+
+      DEPLOYER_LOCAL: '0x1111111111111111111111111111111111111111',
+      DEPLOYER_TESTNET: '0x2222222222222222222222222222222222222222',
+      DEPLOYER_ETHEREUM_MAINNET: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      DEPLOYER_ARBITRUM_SEPOLIA: '0x0987654321098765432109876543210987654321',
+
+      THRESHOLD_LOCAL: '1',
+      THRESHOLD_TESTNET: '2',
+      THRESHOLD_ETHEREUM_SEPOLIA: '3',
+      THRESHOLD_ETHEREUM_MAINNET: '4',
+      THRESHOLD_ARBITRUM_SEPOLIA: '5',
+    } satisfies NodeJS.ProcessEnv;
+
+    test('should parse deployment environment variables correctly', () => {
+      const parse = (networkName: NetworkName) =>
+        parseDeploymentEnvConfig(
+          deploymentTestSchema,
+          networkName,
+          deploymentTestEnv,
+        );
+
+      const { layers, mergedConfig } = parse('ethereum-mainnet');
+
+      expectTypeOf(layers).toEqualTypeOf<{
+        global: {
+          NETWORKS: readonly NetworkName[] | null;
+          RETRIES: number | null;
+          GAS_LIMIT: number | null;
+        };
+        perNetworkKind: {
+          GAS_LIMIT: number | null;
+          USE_HW_WALLET: boolean | null;
+          DEPLOYER: EthereumAddress | null;
+          THRESHOLD: number | null;
+        };
+        perNetworkName: {
+          GAS_LIMIT: number | null;
+          USE_HW_WALLET: boolean | null;
+          DEPLOYER: EthereumAddress | null;
+          THRESHOLD: number | null;
+        };
+      }>();
+
+      expectTypeOf({ ...mergedConfig }).toEqualTypeOf<{
+        NETWORKS: readonly NetworkName[] | null;
+        RETRIES: number | null;
+        GAS_LIMIT: number | null;
+        USE_HW_WALLET: boolean | null;
+        DEPLOYER: EthereumAddress | null;
+        THRESHOLD: number | null;
+      }>();
+    });
+  });
+});

--- a/libs/ts/base-utils/src/evm/functions.spec.ts
+++ b/libs/ts/base-utils/src/evm/functions.spec.ts
@@ -1,0 +1,251 @@
+import { describe, expect, test } from 'vitest';
+
+import { Schema as S } from 'effect';
+
+import { EnvSchema, asVarSchema, parseEnvConfig } from '../env/functions';
+import { fromCommaSeparatedString } from '../schemas';
+import { ethereumAddress } from './hex-types';
+import { NetworkName } from './networks';
+import { DeploymentEnvSchema, parseDeploymentEnvConfig } from './functions';
+import { kebabToScreamingSnakeCase } from '../string';
+
+describe('evm/functions', () => {
+  describe('parseNetworkEnvConfig', () => {
+    const parseNetworkEnvConfig = (
+      schema: EnvSchema,
+      networkName: NetworkName,
+      env: NodeJS.ProcessEnv,
+    ) => parseEnvConfig(schema, kebabToScreamingSnakeCase(networkName), env);
+
+    const testSchema = {
+      RPC_URL: S.URL,
+      THRESHOLD: S.NumberFromString,
+      BLOCK_NUMBER: S.BigInt,
+      FEED_IDS: S.Union(S.Literal('all'), fromCommaSeparatedString(S.BigInt)),
+    } satisfies EnvSchema;
+
+    test('should parse environment variables for a specific network', () => {
+      const parsed = parseNetworkEnvConfig(testSchema, 'ethereum-mainnet', {
+        RPC_URL_ETHEREUM_MAINNET: 'https://example.com',
+        THRESHOLD_ETHEREUM_MAINNET: '3',
+        BLOCK_NUMBER_ETHEREUM_MAINNET: `${2n ** 128n}`,
+        FEED_IDS_ETHEREUM_MAINNET: '1,2,3',
+      });
+
+      expect(parsed).toEqual({
+        RPC_URL: new URL('https://example.com'),
+        THRESHOLD: 3,
+        BLOCK_NUMBER: 2n ** 128n,
+        FEED_IDS: [1n, 2n, 3n],
+      });
+    });
+  });
+
+  describe('parseDeploymentEnvConfig', () => {
+    const deploymentTestSchema = {
+      global: {
+        name: S.String,
+        networks: fromCommaSeparatedString(S.String),
+        retries: S.NumberFromString,
+        gasLimit: S.NumberFromString,
+      },
+      perNetworkKind: {
+        gasLimit: S.NumberFromString,
+        useHwWallet: asVarSchema(S.BooleanFromString),
+        deployer: ethereumAddress,
+        threshold: S.NumberFromString,
+      },
+      perNetworkName: {
+        gasLimit: S.NumberFromString,
+        useHwWallet: asVarSchema(S.BooleanFromString),
+        deployer: ethereumAddress,
+        threshold: S.NumberFromString,
+      },
+    } satisfies DeploymentEnvSchema;
+
+    const deploymentTestEnv = {
+      NAME: '',
+      NETWORKS:
+        'local, ethereum-sepolia, ethereum-mainnet, arbitrum-sepolia, arbitrum-mainnet',
+      RETRIES: '3',
+
+      GAS_LIMIT: `${10e9}`,
+      GAS_LIMIT_LOCAL: `${15e9}`,
+      GAS_LIMIT_MAINNET: `${10e9}`,
+      GAS_LIMIT_ETHEREUM_MAINNET: `${7.5e9}`,
+      GAS_LIMIT_ARBITRUM_SEPOLIA: `${25e9}`,
+
+      USE_HW_WALLET_LOCAL: 'true',
+      USE_HW_WALLET_TESTNET: 'false',
+      USE_HW_WALLET_ETHEREUM_MAINNET: 'true',
+
+      DEPLOYER_LOCAL: '0x1111111111111111111111111111111111111111',
+      DEPLOYER_TESTNET: '0x2222222222222222222222222222222222222222',
+      DEPLOYER_ETHEREUM_MAINNET: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      DEPLOYER_ARBITRUM_SEPOLIA: '0x0987654321098765432109876543210987654321',
+
+      THRESHOLD_LOCAL: '1',
+      THRESHOLD_TESTNET: '2',
+      THRESHOLD_ETHEREUM_SEPOLIA: '3',
+      THRESHOLD_ETHEREUM_MAINNET: '4',
+      THRESHOLD_ARBITRUM_SEPOLIA: '5',
+    } satisfies NodeJS.ProcessEnv;
+
+    test('should parse deployment environment variables correctly', () => {
+      const parse = (networkName: NetworkName) =>
+        parseDeploymentEnvConfig(
+          deploymentTestSchema,
+          networkName,
+          deploymentTestEnv,
+        );
+
+      // validateAndPrintDeploymentEnvConfig(parse('arbitrum-mainnet'));
+
+      const ethSepolia = parse('ethereum-sepolia');
+      expect(ethSepolia.suffixes).toEqual({
+        perNetworkName: 'ETHEREUM_SEPOLIA',
+        perNetworkKind: 'TESTNET',
+        global: '',
+      });
+      expect(ethSepolia.mergedConfigSchema).toEqual({
+        // Schemas layers are merged in the order of priority
+        // perNetworkName > perNetworkKind > global
+        gasLimit: {
+          layer: 'perNetworkName',
+          schema: deploymentTestSchema.perNetworkName.gasLimit,
+        },
+        useHwWallet: {
+          layer: 'perNetworkName',
+          schema: deploymentTestSchema.perNetworkName.useHwWallet,
+        },
+        deployer: {
+          layer: 'perNetworkName',
+          schema: deploymentTestSchema.perNetworkName.deployer,
+        },
+        threshold: {
+          layer: 'perNetworkName',
+          schema: deploymentTestSchema.perNetworkName.threshold,
+        },
+
+        name: {
+          layer: 'global',
+          schema: deploymentTestSchema.global.name,
+        },
+        networks: {
+          layer: 'global',
+          schema: deploymentTestSchema.global.networks,
+        },
+        retries: {
+          layer: 'global',
+          schema: deploymentTestSchema.global.retries,
+        },
+      });
+      expect(ethSepolia.mergedConfig).toEqual({
+        name: '',
+        networks: [
+          'local',
+          'ethereum-sepolia',
+          'ethereum-mainnet',
+          'arbitrum-sepolia',
+          'arbitrum-mainnet',
+        ],
+        retries: 3,
+        gasLimit: 10e9, // fallback to global
+        useHwWallet: false, // fallback to testnet
+        deployer: '0x2222222222222222222222222222222222222222', // fallback to testnet
+        threshold: 3, // network-specific
+      });
+
+      expect(ethSepolia.layers).toEqual({
+        global: {
+          name: '',
+          networks: [
+            'local',
+            'ethereum-sepolia',
+            'ethereum-mainnet',
+            'arbitrum-sepolia',
+            'arbitrum-mainnet',
+          ],
+          retries: 3,
+          gasLimit: 10e9,
+        },
+        perNetworkKind: {
+          gasLimit: null,
+          useHwWallet: false,
+          deployer: '0x2222222222222222222222222222222222222222',
+          threshold: 2,
+        },
+        perNetworkName: {
+          gasLimit: null,
+          useHwWallet: null,
+          deployer: null,
+          threshold: 3,
+        },
+      });
+
+      expect(parse('ethereum-mainnet').mergedConfig).toEqual({
+        name: '',
+        networks: [
+          'local',
+          'ethereum-sepolia',
+          'ethereum-mainnet',
+          'arbitrum-sepolia',
+          'arbitrum-mainnet',
+        ],
+        retries: 3,
+        gasLimit: 7.5e9, // network-specific
+        useHwWallet: true, // network-specific
+        deployer: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', // network-specific
+        threshold: 4, // network-specific
+      });
+
+      expect(parse('arbitrum-sepolia').mergedConfig).toEqual({
+        name: '',
+        networks: [
+          'local',
+          'ethereum-sepolia',
+          'ethereum-mainnet',
+          'arbitrum-sepolia',
+          'arbitrum-mainnet',
+        ],
+        retries: 3,
+        gasLimit: 25e9, // network-specific
+        useHwWallet: false, // network-specific
+        deployer: '0x0987654321098765432109876543210987654321', // network-specific
+        threshold: 5, // network-specific
+      });
+
+      expect(parse('arbitrum-mainnet').mergedConfig).toEqual({
+        name: '',
+        networks: [
+          'local',
+          'ethereum-sepolia',
+          'ethereum-mainnet',
+          'arbitrum-sepolia',
+          'arbitrum-mainnet',
+        ],
+        retries: 3,
+        gasLimit: 10e9, // fallback to network kind
+        useHwWallet: null, // not set
+        deployer: null, // not set
+        threshold: null, // not set
+      });
+
+      expect(parse('local').mergedConfig).toEqual({
+        name: '',
+        networks: [
+          'local',
+          'ethereum-sepolia',
+          'ethereum-mainnet',
+          'arbitrum-sepolia',
+          'arbitrum-mainnet',
+        ],
+        retries: 3,
+        gasLimit: 15e9, // network-specific
+        useHwWallet: true, // network-specific
+        deployer: '0x1111111111111111111111111111111111111111', // network-specific
+        threshold: 1, // network-specific
+      });
+    });
+  });
+});

--- a/libs/ts/base-utils/src/evm/functions.ts
+++ b/libs/ts/base-utils/src/evm/functions.ts
@@ -1,0 +1,73 @@
+import {
+  EnvSchema,
+  LayeredEnvSchema,
+  LayeredEnvSchemaToConfig,
+  parseLayeredEnvConfig,
+  reportParsedEnvConfig,
+} from '../env/layered-config';
+import { kebabToScreamingSnakeCase } from '../string';
+import { getNetworkKind, NetworkName } from './networks';
+
+const deploymentEnvLayerPriority = [
+  'perNetworkName',
+  'perNetworkKind',
+  'global',
+] as const;
+
+export type DeploymentEnvPriority = typeof deploymentEnvLayerPriority;
+
+export type DeploymentEnvSchema = LayeredEnvSchema<
+  DeploymentEnvPriority,
+  Record<DeploymentEnvPriority[number], EnvSchema>
+>['layers'];
+
+export function parseDeploymentEnvConfig<
+  EnvSchemaLayers extends Record<DeploymentEnvPriority[number], EnvSchema>,
+  Network extends NetworkName,
+>(
+  config: EnvSchemaLayers,
+  network: Network,
+  env: NodeJS.ProcessEnv = process.env,
+): LayeredEnvSchemaToConfig<DeploymentEnvPriority, EnvSchemaLayers> {
+  const netKind = getNetworkKind(network);
+  const suffixes: Record<DeploymentEnvPriority[number], string> = {
+    global: '',
+    perNetworkKind: kebabToScreamingSnakeCase(netKind),
+    perNetworkName: kebabToScreamingSnakeCase(network),
+  };
+
+  const parsedConfig = parseLayeredEnvConfig(
+    {
+      priority: ['perNetworkName', 'perNetworkKind', 'global'] as const,
+      suffixes,
+      layers: config,
+    },
+    env,
+  );
+
+  return parsedConfig;
+}
+
+export function validateAndPrintDeploymentEnvConfig<
+  EnvSchemaLayers extends Record<DeploymentEnvPriority[number], EnvSchema>,
+>(
+  parsedConfig: LayeredEnvSchemaToConfig<
+    DeploymentEnvPriority,
+    EnvSchemaLayers,
+    true
+  >,
+): LayeredEnvSchemaToConfig<DeploymentEnvPriority, EnvSchemaLayers, false> {
+  const { isValid, validationMessage } = reportParsedEnvConfig(parsedConfig);
+
+  console.log(validationMessage);
+
+  if (!isValid) {
+    throw new Error('Invalid deployment env variables');
+  }
+
+  return parsedConfig as unknown as LayeredEnvSchemaToConfig<
+    DeploymentEnvPriority,
+    EnvSchemaLayers,
+    false
+  >;
+}

--- a/libs/ts/base-utils/src/evm/networks.ts
+++ b/libs/ts/base-utils/src/evm/networks.ts
@@ -146,14 +146,16 @@ const chainIds = [
   1417429182, 324, 300,
 ] as const;
 
-export const networkName = S.Literal(...networks);
+export const networkName = S.Literal(...networks).annotations({
+  identifier: 'NetworkName',
+});
 export const isNetworkName = S.is(networkName);
 export const parseNetworkName = S.decodeUnknownSync(networkName);
 export type NetworkName = typeof networkName.Type;
 
 export const chainId = S.compose(
   NumberFromSelfBigIntOrString,
-  S.Literal(...chainIds),
+  S.Literal(...chainIds).annotations({ identifier: 'ChainId' }),
 );
 export const isChainId = S.is(chainId);
 export const parseChainId = S.decodeUnknownSync(chainId);

--- a/libs/ts/base-utils/src/evm/networks.ts
+++ b/libs/ts/base-utils/src/evm/networks.ts
@@ -164,6 +164,27 @@ export const isNetwork = S.is(network);
 export const parseNetwork = S.decodeUnknownSync(network);
 export type Network = typeof network.Type;
 
+export const networkKindSchema = S.Literal(
+  'local',
+  'testnet',
+  'mainnet',
+).annotations({ identifier: 'NetworkKind' });
+export type NetworkKind = typeof networkKindSchema.Type;
+
+export type NetworkNameToKind<N extends NetworkName> = N extends 'local'
+  ? 'local'
+  : (typeof networkMetadata)[N]['isTestnet'] extends true
+    ? 'testnet'
+    : 'mainnet';
+
+export function getNetworkKind<N extends NetworkName>(
+  network: N,
+): NetworkNameToKind<N> {
+  if (network === 'local') return 'local' as any;
+  if (isTestnet(network)) return 'testnet' as any;
+  return 'mainnet' as any;
+}
+
 export enum Currency {
   ETH = 'ETH',
   AVAX = 'AVAX',

--- a/libs/ts/base-utils/src/string.test.ts
+++ b/libs/ts/base-utils/src/string.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+
+import { camelCaseToScreamingSnakeCase } from './string';
+
+describe('camelCaseSnakeCase', () => {
+  it('should convert a simple camelCase string to SNAKE_CASE', () => {
+    expect(camelCaseToScreamingSnakeCase('fooBar')).toBe('FOO_BAR');
+  });
+
+  it('should convert a camelCase string with multiple humps to SNAKE_CASE', () => {
+    expect(camelCaseToScreamingSnakeCase('fooBarBaz')).toBe('FOO_BAR_BAZ');
+  });
+
+  it('should handle an empty string', () => {
+    expect(camelCaseToScreamingSnakeCase('')).toBe('');
+  });
+
+  it('should handle a string that is already SNAKE_CASE (it should remain uppercase)', () => {
+    expect(camelCaseToScreamingSnakeCase('FOO_BAR')).toBe('FOO_BAR');
+  });
+
+  it('should handle a single word in lowercase', () => {
+    expect(camelCaseToScreamingSnakeCase('foobar')).toBe('FOOBAR');
+  });
+
+  it('should handle a single word in uppercase', () => {
+    expect(camelCaseToScreamingSnakeCase('FOOBAR')).toBe('FOOBAR');
+  });
+
+  it('should handle strings with numbers', () => {
+    expect(camelCaseToScreamingSnakeCase('fooBar123')).toBe('FOO_BAR123');
+    expect(camelCaseToScreamingSnakeCase('foo123Bar')).toBe('FOO123_BAR');
+  });
+
+  it('should handle strings starting with an uppercase letter', () => {
+    expect(camelCaseToScreamingSnakeCase('FooBar')).toBe('FOO_BAR');
+  });
+
+  it('should handle strings with consecutive uppercase letters', () => {
+    expect(camelCaseToScreamingSnakeCase('fooBARBaz')).toBe('FOO_BAR_BAZ');
+    expect(camelCaseToScreamingSnakeCase('aBCDToEFG')).toBe('A_BCD_TO_EFG');
+  });
+
+  it('should handle strings with leading and trailing uppercase letters', () => {
+    expect(camelCaseToScreamingSnakeCase('HTTPRequest')).toBe('HTTP_REQUEST');
+    expect(camelCaseToScreamingSnakeCase('HttpRequest')).toBe('HTTP_REQUEST');
+    expect(camelCaseToScreamingSnakeCase('requestHTTP')).toBe('REQUEST_HTTP');
+    expect(camelCaseToScreamingSnakeCase('requestHttp')).toBe('REQUEST_HTTP');
+  });
+});

--- a/libs/ts/base-utils/src/string.test.ts
+++ b/libs/ts/base-utils/src/string.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { camelCaseToScreamingSnakeCase } from './string';
+import { camelCaseToScreamingSnakeCase, envVarNameJoin } from './string';
 
 describe('camelCaseSnakeCase', () => {
   it('should convert a simple camelCase string to SNAKE_CASE', () => {
@@ -46,5 +46,55 @@ describe('camelCaseSnakeCase', () => {
     expect(camelCaseToScreamingSnakeCase('HttpRequest')).toBe('HTTP_REQUEST');
     expect(camelCaseToScreamingSnakeCase('requestHTTP')).toBe('REQUEST_HTTP');
     expect(camelCaseToScreamingSnakeCase('requestHttp')).toBe('REQUEST_HTTP');
+  });
+});
+
+describe('envVarNameJoin', () => {
+  it('should join multiple camelCase strings and convert them to SCREAMING_SNAKE_CASE', () => {
+    expect(envVarNameJoin('fooBar', 'bazQux', 'helloWorld')).toBe(
+      'FOO_BAR_BAZ_QUX_HELLO_WORLD',
+    );
+  });
+
+  it('should filter out null and undefined parts', () => {
+    expect(
+      envVarNameJoin('partOne', null, 'partTwo', undefined, 'partThree'),
+    ).toBe('PART_ONE_PART_TWO_PART_THREE');
+  });
+
+  it('should filter out empty string parts', () => {
+    expect(
+      envVarNameJoin('firstPart', '', 'secondPart', '  ', 'thirdPart'),
+    ).toBe('FIRST_PART_SECOND_PART_THIRD_PART');
+  });
+
+  it('should handle an empty array of parts', () => {
+    expect(envVarNameJoin()).toBe('');
+  });
+
+  it('should handle an array with only null, undefined, or empty string parts', () => {
+    expect(envVarNameJoin(null, undefined, '', '   ')).toBe('');
+  });
+
+  it('should handle a single valid part', () => {
+    expect(envVarNameJoin('singlePart')).toBe('SINGLE_PART');
+  });
+
+  it('should handle parts that are already in SCREAMING_SNAKE_CASE', () => {
+    expect(envVarNameJoin('ALREADY_SNAKE', 'anotherPart')).toBe(
+      'ALREADY_SNAKE_ANOTHER_PART',
+    );
+  });
+
+  it('should handle mixed case parts correctly', () => {
+    expect(envVarNameJoin('mixedCase', 'ALLCAPS', 'lowerCase')).toBe(
+      'MIXED_CASE_ALLCAPS_LOWER_CASE',
+    );
+  });
+
+  it('should handle parts with numbers', () => {
+    expect(envVarNameJoin('part1', 'part2WithNumber')).toBe(
+      'PART1_PART2_WITH_NUMBER',
+    );
   });
 });

--- a/libs/ts/base-utils/src/string.ts
+++ b/libs/ts/base-utils/src/string.ts
@@ -53,6 +53,22 @@ export function kebabToCamelCase<Str extends string>(
 }
 
 /**
+ * Converts a camelCase string to SCREAMING_SNAKE_CASE.
+ * @param str - The camelCase string to convert.
+ * @returns The SCREAMING_SNAKE_CASE version of the input string.
+ * @example
+ * ```ts
+ * camelCaseToScreamingSnakeCase('fooBar'); // 'FOO_BAR'
+ * ```
+ */
+export function camelCaseToScreamingSnakeCase(str: string) {
+  return str
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/([A-Z]+)([A-Z])([a-z])/g, '$1_$2$3')
+    .toUpperCase();
+}
+
+/**
  * Compares two strings for equality in a case-insensitive manner.
  *
  * @param a - The first string to compare.

--- a/libs/ts/base-utils/src/string.ts
+++ b/libs/ts/base-utils/src/string.ts
@@ -85,3 +85,12 @@ export function equalsCaseInsensitive(a: string, b: string) {
 export function padNumber(num: number | bigint, size: number, padChar = ' ') {
   return num.toString().padStart(size, padChar);
 }
+
+export function envVarNameJoin(
+  ...parts: (string | null | undefined)[]
+): string {
+  return parts
+    .filter(x => x?.trim()?.length ?? 0 > 0)
+    .map(part => camelCaseToScreamingSnakeCase(part!))
+    .join('_');
+}

--- a/libs/ts/base-utils/src/tty.ts
+++ b/libs/ts/base-utils/src/tty.ts
@@ -1,0 +1,363 @@
+import { createInterface, Interface } from 'node:readline/promises';
+
+import { assert } from './assert';
+
+let _readline: Interface | null = null;
+
+export function readline(): Interface {
+  if (!_readline) {
+    _readline = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+  }
+  return _readline;
+}
+
+export const { isTTY } = process.stdout;
+
+/**
+ * ANSI escape sequences mapping.
+ * Keys are the style names you'll use in the template literal (e.g., {bold ...}).
+ * Each entry has an 'on' and 'off' code.
+ * 'off' codes are crucial for proper nesting and preventing style bleed.
+ */
+const ttyStyles = {
+  // Styles
+  reset: { on: '\u001b[0m', off: '' }, // Reset all, 'off' is empty as it's a full reset
+  bold: { on: '\u001b[1m', off: '\u001b[22m' },
+  dim: { on: '\u001b[2m', off: '\u001b[22m' }, // Dim and Bold share an off code
+  italic: { on: '\u001b[3m', off: '\u001b[23m' },
+  underline: { on: '\u001b[4m', off: '\u001b[24m' },
+  blink: { on: '\u001b[5m', off: '\u001b[25m' },
+  inverse: { on: '\u001b[7m', off: '\u001b[27m' },
+  hidden: { on: '\u001b[8m', off: '\u001b[28m' }, // aka conceal
+  strikethrough: { on: '\u001b[9m', off: '\u001b[29m' },
+
+  // Foreground colors
+  black: { on: '\u001b[30m', off: '\u001b[39m' },
+  red: { on: '\u001b[31m', off: '\u001b[39m' },
+  green: { on: '\u001b[32m', off: '\u001b[39m' },
+  yellow: { on: '\u001b[33m', off: '\u001b[39m' },
+  blue: { on: '\u001b[34m', off: '\u001b[39m' },
+  magenta: { on: '\u001b[35m', off: '\u001b[39m' },
+  cyan: { on: '\u001b[36m', off: '\u001b[39m' },
+  white: { on: '\u001b[37m', off: '\u001b[39m' },
+  gray: { on: '\u001b[90m', off: '\u001b[39m' }, // Bright black
+  grey: { on: '\u001b[90m', off: '\u001b[39m' }, // Alias for gray
+
+  // Bright foreground colors
+  brightRed: { on: '\u001b[91m', off: '\u001b[39m' },
+  brightGreen: { on: '\u001b[92m', off: '\u001b[39m' },
+  brightYellow: { on: '\u001b[93m', off: '\u001b[39m' },
+  brightBlue: { on: '\u001b[94m', off: '\u001b[39m' },
+  brightMagenta: { on: '\u001b[95m', off: '\u001b[39m' },
+  brightCyan: { on: '\u001b[96m', off: '\u001b[39m' },
+  brightWhite: { on: '\u001b[97m', off: '\u001b[39m' },
+
+  // Background colors
+  bgBlack: { on: '\u001b[40m', off: '\u001b[49m' },
+  bgRed: { on: '\u001b[41m', off: '\u001b[49m' },
+  bgGreen: { on: '\u001b[42m', off: '\u001b[49m' },
+  bgYellow: { on: '\u001b[43m', off: '\u001b[49m' },
+  bgBlue: { on: '\u001b[44m', off: '\u001b[49m' },
+  bgMagenta: { on: '\u001b[45m', off: '\u001b[49m' },
+  bgCyan: { on: '\u001b[46m', off: '\u001b[49m' },
+  bgWhite: { on: '\u001b[47m', off: '\u001b[49m' },
+  bgGray: { on: '\u001b[100m', off: '\u001b[49m' }, // Bright black background
+  bgGrey: { on: '\u001b[100m', off: '\u001b[49m' }, // Alias
+
+  // Bright background colors
+  bgBrightRed: { on: '\u001b[101m', off: '\u001b[49m' },
+  bgBrightGreen: { on: '\u001b[102m', off: '\u001b[49m' },
+  bgBrightYellow: { on: '\u001b[103m', off: '\u001b[49m' },
+  bgBrightBlue: { on: '\u001b[104m', off: '\u001b[49m' },
+  bgBrightMagenta: { on: '\u001b[105m', off: '\u001b[49m' },
+  bgBrightCyan: { on: '\u001b[106m', off: '\u001b[49m' },
+  bgBrightWhite: { on: '\u001b[107m', off: '\u001b[49m' },
+};
+
+/**
+ * Template literal tag function to apply ANSI styles.
+ * Usage: color`{bold This is {red bold red}} and this is normal.`
+ * @param {string[]} strings - Array of static string parts.
+ * @param  {...any} values - Array of evaluated expressions.
+ * @returns {string} - The string with ANSI escape codes applied.
+ */
+export function color(strings: TemplateStringsArray, ...values: unknown[]) {
+  // 1. Reconstruct the raw string with interpolated values
+  let rawString = strings[0];
+  for (let i = 0; i < values.length; i++) {
+    rawString += values[i] + strings[i + 1];
+  }
+
+  // 2. Recursive parser function
+  function parseAndStyle(text: string) {
+    let result = '';
+    let currentIndex = 0;
+
+    while (currentIndex < text.length) {
+      // Regex to find the start of a style tag: {styleName<space>
+      // We look for a word followed by a space after '{'
+      const openTagMatch = text.substring(currentIndex).match(/{(\w+)\s/);
+
+      if (!openTagMatch || typeof openTagMatch.index === 'undefined') {
+        // No more tags, append the rest of the text
+        result += text.substring(currentIndex);
+        break;
+      }
+
+      const tagStartIndex = currentIndex + openTagMatch.index;
+      const styleName = openTagMatch[1];
+      // contentStartIndex is after "{styleName "
+      const contentStartIndex = tagStartIndex + styleName.length + 2; // 1 for '{', 1 for space
+
+      // Append text before this tag
+      result += text.substring(currentIndex, tagStartIndex);
+
+      // Find the matching closing brace '}' for this tag
+      // This needs to handle nested braces correctly.
+      let braceBalance = 1;
+      let contentEndIndex = -1;
+      for (let i = contentStartIndex; i < text.length; i++) {
+        if (text[i] === '{') {
+          // Check if it's a new style tag or just a literal brace
+          // A simple heuristic: if it's followed by a word and a space, assume new tag
+          if (text.substring(i).match(/{(\w+)\s/)) {
+            braceBalance++;
+          }
+        } else if (text[i] === '}') {
+          braceBalance--;
+          if (braceBalance === 0) {
+            contentEndIndex = i;
+            break;
+          }
+        }
+      }
+
+      if (contentEndIndex === -1) {
+        // Malformed: no closing brace. Treat the rest as literal.
+        // This includes the opening part of the malformed tag.
+        console.warn(
+          `[tty-color] Malformed style tag: No closing brace for '{${styleName}' starting at index ${tagStartIndex} in chunk "${text.substring(currentIndex, currentIndex + 30)}..."`,
+        );
+        result += text.substring(tagStartIndex);
+        currentIndex = text.length; // End processing
+      } else {
+        const content = text.substring(contentStartIndex, contentEndIndex);
+        const ttyStyles_: Record<string, { on: string; off: string }> =
+          ttyStyles;
+        const style = ttyStyles_[styleName];
+
+        if (style) {
+          result += style.on;
+          result += parseAndStyle(content); // Recursive call for the content
+          result += style.off;
+        } else {
+          // Unknown style, output the tag literally but parse its content
+          console.warn(`[tty-color] Unknown style: ${styleName}`);
+          result += `{${styleName} `;
+          result += parseAndStyle(content); // Still parse content for nested known styles
+          result += `}`;
+        }
+        currentIndex = contentEndIndex + 1;
+      }
+    }
+    return result;
+  }
+
+  return parseAndStyle(rawString);
+}
+
+export function alignText(
+  text: string,
+  width: number,
+  alignDir: 'left' | 'center' | 'right',
+  padding = ' ',
+) {
+  const textWidth = getTextWidth(text);
+  if (textWidth >= width) return text;
+  const paddingLength = width - textWidth;
+  switch (alignDir) {
+    case 'left':
+      return text + padding.repeat(paddingLength);
+    case 'right':
+      return padding.repeat(paddingLength) + text;
+    case 'center': {
+      const leftPadding = Math.floor(paddingLength / 2);
+      const rightPadding = paddingLength - leftPadding;
+      return padding.repeat(leftPadding) + text + padding.repeat(rightPadding);
+    }
+    default:
+      throw new Error(`Invalid alignment direction: ${alignDir}`);
+  }
+}
+
+export const alignLeft = (text: string, width: number, padding = ' ') =>
+  alignText(text, width, 'left', padding);
+export const alignRight = (text: string, width: number, padding = ' ') =>
+  alignText(text, width, 'right', padding);
+export const alignCenter = (text: string, width: number, padding = ' ') =>
+  alignText(text, width, 'center', padding);
+
+export function getTextWidth(str: string) {
+  // 1. Remove ANSI escape sequences.
+  const cleanedStr = str.replace(/\u001b\[[0-9;?]*m/g, '');
+  if (!cleanedStr) return 0; // Handle empty or only-ANSI string
+
+  const segmenter = new Intl.Segmenter(undefined, {
+    granularity: 'grapheme',
+  });
+
+  let width = 0;
+  for (const { segment: grapheme } of segmenter.segment(cleanedStr)) {
+    const firstCodePoint = grapheme.codePointAt(0);
+    // 2. Disallow newline/tab.
+    if (grapheme === '\n' || grapheme === '\t' || firstCodePoint == null) {
+      throw new Error(
+        `Unsupported char: '${grapheme === '\n' ? '\\n' : '\\t'}'`,
+      );
+    }
+
+    // Check if the grapheme is composed of exactly this single code point.
+    const isSingleCodePointGrapheme =
+      String.fromCodePoint(firstCodePoint) === grapheme;
+
+    // 3. Handle single-width characters:
+    //    - Printable ASCII (U+0020 space to U+007E ~)
+    //    - Box Drawing characters (U+2500 to U+257F)
+    if (
+      isSingleCodePointGrapheme &&
+      ((firstCodePoint >= 0x20 && firstCodePoint <= 0x7e) ||
+        (firstCodePoint >= 0x2000 && firstCodePoint <= 0x206f) || // General Punctuation
+        (firstCodePoint >= 0x2500 && firstCodePoint <= 0x257f))
+    ) {
+      width += 1;
+      // 4. Approximate emoji detection (width 2):
+      //    - Grapheme's first char is Extended_Pictographic OR
+      //    - Grapheme consists of more than one Unicode scalar value (complex emoji).
+    } else if (
+      /\p{Extended_Pictographic}/u.test(String.fromCodePoint(firstCodePoint)) ||
+      !isSingleCodePointGrapheme
+    ) {
+      width += 2;
+    } else {
+      // 5. Throw for anything else.
+      throw new Error(
+        `Unsupported grapheme: '${grapheme}' (U+${firstCodePoint.toString(16).toUpperCase()})`,
+      );
+    }
+  }
+  return width;
+}
+
+export type RenderArgs = { maxWidth: number };
+
+export type Element = string | ((args: RenderArgs) => string[]);
+
+export const renderTui = (...elements: Element[]): void =>
+  console.log(
+    renderToString({ maxWidth: process.stdout.columns }, ...elements),
+  );
+
+export const renderToString = (
+  args: RenderArgs,
+  ...elements: Element[]
+): string => renderAllElements(args, ...elements).join('\n');
+
+export const renderAllElements = (
+  args: RenderArgs,
+  ...elements: Element[]
+): string[] => elements.flatMap(e => renderSingleElement(args, e));
+
+export function renderSingleElement(args: RenderArgs, el: Element): string[] {
+  const res = typeof el === 'function' ? el(args) : [el];
+
+  for (let i = 0; i < res.length; i++) {
+    const line = res[i];
+    if (typeof line !== 'string') {
+      throw new Error(`Expected a string, but got '${line}'`);
+    }
+    const wrappedContent = wrapLines(line, args.maxWidth);
+    res.splice(i, 1, ...wrappedContent);
+    i += wrappedContent.length - 1;
+  }
+
+  // trim lines which overflow after wrapping
+  for (let i = 0; i < res.length; i++) {
+    const line = res[i];
+    if (getTextWidth(line) > args.maxWidth) {
+      res[i] = line.slice(0, args.maxWidth);
+    }
+  }
+
+  return res;
+}
+
+export function renderSingleLine(args: RenderArgs, el: Element): string {
+  const lines = renderSingleElement(args, el);
+  if (lines.length != 1) {
+    throw new Error(`Expected a single line, but got ${lines.length} lines`);
+  }
+  return lines[0];
+}
+
+export function wrapLines(text: string, width: number) {
+  if (getTextWidth(text) <= width) {
+    return [text];
+  }
+  const words = text.split(' ');
+  const lines: string[] = [];
+  let currentLine = '';
+  for (const word of words) {
+    const wordWidth = getTextWidth(word);
+    if (currentLine.length + wordWidth > width) {
+      lines.push(currentLine);
+      currentLine = '';
+    }
+    if (currentLine.length > 0) {
+      currentLine += ' ';
+    }
+    currentLine += word;
+  }
+  if (currentLine.length > 0) {
+    lines.push(currentLine);
+  }
+  return lines;
+}
+
+// UI utils
+
+export const line = (len: number) => '─'.repeat(len);
+
+export const vlist = (lines: string[]) => lines.map(l => color`• {bold ${l}}`);
+
+export const drawTitle = (txt: Element) => (args: RenderArgs) => [
+  color`╼ {bold ${renderSingleLine(args, txt)}} ╾`,
+];
+
+export const drawBox =
+  (title: Element, ...content: Element[]) =>
+  (args: RenderArgs) => {
+    args = { maxWidth: args.maxWidth - 4 };
+    title = renderSingleLine(args, drawTitle(title));
+    const renderedContent = renderAllElements(args, ...content);
+    const contentWidth = [title, ...renderedContent].reduce(
+      (max, line) => Math.max(max, getTextWidth(line)),
+      0,
+    );
+    assert(
+      contentWidth <= args.maxWidth,
+      `Content is too wide: ${contentWidth} > ${args.maxWidth}`,
+    );
+    const boxWidth = Math.min(contentWidth, args.maxWidth);
+    const topBorder = `╭${alignLeft(title, boxWidth + 2, '─')}╮`;
+    const botBorder = `╰${line(boxWidth + 2)}╯`;
+    const result = [];
+    result.push(topBorder);
+    for (const line of renderedContent) {
+      result.push(`│ ${alignLeft(line, boxWidth, ' ')} │`);
+    }
+    result.push(botBorder);
+    return result;
+  };

--- a/libs/ts/base-utils/src/type-level.spec-d.ts
+++ b/libs/ts/base-utils/src/type-level.spec-d.ts
@@ -1,0 +1,14 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { UnionToIntersection } from './type-level';
+
+describe('`base-utils/type-level` tests', () => {
+  describe('UnionToIntersection', () => {
+    it('should intersect a union of simple types', () => {
+      type A = { a: string };
+      type B = { b: number };
+      type C = { c: boolean };
+
+      expectTypeOf<UnionToIntersection<A | B | C>>().toEqualTypeOf<A & B & C>();
+    });
+  });
+});

--- a/libs/ts/base-utils/src/type-level.ts
+++ b/libs/ts/base-utils/src/type-level.ts
@@ -6,6 +6,15 @@
  */
 
 export type PrimitiveType = boolean | number | string | symbol | bigint;
+export type LiteralScalar = PrimitiveType | undefined | null;
+export type NonEmptyTuple<T> = [T, ...T[]];
+export type LiteralTuple = [Literal, ...Literal[]]; // NonEmptyTuple<Literal> does not work :(
+export type Literal =
+  | LiteralScalar
+  | LiteralTuple
+  | {
+      [key: string]: Literal;
+    };
 
 export type KeysOf<T> = Extract<keyof T, string>;
 export type ValuesOf<T> = T[KeysOf<T>];

--- a/libs/ts/base-utils/src/type-level.ts
+++ b/libs/ts/base-utils/src/type-level.ts
@@ -55,3 +55,9 @@ export type ReplaceType<Where, Replace, WithWhat> = Where extends Replace
 export function isObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
+
+export type UnionToIntersection<U> = (
+  U extends any ? (x: U) => void : never
+) extends (x: infer I) => void
+  ? I
+  : never;

--- a/libs/ts/config-types/src/data-feeds-config/types.ts
+++ b/libs/ts/config-types/src/data-feeds-config/types.ts
@@ -178,14 +178,14 @@ export const NewFeedSchema = S.mutable(
       aggregation: S.Union(S.Literal('median')).annotations({
         identifier: 'QuorumAggregation',
       }),
-    }),
+    }).annotations({ identifier: 'FeedQuorum' }),
 
     schedule: S.Struct({
       interval_ms: S.Number,
       heartbeat_ms: S.Number,
       deviation_percentage: S.Number,
       first_report_start_unix_time_ms: S.Number,
-    }),
+    }).annotations({ identifier: 'FeedSchedule' }),
 
     // TODO: This field should be optional / different depending on the `type`.
     additional_feed_info: S.mutable(
@@ -199,7 +199,8 @@ export const NewFeedSchema = S.mutable(
           cexPriceFeedsArgsSchema,
           geckoTerminalArgsSchema,
           ethRpcArgsSchema,
-        ),
+        ).annotations({ identifier: 'OracleScriptArguments' }),
+
         compatibility_info: S.UndefinedOr(
           S.Struct({
             chainlink: S.String,
@@ -208,7 +209,7 @@ export const NewFeedSchema = S.mutable(
       }),
     ),
   }),
-);
+).annotations({ identifier: 'FeedV2' });
 
 export type NewFeed = typeof NewFeedSchema.Type;
 
@@ -219,7 +220,7 @@ export const NewFeedsConfigSchema = S.mutable(
   S.Struct({
     feeds: S.mutable(S.Array(NewFeedSchema)),
   }),
-);
+).annotations({ identifier: 'FeedsConfigV2' });
 
 /**
  * Type for the Data Feeds configuration.

--- a/libs/ts/config-types/src/evm-contracts-deployment/index.ts
+++ b/libs/ts/config-types/src/evm-contracts-deployment/index.ts
@@ -19,6 +19,8 @@ export const CLAggregatorAdapterDataSchema = S.Struct({
   description: S.String,
   base: S.NullOr(ethereumAddress),
   quote: S.NullOr(ethereumAddress),
+}).annotations({
+  identifier: 'CLAggregatorAdapterData',
 });
 
 export type CLAggregatorAdapterData = typeof CLAggregatorAdapterDataSchema.Type;
@@ -35,7 +37,7 @@ const ContractsConfigSchemaV1 = S.mutable(
     CLAggregatorAdapter: S.mutable(S.Array(CLAggregatorAdapterDataSchema)),
     SafeMultisig: ethereumAddress,
   }),
-);
+).annotations({ identifier: 'ContractsConfigV1' });
 
 const ContractsConfigSchemaV2 = S.mutable(
   S.Struct({
@@ -53,7 +55,7 @@ const ContractsConfigSchemaV2 = S.mutable(
     SequencerMultisig: ethereumAddress,
     AdminMultisig: ethereumAddress,
   }),
-);
+).annotations({ identifier: 'ContractsConfigV2' });
 
 export type ContractsConfigV2 = typeof ContractsConfigSchemaV2.Type;
 
@@ -67,7 +69,9 @@ export const DeploymentConfigSchemaV1 = S.mutable(
       }),
     ),
   }),
-);
+).annotations({
+  identifier: 'DeploymentConfigV1',
+});
 
 export const DeploymentConfigSchemaV2 = S.mutable(
   S.Struct({
@@ -75,6 +79,8 @@ export const DeploymentConfigSchemaV2 = S.mutable(
     chainId: chainId,
     contracts: ContractsConfigSchemaV2,
   }),
-);
+).annotations({
+  identifier: 'DeploymentConfigV2',
+});
 
 export type DeploymentConfigV2 = typeof DeploymentConfigSchemaV2.Type;

--- a/libs/ts/contracts/tasks/multichain-deploy.ts
+++ b/libs/ts/contracts/tasks/multichain-deploy.ts
@@ -1,22 +1,22 @@
 import { formatEther } from 'ethers';
 import { task } from 'hardhat/config';
 
-import Safe from '@safe-global/protocol-kit';
+import type Safe from '@safe-global/protocol-kit';
 
-import { NetworkConfig, ContractNames, DeployContract } from './types';
+import { getOptionalEnvString } from '@blocksense/base-utils/env';
 import {
   isNetworkName,
   NetworkName,
   parseChainId,
   parseEthereumAddress,
 } from '@blocksense/base-utils/evm';
-
 import { padNumber } from '@blocksense/base-utils/string';
-import { getOptionalEnvString } from '@blocksense/base-utils/env';
 
 import { DeploymentConfigV2 } from '@blocksense/config-types/evm-contracts-deployment';
-import { predictAddress } from './utils';
 import { readConfig, writeEvmDeployment } from '@blocksense/config-types';
+
+import { NetworkConfig, ContractNames, DeployContract } from './types';
+import { predictAddress } from './utils';
 
 task('deploy', 'Deploy contracts')
   .addParam('networks', 'Network to deploy to')

--- a/libs/ts/contracts/tasks/multichain-deploy.ts
+++ b/libs/ts/contracts/tasks/multichain-deploy.ts
@@ -11,6 +11,7 @@ import {
   parseEthereumAddress,
 } from '@blocksense/base-utils/evm';
 import { padNumber } from '@blocksense/base-utils/string';
+import { readline } from '@blocksense/base-utils/tty';
 
 import { DeploymentConfigV2 } from '@blocksense/config-types/evm-contracts-deployment';
 import { readConfig, writeEvmDeployment } from '@blocksense/config-types';
@@ -118,6 +119,11 @@ task('deploy', 'Deploy contracts')
       console.log(`// CREATE2 salts:`);
       for (const [name, salt] of Object.entries(create2ContractSalts)) {
         console.log(`//   | ${name.padStart(17)}| ${salt}`);
+      }
+
+      if ((await readline().question('\nConfirm deployment? (y/n) ')) !== 'y') {
+        console.log('Aborting deployment...');
+        return;
       }
 
       console.log('---------------------------\n');

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "build-single": "yarn workspace $0 run build",
     "build:recursive": "yarn workspaces foreach --from $0 -Rp --topological-dev run build",
     "build:with-deps": "yarn build:recursive $(jq -r .name $INIT_CWD/package.json)",
+    "build:typecheck": "rm -rf $INIT_CWD/dist && tsc -p $INIT_CWD/tsconfig.json",
+    "build:typecheck-rec": "yarn workspaces foreach -Rp --topological-dev --from $(jq -r .name $INIT_CWD/package.json) run tsc -p $INIT_CWD/tsconfig.json",
     "build:all": "yarn workspaces foreach --all -p --topological-dev run build",
     "test": "yarn workspaces foreach --from $0 -Rp --topological-dev run test",
     "test-single": "yarn workspace $0 run test",


### PR DESCRIPTION

## Description

This pull request introduces a powerful, type-safe, and hierarchical system for parsing environment variable configurations, primarily aimed at simplifying multi-network EVM deployments. It adds new core functionality to the `@blocksense/base-utils/env` module and a rich set of supporting utilities.

### The Problem

Managing deployment configurations across numerous networks (e.g., `local`, `ethereum-sepolia`, `arbitrum-mainnet`) can be cumbersome. Configuration parameters often have default values but need to be overridden for specific network types (testnet vs. mainnet) or for individual networks. This leads to complex, hard-to-maintain, and error-prone deployment scripts.

### The Solution

A new layered configuration parser is introduced. The core functions are:
-   `parseLayeredEnvConfig`: A generic function for parsing environment variables from a schema with prioritized layers.
-   `parseDeploymentEnvConfig`: A specialized helper for EVM deployments that uses a predefined priority order: `perNetworkName` > `perNetworkKind` > `global`.

This system allows developers to define a configuration schema, and the parser will automatically find and merge the correct environment variables based on the target network.

### Key Features

*   **Hierarchical Overrides:** Define configuration values at a global level and seamlessly override them for network kinds (`MAINNET`, `TESTNET`) or specific network names (`ETHEREUM_MAINNET`).
    *   *Example: A global `GAS_LIMIT` can be overridden by `GAS_LIMIT_MAINNET`, which can be further overridden by `GAS_LIMIT_ETHEREUM_MAINNET`.*

*   **Enhanced Developer Experience:** A new `validateAndPrintDeploymentEnvConfig` function provides a rich, colorized report in the console. This report clearly shows:
    *   The final merged configuration values.
    *   Which layer each value was sourced from (e.g., `global`, `perNetworkName`).
    *   The exact environment variable name that was read.
    *   A clear list of any missing environment variables, preventing deployment errors.

*   **Type Safety with `effect/Schema`:** The entire system is built on `effect/Schema`, ensuring that environment variables are parsed into their correct types (e.g., `string`, `number`, `URL`, custom types) and that the final configuration object is strongly typed.

### Supporting Changes

To enable this feature, several underlying utilities were added or improved:
-   **`@blocksense/base-utils/string`**: New helpers `camelCaseToScreamingSnakeCase` and `envVarNameJoin` for conventional environment variable naming.
-   **`@blocksense/base-utils/tty`**: A new standalone module for advanced TTY interactions, including a powerful `color` template literal tag for styling console output and a `drawBox` utility for creating the report.
-   **`@blocksense/base-utils/type-level`**: Added `UnionToIntersection` to correctly infer the type of the merged configuration object.
-   **General Improvements**: Enhanced error reporting for JSON schema decoding, made object iterators (`keysOf`, `entriesOf`) more efficient by returning generators, and added more schema annotations for better introspection.
