### PR TITLE
[gh-actions]: Lint job runs on `self-hosted, nixos, x86-64-v3`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: self-hosted
+    runs-on: [self-hosted, nixos, x86-64-v3]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
I noticed that the `lint` job takes significantly longer to complete when it runs on `solunska-server-blocksense-00n`. This PR updates the configuration to run the lint job on our machines that are faster, improving CI performance.