### PR TITLE
Add support for managing `process-compose` environments via `just`

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -13,6 +13,35 @@ change-devshell shell="default":
 list-devshells:
   @{{root-dir}}/scripts/dev-shell/list-devshells.sh
 
+# List available process compose environments
+list-environments:
+  #!/usr/bin/env bash
+  nix eval --impure -L --json --apply builtins.attrNames \
+    .#legacyPackages.{{system}}.process-compose-environments \
+    2>/dev/null \
+    | jq -r '.[]'
+
+# Build process compose artifacts for a specific environment or all environments
+build-environment environment="all":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  PROCESS_COMPOSE_ARTIFACTS_DIR="$GIT_ROOT/config/generated/process-compose"
+  if [[ {{environment}} == "all" ]]; then
+    nix build --impure -L --json .#allProcessComposeFiles \
+      | jq -r '.[0].outputs.out' \
+      | xargs -I{} cp -rfs {}/. $PROCESS_COMPOSE_ARTIFACTS_DIR
+  else
+    nix build --impure -L --json .#legacyPackages.{{system}}.process-compose-environments.{{environment}} \
+      | jq -r '.[0].outputs.out' \
+      | xargs -I{} cp -rfs {} $PROCESS_COMPOSE_ARTIFACTS_DIR/{{environment}}-process-compose.yaml
+  fi
+  echo "Process Compose artifacts copied to $PROCESS_COMPOSE_ARTIFACTS_DIR"
+
+# Start a specific process compose environment
+start-environment environment:
+  #!/usr/bin/env bash
+  run-{{environment}}
+
 build-ts package="all":
   #!/usr/bin/env bash
   set -euo pipefail

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,6 @@
 root-dir := justfile_directory()
 spin-data-dir := root-dir + "/target/spin-artifacts"
+system := `nix eval --raw --impure --expr 'builtins.currentSystem'`
 
 default:
   @just --list

--- a/nix/shells/pkg-sets/dev-shell.nix
+++ b/nix/shells/pkg-sets/dev-shell.nix
@@ -14,6 +14,7 @@
     curl
     oras
     just
+    findutils
   ];
 
   enterShell =

--- a/nix/test-environments/default.nix
+++ b/nix/test-environments/default.nix
@@ -19,7 +19,7 @@
       allEnvironments = lib.pipe allEnvironmentNames [
         (builtins.map (name: {
           inherit name;
-          file = config.devenv.shells.${name}.process.managers.process-compose.configFile;
+          value = config.devenv.shells.${name}.process.managers.process-compose.configFile;
         }))
       ];
 
@@ -27,7 +27,7 @@
         (builtins.map (x: {
           name = "run-${x.name}";
           value = pkgs.writeShellScriptBin "run-${x.name}" ''
-            ${lib.getExe pkgs.process-compose} -f ${x.file}
+            ${lib.getExe pkgs.process-compose} -f ${x.value}
           '';
         }))
         lib.listToAttrs
@@ -38,12 +38,16 @@
         (
           set -x
           ${lib.concatMapStringsSep "\n" (
-            x: "cp ${x.file} $out/${x.name}-process-compose.yaml"
+            x: "cp ${x.value} $out/${x.name}-process-compose.yaml"
           ) allEnvironments}
         )
       '';
     in
     {
+      legacyPackages = {
+        process-compose-environments = lib.listToAttrs allEnvironments;
+      };
+
       packages = {
         inherit allProcessComposeFiles;
       } // runEnvironments;


### PR DESCRIPTION
# Add support for managing `process-compose` environments via `just`

This PR introduces a new set of developer commands to streamline working with `process-compose'- based infrastructure environments.

## What's included

### New just commands

* `list-environments`: Lists all available environments using `nix eval`.
* `build-environment`: Builds one or all environment definitions via Nix and copies the result to `config/generated/process-compose/`.
* `start-environment`: Shorthand for running `run-<env>` scripts (which are auto-generated via the Nix flake).

### How to use them:

#### List available environments

  ```bash
  just list-environments
  ```

  Example output:

  ```
  example-setup-01
  example-setup-02
  example-setup-03
  ```

---

#### Build environment artifacts

  ```bash
  just build-environment <environment>
  ```

  Builds the `process-compose` config for the specified environment and copies the result to `config/generated/process-compose/`.

  Example:

  ```bash
  just build-environment example-setup-01
  ```

  To build all environments at once:

  ```bash
  just build-environment
  # or explicitly:
  just build-environment all
  ```

---

#### Start an environment

  ```bash
  just start-environment <environment>
  ```

  Runs the given environment via `process-compose`. Equivalent to running the autogenerated `run-<env>` script exposed from the flake.

  Example:

  ```bash
  just start-environment example-setup-01
  ```
> Note: You might need to run `direvn reload` first.

### Supporting changes

* Added a `system` variable to the Justfile for platform awareness in Nix expressions.
* Introduced `config/generated/process-compose/` folder to store generated artifacts.
* Nix flake now exposes all process-compose environments under `legacyPackages.process-compose-environments` for use in scripting.
* Added `findutils` to the dev shell to support utility commands  (`xargs`) used in these workflows.

### Why this matters

These changes allow devs to quickly:

* Discover available process-compose environments.
* Build and run them without needing to understand the underlying nix structure.

### Open Questions

* [x] **Should we extract the inline Bash logic from these Justfile commands into dedicated scripts under `scripts/environments/`, similar to how we organize `dev-shells`?**
  This might improve readability and make the logic easier to audit. Would the added indirection be worth it?
  
  A: After some internal discussions, we agreed on keeping it that way, at least for now. The scripts are quite simple, and the indirection would only throttle the reading. If the `justfile` gets too complicated, we might consider refactoring.
  
* [x] **Document the new commans** - See [BSN-3186: Update Running the System section in SETUP.md ](https://coda.io/d/_d6vM0kjfQP6#_tuk5j/r3186&view=full)

--- 

> Closes: [BSN-3187: Add support for managing process-compose environments via just](https://coda.io/d/_d6vM0kjfQP6#_tuk5j/r3187&view=full)
