### PR TITLE
[just]:  Refactor process-compose environment runner: remove Nix-generated `run-<env>` scripts

### DIFF
--- a/nix/test-environments/default.nix
+++ b/nix/test-environments/default.nix
@@ -23,16 +23,6 @@
         }))
       ];
 
-      runEnvironments = lib.pipe allEnvironments [
-        (builtins.map (x: {
-          name = "run-${x.name}";
-          value = pkgs.writeShellScriptBin "run-${x.name}" ''
-            ${lib.getExe pkgs.process-compose} -f ${x.value}
-          '';
-        }))
-        lib.listToAttrs
-      ];
-
       allProcessComposeFiles = pkgs.runCommand "allProcessComposeFiles" { } ''
         mkdir $out
         (
@@ -50,17 +40,13 @@
 
       packages = {
         inherit allProcessComposeFiles;
-      } // runEnvironments;
+      };
 
-      devenv.shells =
-        {
-          default.packages = builtins.attrValues runEnvironments;
-        }
-        // lib.genAttrs allEnvironmentNames (name: {
-          imports = [
-            self.nixosModules.blocksense-process-compose
-            ./${name}.nix
-          ];
-        });
+      devenv.shells = lib.genAttrs allEnvironmentNames (name: {
+        imports = [
+          self.nixosModules.blocksense-process-compose
+          ./${name}.nix
+        ];
+      });
     };
 }


### PR DESCRIPTION
### What Changed

* Removed `runEnvironments` from `nix/test-environments/default.nix`.
  These shell script wrappers (e.g., `run-example-setup-02`) are no longer generated via Nix.

* Updated the `start-environment` Justfile command to:

  * Build the relevant YAML file if it doesn’t already exist.
  * Directly invoke `process-compose -f <env>.yaml` rather than relying on `run-<env>` scripts.
  * Introduced a `PROCESS_COMPOSE_ARTIFACTS_DIR` constant for reuse.
