### PR TITLE
docs: add README for NFT app

### DIFF
--- a/apps/nft.blocksense.network/README.md
+++ b/apps/nft.blocksense.network/README.md
@@ -1,0 +1,45 @@
+# NFT App – Blocksense Network
+
+This app allows users to mint and claim NFTs on the Blocksense Network. It features a modern React UI, TypeScript, and Tailwind CSS for styling.
+
+## Features
+- Mint NFTs via a user-friendly form
+- Claim NFTs with a single click
+- Responsive, modern UI (React + Tailwind)
+- Modular components for easy customization
+
+## Key Files
+- `src/mint.ts` – NFT minting logic
+- `src/index.ts` – App entry point
+- `components/` – UI components (forms, buttons, hero, navbar, etc.)
+- `config.ts` – App configuration
+
+## Getting Started
+1. Navigate to this directory:
+   ```sh
+   cd apps/nft.blocksense.network
+   ```
+2. Install dependencies:
+   ```sh
+   npm install
+   ```
+3. Run the app:
+   ```sh
+   npm run dev
+   ```
+
+## Project Structure
+- `components/` – React components for UI
+- `src/` – Main logic and entry point
+- `public/` – Static assets
+
+## How It Works
+- **Minting**: Fill out the mint form and submit to mint an NFT.
+- **Claiming**: Use the claim button to receive your NFT.
+
+## Customization
+- Update UI in `components/`
+- Adjust minting logic in `src/mint.ts`
+
+---
+For more details, see the source code or contact the Blocksense team.


### PR DESCRIPTION
This PR adds a README to `apps/nft.blocksense.network` with an overview, usage instructions, and project structure for the NFT app. It covers minting, claiming, and customization details for developers and users.