### PR TITLE
[changelog-generator]: Add `list feeds` command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -63,6 +63,7 @@ build-ts package="all":
     yarn build-single @blocksense/sol-reflector
     yarn build-single @blocksense/contracts
     yarn build-single @blocksense/data-feeds-config-generator
+    yarn build-single @blocksense/changelog-generator
   else
     yarn build:recursive {{package}}
   fi

--- a/apps/changelog-generator/package.json
+++ b/apps/changelog-generator/package.json
@@ -18,6 +18,8 @@
     "changeset-publish": "yarn build && TEST_DIST= yarn vitest && changeset publish"
   },
   "dependencies": {
+    "@blocksense/base-utils": "workspace:^",
+    "@blocksense/config-types": "workspace:^",
     "@effect/cli": "0.63.9",
     "@effect/cluster": "^0.38.14",
     "@effect/experimental": "^0.48.10",

--- a/apps/changelog-generator/package.json
+++ b/apps/changelog-generator/package.json
@@ -7,7 +7,7 @@
   "bin": "./dist/bin.cjs",
   "scripts": {
     "build": "tsup --dts && yarn copy-package-json",
-    "ts": "yarn node --import tsx",
+    "start": "yarn node --import tsx ./src/bin.ts",
     "build:ts": "tsup",
     "lint": "yarn run -T eslint \"**/{src,test,examples,scripts,dtslint}/**/*.{ts,mjs}\"",
     "lint-fix": "yarn lint --fix",

--- a/apps/changelog-generator/package.json
+++ b/apps/changelog-generator/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@blocksense/changelog-generator",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "license": "MIT",
-  "description": "An Effect app related with Release notes functionality",
+  "description": "Blocksense Changelog Generator",
   "bin": "./dist/bin.cjs",
   "scripts": {
     "build": "tsup --dts && yarn copy-package-json",

--- a/apps/changelog-generator/src/Cli.ts
+++ b/apps/changelog-generator/src/Cli.ts
@@ -1,5 +1,7 @@
 import { Command } from '@effect/cli';
 
+import packageJson from '../package.json';
+
 import { listFeeds } from './commands/list-feeds';
 
 const command = Command.make('changelog-generator').pipe(
@@ -7,6 +9,6 @@ const command = Command.make('changelog-generator').pipe(
 );
 
 export const run = Command.run(command, {
-  name: 'Changelog Generator',
-  version: '0.1.0',
+  name: packageJson.description,
+  version: packageJson.version,
 });

--- a/apps/changelog-generator/src/Cli.ts
+++ b/apps/changelog-generator/src/Cli.ts
@@ -1,8 +1,12 @@
-import * as Command from '@effect/cli/Command';
+import { Command } from '@effect/cli';
 
-const command = Command.make('hello');
+import { listFeeds } from './commands/list-feeds';
+
+const command = Command.make('changelog-generator').pipe(
+  Command.withSubcommands([listFeeds]),
+);
 
 export const run = Command.run(command, {
-  name: 'Hello World',
-  version: '0.0.0',
+  name: 'Changelog Generator',
+  version: '0.1.0',
 });

--- a/apps/changelog-generator/src/bin.ts
+++ b/apps/changelog-generator/src/bin.ts
@@ -7,5 +7,5 @@ import { run } from './Cli.js';
 
 run(process.argv).pipe(
   Effect.provide(NodeContext.layer),
-  NodeRuntime.runMain({ disableErrorReporting: true }),
+  NodeRuntime.runMain({ disableErrorReporting: false }),
 );

--- a/apps/changelog-generator/src/commands/list-feeds.ts
+++ b/apps/changelog-generator/src/commands/list-feeds.ts
@@ -1,0 +1,59 @@
+import { readdirSync } from 'fs';
+
+import { configDir, parseNetworkName } from '@blocksense/base-utils';
+import type { TableRow } from '@blocksense/base-utils/tty';
+import { renderTui, drawTable } from '@blocksense/base-utils/tty';
+import {
+  configDirs,
+  readConfig,
+  readEvmDeployment,
+} from '@blocksense/config-types';
+import { Command, Options } from '@effect/cli';
+import { Effect } from 'effect';
+
+const availableNetworks = readdirSync(
+  configDirs.evm_contracts_deployment_v2,
+).map(filename => parseNetworkName(filename.replace(/\.json$/, '')));
+
+export const listFeeds = Command.make(
+  'list-feeds',
+  {
+    dir: Options.directory('dir').pipe(Options.withDefault(configDir)),
+    network: Options.choice('network', availableNetworks),
+  },
+  ({ dir, network }) =>
+    Effect.gen(function* () {
+      const feedConfig = yield* Effect.tryPromise(() =>
+        readConfig('feeds_config_v2', dir),
+      );
+
+      const deploymentData = yield* Effect.tryPromise(() =>
+        readEvmDeployment(network, true),
+      );
+
+      const rows: Array<TableRow> = feedConfig.feeds.map(feed => {
+        const contract = deploymentData?.contracts?.CLAggregatorAdapter.find(
+          data => data.constructorArgs[2] == feed.id,
+        );
+        return [
+          feed.full_name,
+          `${contract?.address ?? ''}`,
+          `${contract?.constructorArgs[1] ?? ''}`,
+          `${contract?.base ?? ''}`,
+          `${contract?.quote ?? ''}`,
+        ];
+      });
+
+      renderTui(
+        drawTable([...rows], {
+          headers: [
+            'Feed Name',
+            'Address',
+            'Decimals',
+            'Base Address',
+            'Quote Address',
+          ],
+        }),
+      );
+    }),
+);

--- a/apps/changelog-generator/tsconfig.json
+++ b/apps/changelog-generator/tsconfig.json
@@ -10,6 +10,7 @@
       "@template/cli/*": ["./src/*.js"]
     }
   },
+  "exclude": ["dist"],
   "references": [
     { "path": "tsconfig.src.json" },
     { "path": "tsconfig.test.json" },

--- a/apps/changelog-generator/tsconfig.scripts.json
+++ b/apps/changelog-generator/tsconfig.scripts.json
@@ -8,6 +8,7 @@
   ],
   "compilerOptions": {
     "rootDir": ".",
-    "tsBuildInfoFile": ".tsbuildinfo/scripts.tsbuildinfo"
+    "tsBuildInfoFile": ".tsbuildinfo/scripts.tsbuildinfo",
+    "composite": true
   }
 }

--- a/apps/changelog-generator/tsconfig.src.json
+++ b/apps/changelog-generator/tsconfig.src.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo"
+    "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
+    "composite": true
   }
 }

--- a/apps/changelog-generator/tsconfig.test.json
+++ b/apps/changelog-generator/tsconfig.test.json
@@ -3,6 +3,7 @@
   "include": ["test"],
   "compilerOptions": {
     "rootDir": "test",
-    "tsBuildInfoFile": ".tsbuildinfo/test.tsbuildinfo"
+    "tsBuildInfoFile": ".tsbuildinfo/test.tsbuildinfo",
+    "composite": true
   }
 }

--- a/libs/ts/config-types/src/read-write-config.ts
+++ b/libs/ts/config-types/src/read-write-config.ts
@@ -131,6 +131,8 @@ export const configFiles = {
   };
 };
 
+export { configDir };
+
 export const configDirs = {
   ['evm_contracts_deployment_v2']: join(
     configDir,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2095,7 +2095,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@blocksense/base-utils@workspace:*, @blocksense/base-utils@workspace:libs/ts/base-utils":
+"@blocksense/base-utils@workspace:*, @blocksense/base-utils@workspace:^, @blocksense/base-utils@workspace:libs/ts/base-utils":
   version: 0.0.0-use.local
   resolution: "@blocksense/base-utils@workspace:libs/ts/base-utils"
   dependencies:
@@ -2113,6 +2113,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@blocksense/changelog-generator@workspace:apps/changelog-generator"
   dependencies:
+    "@blocksense/base-utils": "workspace:^"
+    "@blocksense/config-types": "workspace:^"
     "@changesets/changelog-github": "npm:^0.5.1"
     "@changesets/cli": "npm:^2.29.4"
     "@effect/cli": "npm:0.63.9"
@@ -2139,7 +2141,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@blocksense/config-types@workspace:*, @blocksense/config-types@workspace:libs/ts/config-types":
+"@blocksense/config-types@workspace:*, @blocksense/config-types@workspace:^, @blocksense/config-types@workspace:libs/ts/config-types":
   version: 0.0.0-use.local
   resolution: "@blocksense/config-types@workspace:libs/ts/config-types"
   dependencies:


### PR DESCRIPTION
### Description
This is a preview how to add simple command within `Effect CLI app` and how to run the command.

### Usage
Run the following command in the `/apps/changelog-generator/`:

```
yarn start list-feeds --network <network>
```
where `<network>` is for example: `ink-sepolia`, `citrea-testnet`, etc.

As a result you should see a table containing `feed name`, `address`, `decimals`, `base` and `quote` for each available feed. 

The output of running the above mentioned command is:
<img width="1331" alt="Screenshot 2025-06-20 at 13 16 39" src="https://github.com/user-attachments/assets/4c1a541c-20c9-4030-8f12-82c79648a986" />

### Wizard mode 🧙🏻‍♂️ 
Additionally you can run
```
yarn start list-feeds --wizard
```
where you enter the interactive mode of the CLI app. The result is shown below:

[![asciicast](https://asciinema.org/a/0eDUR1Q9ci77CagSUPpOFClkl.svg)](https://asciinema.org/a/0eDUR1Q9ci77CagSUPpOFClkl)

### Additional info
Apart from that, in the `/apps/changelog-generator/` you can run the following command for more info:
```
yarn node ./dist/bin.cjs
```

<img width="1063" alt="Screenshot 2025-06-19 at 16 44 11" src="https://github.com/user-attachments/assets/4b1836b2-f933-40c1-b88a-7173b8c6c265" />
