### PR TITLE
[contracts]: Convert hh task to functions and some other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ libs/ts/ui/storybook-static
 # wasm artifacts
 .spin/
 *.wasm
+
+# Local EVM contracts deployment artifacts
+config/evm_contracts_deployment_v2/local.json

--- a/Justfile
+++ b/Justfile
@@ -64,3 +64,7 @@ clean:
     -e .vscode \
     -e .pre-commit-config.yaml \
     -- {{root-dir}}
+
+[working-directory: 'libs/ts/contracts']
+deploy-evm-contracts network-name:
+  yarn hardhat deploy --networks {{network-name}}

--- a/libs/ts/base-utils/package.json
+++ b/libs/ts/base-utils/package.json
@@ -42,6 +42,11 @@
       "import": "./dist/esm/evm/index.mjs",
       "types": "./src/evm/index.ts"
     },
+    "./evm/functions": {
+      "require": "./dist/cjs/evm/functions.cjs",
+      "import": "./dist/esm/evm/functions.mjs",
+      "types": "./src/evm/functions.ts"
+    },
     "./evm/networks": {
       "require": "./dist/cjs/evm/networks.cjs",
       "import": "./dist/esm/evm/networks.mjs",

--- a/libs/ts/contracts/hardhat.config.ts
+++ b/libs/ts/contracts/hardhat.config.ts
@@ -9,7 +9,7 @@ import 'solidity-coverage';
 import '@typechain/hardhat';
 import 'hardhat-contract-sizer';
 import 'hardhat-gas-reporter';
-import '../sol-reflector/src';
+import '@blocksense/sol-reflector';
 
 import { fromEntries } from '@blocksense/base-utils/array-iter';
 import {

--- a/libs/ts/contracts/package.json
+++ b/libs/ts/contracts/package.json
@@ -13,6 +13,10 @@
       "require": "./artifacts/docs/abi.json",
       "import": "./artifacts/docs/abi.json"
     },
+    "./typechain": {
+      "types": "./typechain/index.ts",
+      "require": "./typechain/index.ts"
+    },
     "./contractsFileStructure.json": {
       "require": "./artifacts/docs/contractsFileStructure.json",
       "import": "./artifacts/docs/contractsFileStructure.json"

--- a/libs/ts/contracts/tasks/deployment-utils/access-control.ts
+++ b/libs/ts/contracts/tasks/deployment-utils/access-control.ts
@@ -10,6 +10,7 @@ import {
 
 import { getEnvString, getOptionalEnvString } from '@blocksense/base-utils';
 import { ContractNames, NetworkConfig } from '../types';
+import { executeMultisigTransaction } from './multisig-tx-exec';
 
 export type Params = {
   config: NetworkConfig;
@@ -135,7 +136,7 @@ export async function setUpAccessControl({
   }
 
   if (transactions.length > 0) {
-    await run('multisig-tx-exec', {
+    await executeMultisigTransaction({
       transactions,
       safe: adminMultisig,
       config,
@@ -199,7 +200,7 @@ export async function setUpAccessControl({
       };
       sequencerTransactions.push(safeTxRemoveOwner);
 
-      await run('multisig-tx-exec', {
+      await executeMultisigTransaction({
         transactions: sequencerTransactions,
         safe: sequencerMultisig,
         config,

--- a/libs/ts/contracts/tasks/deployment-utils/access-control.ts
+++ b/libs/ts/contracts/tasks/deployment-utils/access-control.ts
@@ -1,115 +1,187 @@
-import { task } from 'hardhat/config';
-import { ContractNames, NetworkConfig } from '../types';
+import { Artifacts, RunTaskFunction } from 'hardhat/types';
+import { AbiCoder, Contract, solidityPacked } from 'ethers';
+
 import { ContractsConfigV2 } from '@blocksense/config-types/evm-contracts-deployment';
 import Safe from '@safe-global/protocol-kit';
 import {
   OperationType,
   SafeTransactionDataPartial,
 } from '@safe-global/safe-core-sdk-types';
+
 import { getEnvString, getOptionalEnvString } from '@blocksense/base-utils';
+import { ContractNames, NetworkConfig } from '../types';
 
-task('access-control', '[UTILS] Set up access control').setAction(
-  async (args, { ethers, artifacts, run }) => {
-    const {
-      config,
-      deployData,
-      adminMultisig,
-      sequencerMultisig,
-    }: {
-      config: NetworkConfig;
-      deployData: ContractsConfigV2;
-      adminMultisig: Safe;
-      sequencerMultisig?: Safe;
-    } = args;
+export type Params = {
+  config: NetworkConfig;
+  deployData: ContractsConfigV2;
+  adminMultisig: Safe;
+  sequencerMultisig?: Safe;
+  run: RunTaskFunction;
+  artifacts: Artifacts;
+};
 
-    const adminSigner = config.adminMultisig.signer ?? config.ledgerAccount!;
-    const sequencerSigner =
-      config.sequencerMultisig.signer ?? config.ledgerAccount!;
+export async function setUpAccessControl({
+  run,
+  artifacts,
+  config,
+  deployData,
+  adminMultisig,
+  sequencerMultisig,
+}: Params) {
+  const adminSigner = config.adminMultisig.signer ?? config.ledgerAccount!;
+  const sequencerSigner =
+    config.sequencerMultisig.signer ?? config.ledgerAccount!;
 
-    console.log('\nSetting sequencer role in sequencer guard...');
+  console.log('\nSetting sequencer role in sequencer guard...');
 
-    const abiCoder = new ethers.AbiCoder();
-    const transactions: SafeTransactionDataPartial[] = [];
+  const abiCoder = new AbiCoder();
+  const transactions: SafeTransactionDataPartial[] = [];
 
-    const guard = new ethers.Contract(
-      deployData.coreContracts.OnlySequencerGuard.address,
-      artifacts.readArtifactSync(ContractNames.OnlySequencerGuard).abi,
+  const guard = new Contract(
+    deployData.coreContracts.OnlySequencerGuard!.address,
+    artifacts.readArtifactSync(ContractNames.OnlySequencerGuard).abi,
+    adminSigner,
+  );
+  if (sequencerMultisig) {
+    const isSequencerSet = await guard.getSequencerRole(
+      getEnvString('SEQUENCER_ADDRESS'),
+    );
+
+    if (!isSequencerSet) {
+      const safeTxSetGuard: SafeTransactionDataPartial = {
+        to: guard.target.toString(),
+        value: '0',
+        data: guard.interface.encodeFunctionData('setSequencer', [
+          getEnvString('SEQUENCER_ADDRESS'), // sequencer address
+          true,
+        ]),
+        operation: OperationType.Call,
+      };
+      transactions.push(safeTxSetGuard);
+    } else {
+      console.log('Sequencer guard already set up');
+    }
+  }
+
+  const sequencerMultisigAddress = sequencerMultisig
+    ? await sequencerMultisig.getAddress()
+    : getOptionalEnvString('SEQUENCER_ADDRESS', '');
+  if (sequencerMultisigAddress) {
+    console.log(
+      '\nSetting up access control and adding owners to admin multisig...',
+    );
+
+    const accessControl = new Contract(
+      deployData.coreContracts.AccessControl.address,
+      artifacts.readArtifactSync(ContractNames.AccessControl).abi,
       adminSigner,
     );
-    if (sequencerMultisig) {
-      const isSequencerSet = await guard.getSequencerRole(
-        getEnvString('SEQUENCER_ADDRESS'),
-      );
 
-      if (!isSequencerSet) {
-        const safeTxSetGuard: SafeTransactionDataPartial = {
-          to: guard.target.toString(),
-          value: '0',
-          data: guard.interface.encodeFunctionData('setSequencer', [
-            getEnvString('SEQUENCER_ADDRESS'), // sequencer address
-            true,
-          ]),
-          operation: OperationType.Call,
-        };
-        transactions.push(safeTxSetGuard);
-      } else {
-        console.log('Sequencer guard already set up');
-      }
-    }
-
-    const sequencerMultisigAddress = sequencerMultisig
-      ? await sequencerMultisig.getAddress()
-      : getOptionalEnvString('SEQUENCER_ADDRESS', '');
-    if (sequencerMultisigAddress) {
-      console.log(
-        '\nSetting up access control and adding owners to admin multisig...',
-      );
-
-      const accessControl = new ethers.Contract(
-        deployData.coreContracts.AccessControl.address,
-        artifacts.readArtifactSync(ContractNames.AccessControl).abi,
-        adminSigner,
-      );
-
-      const isAllowed = Boolean(
-        Number(
-          await sequencerSigner.call({
-            to: accessControl.target.toString(),
-            data: sequencerMultisigAddress,
-          }),
-        ),
-      );
-
-      if (!isAllowed) {
-        const safeTxSetAccessControl: SafeTransactionDataPartial = {
+    const isAllowed = Boolean(
+      Number(
+        await sequencerSigner.call({
           to: accessControl.target.toString(),
-          value: '0',
-          data: ethers.solidityPacked(
-            ['address', 'bool'],
-            [sequencerMultisigAddress, true],
-          ),
-          operation: OperationType.Call,
-        };
-        transactions.push(safeTxSetAccessControl);
-      } else {
-        console.log('Access control already set up');
-      }
+          data: sequencerMultisigAddress,
+        }),
+      ),
+    );
+
+    if (!isAllowed) {
+      const safeTxSetAccessControl: SafeTransactionDataPartial = {
+        to: accessControl.target.toString(),
+        value: '0',
+        data: solidityPacked(
+          ['address', 'bool'],
+          [sequencerMultisigAddress, true],
+        ),
+        operation: OperationType.Call,
+      };
+      transactions.push(safeTxSetAccessControl);
+    } else {
+      console.log('Access control already set up');
+    }
+  }
+
+  const owners = await adminMultisig.getOwners();
+  if (owners.length === 1 && config.adminMultisig.owners.length > 0) {
+    const adminMultisigAddress = await adminMultisig.getAddress();
+    for (const owner of config.adminMultisig.owners) {
+      const safeTxAddOwner = await adminMultisig.createAddOwnerTx({
+        ownerAddress: owner,
+      });
+      transactions.push(safeTxAddOwner.data);
     }
 
-    const owners = await adminMultisig.getOwners();
+    const prevOwnerAddress = config.adminMultisig.owners[0];
+    // removeOwner(address prevOwner, address owner, uint256 threshold);
+    const safeTxRemoveOwner: SafeTransactionDataPartial = {
+      to: adminMultisigAddress,
+      value: '0',
+      data:
+        '0xf8dc5dd9' +
+        abiCoder
+          .encode(
+            ['address', 'address', 'uint256'],
+            [
+              prevOwnerAddress,
+              await adminSigner.getAddress(),
+              config.adminMultisig.threshold,
+            ],
+          )
+          .slice(2),
+      operation: OperationType.Call,
+    };
+    transactions.push(safeTxRemoveOwner);
+  }
+
+  if (transactions.length > 0) {
+    await run('multisig-tx-exec', {
+      transactions,
+      safe: adminMultisig,
+      config,
+    });
+
     if (owners.length === 1 && config.adminMultisig.owners.length > 0) {
-      const adminMultisigAddress = await adminMultisig.getAddress();
-      for (const owner of config.adminMultisig.owners) {
-        const safeTxAddOwner = await adminMultisig.createAddOwnerTx({
+      console.log(
+        'Admin multisig owners changed to',
+        await adminMultisig.getOwners(),
+      );
+      console.log('Removed signer from multisig owners');
+      console.log('Current threshold', await adminMultisig.getThreshold());
+    }
+  }
+
+  if (!!sequencerMultisig) {
+    console.log(
+      '\nSetting up sequencer guard, adding reporters as owners and removing sequencer from owners...',
+    );
+
+    const enabledGuard = await sequencerMultisig.getGuard();
+    if (enabledGuard !== guard.target.toString()) {
+      const sequencerMultisigAddress = await sequencerMultisig.getAddress();
+      const sequencerTransactions: SafeTransactionDataPartial[] = [];
+
+      const safeTxSetGuard = await sequencerMultisig.createEnableGuardTx(
+        await guard.getAddress(),
+      );
+      sequencerTransactions.push(safeTxSetGuard.data);
+
+      const safeTxSetModule = await sequencerMultisig.createEnableModuleTx(
+        deployData.coreContracts.AdminExecutorModule!.address,
+      );
+      sequencerTransactions.push(safeTxSetModule.data);
+
+      for (const owner of config.sequencerMultisig.owners) {
+        const safeTxAddOwner = await sequencerMultisig.createAddOwnerTx({
           ownerAddress: owner,
         });
-        transactions.push(safeTxAddOwner.data);
+        sequencerTransactions.push(safeTxAddOwner.data);
       }
 
-      const prevOwnerAddress = config.adminMultisig.owners[0];
+      const prevOwnerAddress = config.sequencerMultisig.owners[0];
       // removeOwner(address prevOwner, address owner, uint256 threshold);
       const safeTxRemoveOwner: SafeTransactionDataPartial = {
-        to: adminMultisigAddress,
+        to: sequencerMultisigAddress,
         value: '0',
         data:
           '0xf8dc5dd9' +
@@ -118,100 +190,30 @@ task('access-control', '[UTILS] Set up access control').setAction(
               ['address', 'address', 'uint256'],
               [
                 prevOwnerAddress,
-                await adminSigner.getAddress(),
-                config.adminMultisig.threshold,
+                await sequencerSigner.getAddress(),
+                config.sequencerMultisig.threshold,
               ],
             )
             .slice(2),
         operation: OperationType.Call,
       };
-      transactions.push(safeTxRemoveOwner);
-    }
+      sequencerTransactions.push(safeTxRemoveOwner);
 
-    if (transactions.length > 0) {
       await run('multisig-tx-exec', {
-        transactions,
-        safe: adminMultisig,
+        transactions: sequencerTransactions,
+        safe: sequencerMultisig,
         config,
       });
 
-      if (owners.length === 1 && config.adminMultisig.owners.length > 0) {
-        console.log(
-          'Admin multisig owners changed to',
-          await adminMultisig.getOwners(),
-        );
-        console.log('Removed signer from multisig owners');
-        console.log('Current threshold', await adminMultisig.getThreshold());
-      }
-    }
-
-    if (!!sequencerMultisig) {
+      console.log('Only sequencer guard set');
       console.log(
-        '\nSetting up sequencer guard, adding reporters as owners and removing sequencer from owners...',
+        'Sequencer multisig owners changed to reporters',
+        await sequencerMultisig.getOwners(),
       );
-
-      const enabledGuard = await sequencerMultisig.getGuard();
-      if (enabledGuard !== guard.target.toString()) {
-        const sequencerMultisigAddress = await sequencerMultisig.getAddress();
-        const sequencerTransactions: SafeTransactionDataPartial[] = [];
-
-        const safeTxSetGuard = await sequencerMultisig.createEnableGuardTx(
-          await guard.getAddress(),
-        );
-        sequencerTransactions.push(safeTxSetGuard.data);
-
-        const safeTxSetModule = await sequencerMultisig.createEnableModuleTx(
-          deployData.coreContracts.AdminExecutorModule!.address,
-        );
-        sequencerTransactions.push(safeTxSetModule.data);
-
-        for (const owner of config.sequencerMultisig.owners) {
-          const safeTxAddOwner = await sequencerMultisig.createAddOwnerTx({
-            ownerAddress: owner,
-          });
-          sequencerTransactions.push(safeTxAddOwner.data);
-        }
-
-        const prevOwnerAddress = config.sequencerMultisig.owners[0];
-        // removeOwner(address prevOwner, address owner, uint256 threshold);
-        const safeTxRemoveOwner: SafeTransactionDataPartial = {
-          to: sequencerMultisigAddress,
-          value: '0',
-          data:
-            '0xf8dc5dd9' +
-            abiCoder
-              .encode(
-                ['address', 'address', 'uint256'],
-                [
-                  prevOwnerAddress,
-                  await sequencerSigner.getAddress(),
-                  config.sequencerMultisig.threshold,
-                ],
-              )
-              .slice(2),
-          operation: OperationType.Call,
-        };
-        sequencerTransactions.push(safeTxRemoveOwner);
-
-        await run('multisig-tx-exec', {
-          transactions: sequencerTransactions,
-          safe: sequencerMultisig,
-          config,
-        });
-
-        console.log('Only sequencer guard set');
-        console.log(
-          'Sequencer multisig owners changed to reporters',
-          await sequencerMultisig.getOwners(),
-        );
-        console.log('Removed sequencer from multisig owners');
-        console.log(
-          'Current threshold',
-          await sequencerMultisig.getThreshold(),
-        );
-      } else {
-        console.log('Sequencer guard already set up');
-      }
+      console.log('Removed sequencer from multisig owners');
+      console.log('Current threshold', await sequencerMultisig.getThreshold());
+    } else {
+      console.log('Sequencer guard already set up');
     }
-  },
-);
+  }
+}

--- a/libs/ts/contracts/tasks/deployment-utils/deploy-contracts.ts
+++ b/libs/ts/contracts/tasks/deployment-utils/deploy-contracts.ts
@@ -1,116 +1,121 @@
-import { parseEthereumAddress } from '@blocksense/base-utils';
-import { ContractsConfigV2 } from '@blocksense/config-types/evm-contracts-deployment';
-import Safe from '@safe-global/protocol-kit';
 import {
   SafeTransactionDataPartial,
   OperationType,
 } from '@safe-global/safe-core-sdk-types';
+import Safe from '@safe-global/protocol-kit';
 import { getCreateCallDeployment } from '@safe-global/safe-deployments';
-import { task } from 'hardhat/config';
+import { AbiCoder, Contract, solidityPacked } from 'ethers';
+import { Artifacts, RunTaskFunction } from 'hardhat/types';
+
+import { parseEthereumAddress } from '@blocksense/base-utils';
+import { ContractsConfigV2 } from '@blocksense/config-types/evm-contracts-deployment';
+
 import { DeployContract, ContractNames, NetworkConfig } from '../types';
 import { predictAddress, checkAddressExists } from '../utils';
 
-task('deploy-contracts', '[UTILS] Deploy contracts to the network').setAction(
-  async (args, { ethers, artifacts, run }) => {
-    const {
-      config,
-      adminMultisig,
-      contracts,
-    }: {
-      config: NetworkConfig;
-      adminMultisig: Safe;
-      contracts: DeployContract[];
-    } = args;
+type Params = {
+  config: NetworkConfig;
+  adminMultisig: Safe;
+  contracts: DeployContract[];
+  run: RunTaskFunction;
+  artifacts: Artifacts;
+};
 
-    const signer = config.adminMultisig.signer || config.ledgerAccount;
+export async function deployContracts({
+  config,
+  adminMultisig,
+  contracts,
+  run,
+  artifacts,
+}: Params) {
+  const signer = config.adminMultisig.signer || config.ledgerAccount;
 
-    const createCallAddress = config.safeAddresses.createCallAddress;
+  const createCallAddress = config.safeAddresses.createCallAddress;
 
-    const createCall = new ethers.Contract(
-      createCallAddress,
-      getCreateCallDeployment()?.abi!,
-      signer,
+  const createCall = new Contract(
+    createCallAddress,
+    getCreateCallDeployment()?.abi!,
+    signer,
+  );
+
+  const ContractsConfigV2 = {
+    coreContracts: {},
+  } as ContractsConfigV2;
+
+  const abiCoder = AbiCoder.defaultAbiCoder();
+
+  const BATCH_LENGTH = 30;
+  const transactions: SafeTransactionDataPartial[] = [];
+  for (const [index, contract] of contracts.entries()) {
+    const encodedArgs = abiCoder.encode(
+      contract.argsTypes,
+      contract.argsValues,
     );
 
-    const ContractsConfigV2 = {
-      coreContracts: {},
-    } as ContractsConfigV2;
+    const artifact = artifacts.readArtifactSync(contract.name);
+    const bytecode = solidityPacked(
+      ['bytes', 'bytes'],
+      [artifact.bytecode, encodedArgs],
+    );
 
-    const abiCoder = ethers.AbiCoder.defaultAbiCoder();
+    const contractAddress = await predictAddress(
+      artifacts,
+      config,
+      contract.name,
+      contract.salt,
+      encodedArgs,
+    );
 
-    const BATCH_LENGTH = 30;
-    const transactions: SafeTransactionDataPartial[] = [];
-    for (const [index, contract] of contracts.entries()) {
-      const encodedArgs = abiCoder.encode(
-        contract.argsTypes,
-        contract.argsValues,
+    const feedName = contract.feedRegistryInfo?.description;
+    const contractName = feedName
+      ? `CLAggregatorAdapter - ${feedName}`
+      : contract.name;
+    console.log(`Predicted address for '${contractName}': `, contractAddress);
+
+    if (!(await checkAddressExists(config, contractAddress))) {
+      const encodedData = createCall.interface.encodeFunctionData(
+        'performCreate2',
+        [0n, bytecode, contract.salt],
       );
 
-      const artifact = artifacts.readArtifactSync(contract.name);
-      const bytecode = ethers.solidityPacked(
-        ['bytes', 'bytes'],
-        [artifact.bytecode, encodedArgs],
-      );
-
-      const contractAddress = await predictAddress(
-        artifacts,
-        config,
-        contract.name,
-        contract.salt,
-        encodedArgs,
-      );
-
-      const feedName = contract.feedRegistryInfo?.description;
-      const contractName = feedName
-        ? `CLAggregatorAdapter - ${feedName}`
-        : contract.name;
-      console.log(`Predicted address for '${contractName}': `, contractAddress);
-
-      if (!(await checkAddressExists(config, contractAddress))) {
-        const encodedData = createCall.interface.encodeFunctionData(
-          'performCreate2',
-          [0n, bytecode, contract.salt],
-        );
-
-        const safeTransactionData: SafeTransactionDataPartial = {
-          to: createCallAddress,
-          value: '0',
-          data: encodedData,
-          operation: OperationType.Call,
-        };
-        transactions.push(safeTransactionData);
-      } else {
-        console.log(`  -> ✅ already deployed`);
-      }
-
-      if (contract.name === ContractNames.CLAggregatorAdapter) {
-        (ContractsConfigV2[contract.name] ??= []).push({
-          description: contract.feedRegistryInfo?.description ?? '',
-          base: contract.feedRegistryInfo?.base ?? null,
-          quote: contract.feedRegistryInfo?.quote ?? null,
-          address: parseEthereumAddress(contractAddress),
-          constructorArgs: contract.argsValues,
-        });
-      } else {
-        ContractsConfigV2.coreContracts[contract.name] = {
-          address: parseEthereumAddress(contractAddress),
-          constructorArgs: contract.argsValues,
-        };
-      }
-
-      if (
-        transactions.length === BATCH_LENGTH ||
-        (index === contracts.length - 1 && transactions.length > 0)
-      ) {
-        await run('multisig-tx-exec', {
-          transactions,
-          safe: adminMultisig,
-          config,
-        });
-        transactions.length = 0;
-      }
+      const safeTransactionData: SafeTransactionDataPartial = {
+        to: createCallAddress,
+        value: '0',
+        data: encodedData,
+        operation: OperationType.Call,
+      };
+      transactions.push(safeTransactionData);
+    } else {
+      console.log(`  -> ✅ already deployed`);
     }
 
-    return ContractsConfigV2;
-  },
-);
+    if (contract.name === ContractNames.CLAggregatorAdapter) {
+      (ContractsConfigV2[contract.name] ??= []).push({
+        description: contract.feedRegistryInfo?.description ?? '',
+        base: contract.feedRegistryInfo?.base ?? null,
+        quote: contract.feedRegistryInfo?.quote ?? null,
+        address: parseEthereumAddress(contractAddress),
+        constructorArgs: contract.argsValues,
+      });
+    } else {
+      ContractsConfigV2.coreContracts[contract.name] = {
+        address: parseEthereumAddress(contractAddress),
+        constructorArgs: contract.argsValues,
+      };
+    }
+
+    if (
+      transactions.length === BATCH_LENGTH ||
+      (index === contracts.length - 1 && transactions.length > 0)
+    ) {
+      await run('multisig-tx-exec', {
+        transactions,
+        safe: adminMultisig,
+        config,
+      });
+      transactions.length = 0;
+    }
+  }
+
+  return ContractsConfigV2;
+}

--- a/libs/ts/contracts/tasks/deployment-utils/deploy-contracts.ts
+++ b/libs/ts/contracts/tasks/deployment-utils/deploy-contracts.ts
@@ -12,6 +12,7 @@ import { ContractsConfigV2 } from '@blocksense/config-types/evm-contracts-deploy
 
 import { DeployContract, ContractNames, NetworkConfig } from '../types';
 import { predictAddress, checkAddressExists } from '../utils';
+import { executeMultisigTransaction } from './multisig-tx-exec';
 
 type Params = {
   config: NetworkConfig;
@@ -108,7 +109,7 @@ export async function deployContracts({
       transactions.length === BATCH_LENGTH ||
       (index === contracts.length - 1 && transactions.length > 0)
     ) {
-      await run('multisig-tx-exec', {
+      await executeMultisigTransaction({
         transactions,
         safe: adminMultisig,
         config,

--- a/libs/ts/contracts/tasks/deployment-utils/deploy-multisig.ts
+++ b/libs/ts/contracts/tasks/deployment-utils/deploy-multisig.ts
@@ -1,85 +1,82 @@
-import { task } from 'hardhat/config';
 import Safe, {
   SafeAccountConfig,
   PredictedSafeProps,
 } from '@safe-global/protocol-kit';
+import { hexlify, toUtf8Bytes } from 'ethers';
+
 import { NetworkConfig } from '../types';
 import { checkAddressExists } from '../utils';
 
-task('deploy-multisig', '[UTILS] Deploy multisig contract').setAction(
-  async (args, { ethers }) => {
-    const {
-      config,
-      type,
-    }: {
-      config: NetworkConfig;
-      type: keyof Pick<NetworkConfig, 'adminMultisig' | 'sequencerMultisig'>;
-    } = args;
-    const safeVersion = '1.4.1';
+type Params = {
+  config: NetworkConfig;
+  type: keyof Pick<NetworkConfig, 'adminMultisig' | 'sequencerMultisig'>;
+};
 
-    const signer = config[type].signer;
+export async function deployMultisig({ config, type }: Params): Promise<Safe> {
+  const safeVersion = '1.4.1';
 
-    const safeAccountConfig: SafeAccountConfig = {
-      owners: [
-        signer ? signer.address : await config.ledgerAccount!.getAddress(),
-      ],
-      threshold: 1,
-    };
+  const signer = config[type].signer;
 
-    const saltNonce = ethers.hexlify(ethers.toUtf8Bytes(type));
+  const safeAccountConfig: SafeAccountConfig = {
+    owners: [
+      signer ? signer.address : await config.ledgerAccount!.getAddress(),
+    ],
+    threshold: 1,
+  };
 
-    const predictedSafe: PredictedSafeProps = {
-      safeAccountConfig,
-      safeDeploymentConfig: {
-        saltNonce,
-        safeVersion,
-      },
-    };
+  const saltNonce = hexlify(toUtf8Bytes(type));
 
-    const protocolKit = await Safe.init({
+  const predictedSafe: PredictedSafeProps = {
+    safeAccountConfig,
+    safeDeploymentConfig: {
+      saltNonce,
+      safeVersion,
+    },
+  };
+
+  const protocolKit = await Safe.init({
+    provider: config.rpc,
+    signer: signer?.privateKey,
+    predictedSafe,
+    contractNetworks: {
+      [config.network.chainId.toString()]: config.safeAddresses,
+    },
+  });
+
+  const safeAddress = await protocolKit.getAddress();
+
+  console.log(`Predicted ${type} address: ${safeAddress}`);
+
+  if (await checkAddressExists(config, safeAddress)) {
+    console.log(`  -> ✅ ${type} already deployed!`);
+    return protocolKit.connect({
       provider: config.rpc,
       signer: signer?.privateKey,
-      predictedSafe,
+      safeAddress,
       contractNetworks: {
         [config.network.chainId.toString()]: config.safeAddresses,
       },
     });
+  } else {
+    console.log(`  -> ⏳ ${type} not found, deploying...`);
+  }
 
-    const safeAddress = await protocolKit.getAddress();
+  const deploymentTransaction =
+    await protocolKit.createSafeDeploymentTransaction();
 
-    console.log(`Predicted ${type} address: ${safeAddress}`);
+  const transactionHash = await (
+    signer ?? config.ledgerAccount!
+  ).sendTransaction({
+    to: deploymentTransaction.to,
+    value: BigInt(deploymentTransaction.value),
+    data: deploymentTransaction.data as `0x${string}`,
+  });
 
-    if (await checkAddressExists(config, safeAddress)) {
-      console.log(`  -> ✅ ${type} already deployed!`);
-      return protocolKit.connect({
-        provider: config.rpc,
-        signer: signer?.privateKey,
-        safeAddress,
-        contractNetworks: {
-          [config.network.chainId.toString()]: config.safeAddresses,
-        },
-      });
-    } else {
-      console.log(`  -> ⏳ ${type} not found, deploying...`);
-    }
+  const transactionReceipt = await config.provider.waitForTransaction(
+    transactionHash.hash,
+  );
 
-    const deploymentTransaction =
-      await protocolKit.createSafeDeploymentTransaction();
+  console.log('    ✅ Safe deployment tx hash:', transactionReceipt?.hash);
 
-    const transactionHash = await (
-      signer ?? config.ledgerAccount!
-    ).sendTransaction({
-      to: deploymentTransaction.to,
-      value: BigInt(deploymentTransaction.value),
-      data: deploymentTransaction.data as `0x${string}`,
-    });
-
-    const transactionReceipt = await config.provider.waitForTransaction(
-      transactionHash.hash,
-    );
-
-    console.log('    ✅ Safe deployment tx hash:', transactionReceipt?.hash);
-
-    return protocolKit.connect({ safeAddress });
-  },
-);
+  return protocolKit.connect({ safeAddress });
+}

--- a/libs/ts/contracts/tasks/deployment-utils/init-chain.ts
+++ b/libs/ts/contracts/tasks/deployment-utils/init-chain.ts
@@ -1,135 +1,133 @@
-import assert from 'node:assert';
+import type { Network, Signer } from 'ethers';
+import { Wallet, JsonRpcProvider } from 'ethers';
 
-import { task } from 'hardhat/config';
-import { Network, Signer, Wallet } from 'ethers';
+import type { HardhatEthersHelpers } from '@nomicfoundation/hardhat-ethers/types';
 
 import {
-  isNetworkName,
   getRpcUrl,
   kebabToScreamingSnakeCase,
   parseEthereumAddress,
   getOptionalEnvString,
   getEnvString,
+  NetworkName,
 } from '@blocksense/base-utils';
 
 import { awaitTimeout } from '../utils';
 import { NetworkConfig } from '../types';
 
-task('init-chain', '[UTILS] Init chain configuration').setAction(
-  async ({ networkName }, { ethers }) => {
-    assert(isNetworkName(networkName), `Invalid network name: ${networkName}`);
-    const rpc = getRpcUrl(networkName);
-    const provider = new ethers.JsonRpcProvider(rpc);
+export async function initChain(
+  ethers: HardhatEthersHelpers,
+  networkName: NetworkName,
+): Promise<NetworkConfig> {
+  const rpc = getRpcUrl(networkName);
+  const provider = new JsonRpcProvider(rpc);
 
-    let network: Network | undefined;
-    try {
-      network = await Promise.race([
-        provider.getNetwork(),
-        awaitTimeout(5000, 'provider.getNetwork() timed out after 5 seconds'),
-      ]);
+  let network: Network | undefined;
+  try {
+    network = await Promise.race([
+      provider.getNetwork(),
+      awaitTimeout(5000, 'provider.getNetwork() timed out after 5 seconds'),
+    ]);
 
-      if (!network) {
-        throw new Error(`Network not initialized`);
-      }
-    } catch (err) {
-      console.log(err);
-      process.exit(1);
+    if (!network) {
+      throw new Error(`Network not initialized`);
     }
+  } catch (err) {
+    console.log(err);
+    process.exit(1);
+  }
 
-    const envSequencerOwners =
-      process.env[
-        'REPORTER_ADDRESSES_' + kebabToScreamingSnakeCase(networkName)
-      ];
-    const sequencerOwners = envSequencerOwners
-      ? envSequencerOwners
-          .split(',')
-          .map(address => parseEthereumAddress(address))
-      : [];
+  const envSequencerOwners =
+    process.env['REPORTER_ADDRESSES_' + kebabToScreamingSnakeCase(networkName)];
+  const sequencerOwners = envSequencerOwners
+    ? envSequencerOwners
+        .split(',')
+        .map(address => parseEthereumAddress(address))
+    : [];
 
-    const envAdminOwners =
-      process.env[
-        'ADMIN_EXTRA_SIGNERS_' + kebabToScreamingSnakeCase(networkName)
-      ];
-    const adminOwners = envAdminOwners
-      ? envAdminOwners.split(',').map(address => parseEthereumAddress(address))
-      : [];
+  const envAdminOwners =
+    process.env[
+      'ADMIN_EXTRA_SIGNERS_' + kebabToScreamingSnakeCase(networkName)
+    ];
+  const adminOwners = envAdminOwners
+    ? envAdminOwners.split(',').map(address => parseEthereumAddress(address))
+    : [];
 
-    const deploySequencerMultisig = JSON.parse(
-      getOptionalEnvString(
-        'DEPLOY_WITH_SEQUENCER_MULTISIG_' +
-          kebabToScreamingSnakeCase(networkName),
-        'true',
+  const deploySequencerMultisig = JSON.parse(
+    getOptionalEnvString(
+      'DEPLOY_WITH_SEQUENCER_MULTISIG_' +
+        kebabToScreamingSnakeCase(networkName),
+      'true',
+    ),
+  );
+
+  let ledgerAccount: Signer | undefined;
+  let admin: Wallet | undefined;
+
+  const ledgerAccountAddress = getOptionalEnvString('LEDGER_ACCOUNT', '');
+  if (ledgerAccountAddress) {
+    ledgerAccount = await ethers.getSigner(ledgerAccountAddress);
+  } else {
+    admin = new Wallet(getEnvString('ADMIN_SIGNER_PRIVATE_KEY'), provider);
+  }
+
+  const feedIds = getOptionalEnvString(
+    'FEED_IDS_' + kebabToScreamingSnakeCase(networkName),
+    '',
+  );
+
+  return {
+    rpc,
+    provider,
+    network,
+    networkName,
+    sequencerMultisig: {
+      signer: admin,
+      owners: sequencerOwners,
+      threshold: +getOptionalEnvString('REPORTER_THRESHOLD', '1'),
+    },
+    deployWithSequencerMultisig: deploySequencerMultisig,
+    adminMultisig: {
+      signer: admin,
+      owners: adminOwners,
+      threshold: +getOptionalEnvString('ADMIN_THRESHOLD', '1'),
+    },
+    ledgerAccount,
+    feedIds:
+      feedIds === 'all' ? 'all' : feedIds.split(',').map(id => BigInt(id)),
+    safeAddresses: {
+      multiSendAddress: parseEthereumAddress(
+        '0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526',
       ),
-    );
-
-    let ledgerAccount: Signer | undefined;
-    let admin: Wallet | undefined;
-
-    const ledgerAccountAddress = getOptionalEnvString('LEDGER_ACCOUNT', '');
-    if (ledgerAccountAddress) {
-      ledgerAccount = await ethers.getSigner(ledgerAccountAddress);
-    } else {
-      admin = new Wallet(getEnvString('ADMIN_SIGNER_PRIVATE_KEY'), provider);
-    }
-
-    const feedIds = getOptionalEnvString(
-      'FEED_IDS_' + kebabToScreamingSnakeCase(networkName),
-      '',
-    );
-
-    return {
-      rpc,
-      provider,
-      network,
-      networkName,
-      sequencerMultisig: {
-        signer: admin,
-        owners: sequencerOwners,
-        threshold: +getOptionalEnvString('REPORTER_THRESHOLD', '1'),
-      },
-      deployWithSequencerMultisig: deploySequencerMultisig,
-      adminMultisig: {
-        signer: admin,
-        owners: adminOwners,
-        threshold: +getOptionalEnvString('ADMIN_THRESHOLD', '1'),
-      },
-      ledgerAccount,
-      feedIds:
-        feedIds === 'all' ? 'all' : feedIds.split(',').map(id => BigInt(id)),
-      safeAddresses: {
-        multiSendAddress: parseEthereumAddress(
-          '0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526',
-        ),
-        multiSendCallOnlyAddress: parseEthereumAddress(
-          '0x9641d764fc13c8B624c04430C7356C1C7C8102e2',
-        ),
-        createCallAddress: parseEthereumAddress(
-          '0x9b35Af71d77eaf8d7e40252370304687390A1A52',
-        ),
-        safeSingletonAddress: parseEthereumAddress(
-          '0x41675C099F32341bf84BFc5382aF534df5C7461a',
-        ),
-        safeProxyFactoryAddress: parseEthereumAddress(
-          '0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67',
-        ),
-        fallbackHandlerAddress: parseEthereumAddress(
-          '0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99',
-        ),
-        signMessageLibAddress: parseEthereumAddress(
-          '0xd53cd0aB83D845Ac265BE939c57F53AD838012c9',
-        ),
-        simulateTxAccessorAddress: parseEthereumAddress(
-          '0x3d4BA2E0884aa488718476ca2FB8Efc291A46199',
-        ),
-        safeWebAuthnSharedSignerAddress: parseEthereumAddress(
-          // https://github.com/safe-global/safe-modules-deployments/blob/v2.2.4/src/assets/safe-passkey-module/v0.2.1/safe-webauthn-shared-signer.json#L6gs
-          '0x94a4F6affBd8975951142c3999aEAB7ecee555c2',
-        ),
-        safeWebAuthnSignerFactoryAddress: parseEthereumAddress(
-          // https://github.com/safe-global/safe-modules-deployments/blob/v2.2.4/src/assets/safe-passkey-module/v0.2.1/safe-webauthn-signer-factory.json#L6
-          '0x1d31F259eE307358a26dFb23EB365939E8641195',
-        ),
-      },
-    } as NetworkConfig;
-  },
-);
+      multiSendCallOnlyAddress: parseEthereumAddress(
+        '0x9641d764fc13c8B624c04430C7356C1C7C8102e2',
+      ),
+      createCallAddress: parseEthereumAddress(
+        '0x9b35Af71d77eaf8d7e40252370304687390A1A52',
+      ),
+      safeSingletonAddress: parseEthereumAddress(
+        '0x41675C099F32341bf84BFc5382aF534df5C7461a',
+      ),
+      safeProxyFactoryAddress: parseEthereumAddress(
+        '0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67',
+      ),
+      fallbackHandlerAddress: parseEthereumAddress(
+        '0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99',
+      ),
+      signMessageLibAddress: parseEthereumAddress(
+        '0xd53cd0aB83D845Ac265BE939c57F53AD838012c9',
+      ),
+      simulateTxAccessorAddress: parseEthereumAddress(
+        '0x3d4BA2E0884aa488718476ca2FB8Efc291A46199',
+      ),
+      safeWebAuthnSharedSignerAddress: parseEthereumAddress(
+        // https://github.com/safe-global/safe-modules-deployments/blob/v2.2.4/src/assets/safe-passkey-module/v0.2.1/safe-webauthn-shared-signer.json#L6gs
+        '0x94a4F6affBd8975951142c3999aEAB7ecee555c2',
+      ),
+      safeWebAuthnSignerFactoryAddress: parseEthereumAddress(
+        // https://github.com/safe-global/safe-modules-deployments/blob/v2.2.4/src/assets/safe-passkey-module/v0.2.1/safe-webauthn-signer-factory.json#L6
+        '0x1d31F259eE307358a26dFb23EB365939E8641195',
+      ),
+    },
+  };
+}

--- a/libs/ts/contracts/tasks/deployment-utils/register-cl-adapters.ts
+++ b/libs/ts/contracts/tasks/deployment-utils/register-cl-adapters.ts
@@ -12,6 +12,7 @@ import {
 } from '@blocksense/config-types/evm-contracts-deployment';
 
 import { ContractNames, NetworkConfig } from '../types';
+import { executeMultisigTransaction } from './multisig-tx-exec';
 
 type Params = {
   deployData: ContractsConfigV2;
@@ -94,7 +95,7 @@ export async function registerCLAdapters({
       `Registering ${batch.length} CLAggregatorAdapters in CLFeedRegistryAdapter`,
     );
 
-    await run('multisig-tx-exec', {
+    await executeMultisigTransaction({
       transactions: [safeTransactionData],
       safe,
       config,

--- a/libs/ts/contracts/tasks/deployment-utils/register-cl-adapters.ts
+++ b/libs/ts/contracts/tasks/deployment-utils/register-cl-adapters.ts
@@ -1,36 +1,40 @@
-import {
-  CLAggregatorAdapterData,
-  ContractsConfigV2,
-} from '@blocksense/config-types/evm-contracts-deployment';
-import { task } from 'hardhat/config';
-import { ContractNames, NetworkConfig } from '../types';
-import Safe from '@safe-global/protocol-kit';
+import { Contract, ZeroAddress } from 'ethers';
+import { Artifacts, RunTaskFunction } from 'hardhat/types';
 import {
   OperationType,
   SafeTransactionDataPartial,
 } from '@safe-global/safe-core-sdk-types';
+import Safe from '@safe-global/protocol-kit';
 
-task(
-  'register-cl-adapters',
-  '[UTILS] Register CLAggregatorAdapters in CLFeedRegistryAdapter',
-).setAction(async (args, { ethers, artifacts, run }) => {
-  const {
-    deployData,
-    config,
-    safe,
-  }: {
-    deployData: ContractsConfigV2;
-    config: NetworkConfig;
-    safe: Safe;
-  } = args;
+import {
+  CLAggregatorAdapterData,
+  ContractsConfigV2,
+} from '@blocksense/config-types/evm-contracts-deployment';
 
+import { ContractNames, NetworkConfig } from '../types';
+
+type Params = {
+  deployData: ContractsConfigV2;
+  config: NetworkConfig;
+  safe: Safe;
+  run: RunTaskFunction;
+  artifacts: Artifacts;
+};
+
+export async function registerCLAdapters({
+  deployData,
+  config,
+  safe,
+  artifacts,
+  run,
+}: Params): Promise<void> {
   // The difference between setting n and n+1 feeds via CLFeedRegistryAdapter::setFeeds is slightly above 55k gas.
   console.log('\nRegistering CLAggregatorAdapters in CLFeedRegistryAdapter...');
   console.log('------------------------------------------------------------');
 
   const signer = config.adminMultisig.signer || config.ledgerAccount!;
 
-  const registry = new ethers.Contract(
+  const registry = new Contract(
     deployData.coreContracts.CLFeedRegistryAdapter.address,
     artifacts.readArtifactSync(ContractNames.CLFeedRegistryAdapter).abi,
     signer,
@@ -53,7 +57,7 @@ task(
       data.quote,
     );
 
-    if (feed === ethers.ZeroAddress) {
+    if (feed === ZeroAddress) {
       filteredData.push(data);
     } else {
       console.log(
@@ -96,4 +100,4 @@ task(
       config,
     });
   }
-});
+}

--- a/libs/ts/contracts/tasks/deployment-utils/upgrade-proxy-implementation.ts
+++ b/libs/ts/contracts/tasks/deployment-utils/upgrade-proxy-implementation.ts
@@ -10,6 +10,7 @@ import { ContractsConfigV2 } from '@blocksense/config-types/evm-contracts-deploy
 
 import { ContractNames, NetworkConfig } from '../types';
 import { ProxyOp } from '../../test/utils/wrappers/types';
+import { executeMultisigTransaction } from './multisig-tx-exec';
 
 type Params = {
   deployData: ContractsConfigV2;
@@ -50,7 +51,7 @@ export async function upgradeProxyImplementation({
     `Upgrading proxy implementation to ${deployData.coreContracts.AggregatedDataFeedStore.address}`,
   );
 
-  await run('multisig-tx-exec', {
+  await executeMultisigTransaction({
     transactions: [safeTransactionData],
     safe,
     config,

--- a/libs/ts/contracts/tasks/deployment-utils/upgrade-proxy-implementation.ts
+++ b/libs/ts/contracts/tasks/deployment-utils/upgrade-proxy-implementation.ts
@@ -1,30 +1,34 @@
-import { ContractsConfigV2 } from '@blocksense/config-types/evm-contracts-deployment';
-import { task } from 'hardhat/config';
-import { ContractNames, NetworkConfig } from '../types';
+import { Contract } from 'ethers';
+import { Artifacts, RunTaskFunction } from 'hardhat/types';
 import Safe from '@safe-global/protocol-kit';
 import {
   OperationType,
   SafeTransactionDataPartial,
 } from '@safe-global/safe-core-sdk-types';
+
+import { ContractsConfigV2 } from '@blocksense/config-types/evm-contracts-deployment';
+
+import { ContractNames, NetworkConfig } from '../types';
 import { ProxyOp } from '../../test/utils/wrappers/types';
 
-task(
-  'upgrade-proxy-implementation',
-  '[UTILS] Upgrade upgradeable proxy implementation address',
-).setAction(async (args, { ethers, artifacts, run }) => {
-  const {
-    deployData,
-    config,
-    safe,
-  }: {
-    deployData: ContractsConfigV2;
-    config: NetworkConfig;
-    safe: Safe;
-  } = args;
+type Params = {
+  deployData: ContractsConfigV2;
+  config: NetworkConfig;
+  safe: Safe;
+  run: RunTaskFunction;
+  artifacts: Artifacts;
+};
 
+export async function upgradeProxyImplementation({
+  deployData,
+  config,
+  safe,
+  run,
+  artifacts,
+}: Params) {
   const signer = config.adminMultisig.signer || config.ledgerAccount!;
 
-  const proxy = new ethers.Contract(
+  const proxy = new Contract(
     deployData.coreContracts.UpgradeableProxyADFS.address,
     artifacts.readArtifactSync(ContractNames.UpgradeableProxyADFS).abi,
     signer,
@@ -51,4 +55,4 @@ task(
     safe,
     config,
   });
-});
+}

--- a/libs/ts/contracts/tasks/index.ts
+++ b/libs/ts/contracts/tasks/index.ts
@@ -8,5 +8,4 @@ import './deployment-utils/deploy-multisig';
 import './deployment-utils/multisig-tx-exec';
 import './deployment-utils/deploy-contracts';
 import './deployment-utils/register-cl-adapters';
-import './deployment-utils/access-control';
 import './deployment-utils/upgrade-proxy-implementation';

--- a/libs/ts/contracts/tasks/index.ts
+++ b/libs/ts/contracts/tasks/index.ts
@@ -5,7 +5,6 @@ import './verify';
 import './ms-change-sequencer';
 
 import './deployment-utils/deploy-multisig';
-import './deployment-utils/init-chain';
 import './deployment-utils/multisig-tx-exec';
 import './deployment-utils/deploy-contracts';
 import './deployment-utils/register-cl-adapters';

--- a/libs/ts/contracts/tasks/index.ts
+++ b/libs/ts/contracts/tasks/index.ts
@@ -6,6 +6,5 @@ import './ms-change-sequencer';
 
 import './deployment-utils/deploy-multisig';
 import './deployment-utils/multisig-tx-exec';
-import './deployment-utils/deploy-contracts';
 import './deployment-utils/register-cl-adapters';
 import './deployment-utils/upgrade-proxy-implementation';

--- a/libs/ts/contracts/tasks/index.ts
+++ b/libs/ts/contracts/tasks/index.ts
@@ -4,7 +4,6 @@ import './multichain-deploy';
 import './verify';
 import './ms-change-sequencer';
 
-import './deployment-utils/deploy-multisig';
 import './deployment-utils/multisig-tx-exec';
 import './deployment-utils/register-cl-adapters';
 import './deployment-utils/upgrade-proxy-implementation';

--- a/libs/ts/contracts/tasks/index.ts
+++ b/libs/ts/contracts/tasks/index.ts
@@ -5,4 +5,3 @@ import './verify';
 import './ms-change-sequencer';
 
 import './deployment-utils/multisig-tx-exec';
-import './deployment-utils/upgrade-proxy-implementation';

--- a/libs/ts/contracts/tasks/index.ts
+++ b/libs/ts/contracts/tasks/index.ts
@@ -5,5 +5,4 @@ import './verify';
 import './ms-change-sequencer';
 
 import './deployment-utils/multisig-tx-exec';
-import './deployment-utils/register-cl-adapters';
 import './deployment-utils/upgrade-proxy-implementation';

--- a/libs/ts/contracts/tasks/index.ts
+++ b/libs/ts/contracts/tasks/index.ts
@@ -3,5 +3,3 @@ import './test-fund-ledger';
 import './multichain-deploy';
 import './verify';
 import './ms-change-sequencer';
-
-import './deployment-utils/multisig-tx-exec';

--- a/libs/ts/contracts/tasks/ms-change-sequencer.ts
+++ b/libs/ts/contracts/tasks/ms-change-sequencer.ts
@@ -9,12 +9,13 @@ import {
 } from '@safe-global/safe-core-sdk-types';
 import { adjustVInSignature } from '@safe-global/protocol-kit/dist/src/utils';
 import { readEvmDeployment } from '@blocksense/config-types';
+import { initChain } from './deployment-utils/init-chain';
 
 task('change-sequencer', 'Change sequencer role in Access Control contract')
   .addParam('networks', 'Network to deploy to')
   .addParam('sequencerAddress', 'Sequencer address')
   .addParam('setRole', 'Enable/Disable sequencer address role in AC')
-  .setAction(async (args, { ethers, run }) => {
+  .setAction(async (args, { ethers }) => {
     console.log('args', args);
     const networks = args.networks.split(',');
     const configs: NetworkConfig[] = [];
@@ -22,7 +23,7 @@ task('change-sequencer', 'Change sequencer role in Access Control contract')
       if (!isNetworkName(network)) {
         throw new Error(`Invalid network: ${network}`);
       }
-      configs.push(await run('init-chain', { networkName: network }));
+      configs.push(await initChain(ethers, network));
     }
 
     for (const config of configs) {

--- a/libs/ts/contracts/tasks/multichain-deploy.ts
+++ b/libs/ts/contracts/tasks/multichain-deploy.ts
@@ -20,6 +20,7 @@ import { NetworkConfig, ContractNames, DeployContract } from './types';
 import { predictAddress } from './utils';
 import { initChain } from './deployment-utils/init-chain';
 import { setUpAccessControl } from './deployment-utils/access-control';
+import { deployContracts } from './deployment-utils/deploy-contracts';
 
 task('deploy', 'Deploy contracts')
   .addParam('networks', 'Network to deploy to')
@@ -235,10 +236,12 @@ task('deploy', 'Deploy contracts')
         });
       }
 
-      const deployData = await run('deploy-contracts', {
+      const deployData = await deployContracts({
         config,
         adminMultisig,
         contracts,
+        run,
+        artifacts,
       });
 
       deployData.coreContracts.OnlySequencerGuard ??= {

--- a/libs/ts/contracts/tasks/multichain-deploy.ts
+++ b/libs/ts/contracts/tasks/multichain-deploy.ts
@@ -18,6 +18,7 @@ import { readConfig, writeEvmDeployment } from '@blocksense/config-types';
 
 import { NetworkConfig, ContractNames, DeployContract } from './types';
 import { predictAddress } from './utils';
+import { initChain } from './deployment-utils/init-chain';
 
 task('deploy', 'Deploy contracts')
   .addParam('networks', 'Network to deploy to')
@@ -28,7 +29,7 @@ task('deploy', 'Deploy contracts')
       if (!isNetworkName(network)) {
         throw new Error(`Invalid network: ${network}`);
       }
-      configs.push(await run('init-chain', { networkName: network }));
+      configs.push(await initChain(ethers, network));
     }
 
     const { feeds } = await readConfig('feeds_config_v2');

--- a/libs/ts/contracts/tasks/multichain-deploy.ts
+++ b/libs/ts/contracts/tasks/multichain-deploy.ts
@@ -19,6 +19,7 @@ import { readConfig, writeEvmDeployment } from '@blocksense/config-types';
 import { NetworkConfig, ContractNames, DeployContract } from './types';
 import { predictAddress } from './utils';
 import { initChain } from './deployment-utils/init-chain';
+import { setUpAccessControl } from './deployment-utils/access-control';
 
 task('deploy', 'Deploy contracts')
   .addParam('networks', 'Network to deploy to')
@@ -276,7 +277,9 @@ task('deploy', 'Deploy contracts')
         deployData,
       });
 
-      await run('access-control', {
+      await setUpAccessControl({
+        run,
+        artifacts,
         config,
         deployData,
         adminMultisig,

--- a/libs/ts/contracts/tasks/multichain-deploy.ts
+++ b/libs/ts/contracts/tasks/multichain-deploy.ts
@@ -22,6 +22,7 @@ import { initChain } from './deployment-utils/init-chain';
 import { setUpAccessControl } from './deployment-utils/access-control';
 import { deployContracts } from './deployment-utils/deploy-contracts';
 import { deployMultisig } from './deployment-utils/deploy-multisig';
+import { registerCLAdapters } from './deployment-utils/register-cl-adapters';
 
 task('deploy', 'Deploy contracts')
   .addParam('networks', 'Network to deploy to')
@@ -275,10 +276,12 @@ task('deploy', 'Deploy contracts')
         deployData,
       });
 
-      await run('register-cl-adapters', {
+      await registerCLAdapters({
         config,
         safe: adminMultisig,
         deployData,
+        run,
+        artifacts,
       });
 
       await setUpAccessControl({

--- a/libs/ts/contracts/tasks/multichain-deploy.ts
+++ b/libs/ts/contracts/tasks/multichain-deploy.ts
@@ -23,6 +23,7 @@ import { setUpAccessControl } from './deployment-utils/access-control';
 import { deployContracts } from './deployment-utils/deploy-contracts';
 import { deployMultisig } from './deployment-utils/deploy-multisig';
 import { registerCLAdapters } from './deployment-utils/register-cl-adapters';
+import { upgradeProxyImplementation } from './deployment-utils/upgrade-proxy-implementation';
 
 task('deploy', 'Deploy contracts')
   .addParam('networks', 'Network to deploy to')
@@ -270,10 +271,12 @@ task('deploy', 'Deploy contracts')
       console.log(`// balance: ${fmtEth(signerBalancePost)}`);
       console.log(`//    diff: ${fmtEth(signerBalance - signerBalancePost)}`);
 
-      await run('upgrade-proxy-implementation', {
+      await upgradeProxyImplementation({
         config,
         safe: adminMultisig,
         deployData,
+        run,
+        artifacts,
       });
 
       await registerCLAdapters({

--- a/libs/ts/contracts/tasks/multichain-deploy.ts
+++ b/libs/ts/contracts/tasks/multichain-deploy.ts
@@ -21,6 +21,7 @@ import { predictAddress } from './utils';
 import { initChain } from './deployment-utils/init-chain';
 import { setUpAccessControl } from './deployment-utils/access-control';
 import { deployContracts } from './deployment-utils/deploy-contracts';
+import { deployMultisig } from './deployment-utils/deploy-multisig';
 
 task('deploy', 'Deploy contracts')
   .addParam('networks', 'Network to deploy to')
@@ -131,7 +132,7 @@ task('deploy', 'Deploy contracts')
 
       console.log('---------------------------\n');
 
-      const adminMultisig = await run('deploy-multisig', {
+      const adminMultisig = await deployMultisig({
         config,
         type: 'adminMultisig',
       });
@@ -208,7 +209,7 @@ task('deploy', 'Deploy contracts')
       let sequencerMultisigAddress = parseEthereumAddress(ethers.ZeroAddress);
 
       if (config.deployWithSequencerMultisig) {
-        sequencerMultisig = await run('deploy-multisig', {
+        sequencerMultisig = await deployMultisig({
           config,
           type: 'sequencerMultisig',
         });

--- a/libs/ts/contracts/tasks/test-multichain-deploy.ts
+++ b/libs/ts/contracts/tasks/test-multichain-deploy.ts
@@ -15,6 +15,7 @@ import { Feed, WriteOp } from '../test/utils/wrappers/types';
 
 import { expect } from 'chai';
 import { initChain } from './deployment-utils/init-chain';
+import { executeMultisigTransaction } from './deployment-utils/multisig-tx-exec';
 
 task(
   'test-deploy',
@@ -215,7 +216,7 @@ task(
     operation: OperationType.Call,
   };
 
-  await run('multisig-tx-exec', {
+  await executeMultisigTransaction({
     transactions: [changeSequencerTxData],
     safe: adminMultisig,
     config,
@@ -276,7 +277,7 @@ task(
     operation: OperationType.Call,
   };
 
-  await run('multisig-tx-exec', {
+  await executeMultisigTransaction({
     transactions: [changeAccessControlTxData],
     safe: adminMultisig,
     config,

--- a/libs/ts/contracts/tasks/test-multichain-deploy.ts
+++ b/libs/ts/contracts/tasks/test-multichain-deploy.ts
@@ -14,6 +14,7 @@ import { encodeDataAndTimestamp } from '../test/utils/helpers/common';
 import { Feed, WriteOp } from '../test/utils/wrappers/types';
 
 import { expect } from 'chai';
+import { initChain } from './deployment-utils/init-chain';
 
 task(
   'test-deploy',
@@ -21,9 +22,7 @@ task(
 ).setAction(async (_, { ethers, run }) => {
   const network = 'local';
 
-  const config: NetworkConfig = await run('init-chain', {
-    networkName: network,
-  });
+  const config = await initChain(ethers, network);
 
   if (!config.deployWithSequencerMultisig) {
     console.log('Test needs sequencer multisig set!');


### PR DESCRIPTION
#### Summary

This PR refactors all remaining Hardhat tasks into regular TypeScript functions.

> Note: This is another part of https://github.com/blocksense-network/blocksense/pull/1236

#### What's changed

* Replaced all `HardhatTaskDefinition`s (e.g. `deploy-contracts`, `deploy-multisig`, `upgrade-proxy-implementation`, etc.) with regular async functions.
* Updated scripts to call these functions directly.
* Cleaned up related imports and project config.
* Ensured `typechain` outputs are properly exported to support both `require()` and `import()` usage.
* Introduced a new `just deploy-evm-contracts` command for streamlined deployment.
