### PR TITLE
fix(direnv): Fix direnv on macOS systems with old version of `find`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -6,6 +6,4 @@ fi
 
 dotenv_if_exists
 
-watch_file "$(find ./nix -name "*.nix" -printf '"%p" ')"
-
 use flake ".#${DEV_SHELL:-default}" --impure


### PR DESCRIPTION
The default version of find (`/usr/bin/find`) doesn't support `-p`.
Additionally the `watch_file` function sometimes is not able to accept long list of files.