### PR TITLE
[just/nix] Cleanup refactors related to process-compose environments. Improvements in Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -33,14 +33,14 @@ build-environment environment="all":
   else
     nix build --impure -L --json .#legacyPackages.{{system}}.process-compose-environments.{{environment}} \
       | jq -r '.[0].outputs.out' \
-      | xargs -I{} cp -rfs {} {{process-compose-artifacts-dir}}/{{environment}}-process-compose.yaml
+      | xargs -I{} cp -rfs {} {{process-compose-artifacts-dir}}/process-compose-{{environment}}.yaml
   fi
   echo "Process Compose artifacts copied to {{process-compose-artifacts-dir}}"
 
 # Start a specific process compose environment
 start-environment environment:
   #!/usr/bin/env bash
-  PC_FILE="{{process-compose-artifacts-dir}}/{{environment}}-process-compose.yaml"
+  PC_FILE="{{process-compose-artifacts-dir}}/process-compose-{{environment}}.yaml"
   if ! test -f "$PC_FILE"; then
     just build-environment {{environment}}
   fi

--- a/Justfile
+++ b/Justfile
@@ -6,15 +6,18 @@ process-compose-artifacts-dir := root-dir + "/config/generated/process-compose"
 default:
   @just --list
 
-# Switch to a different dev shell environment
+[group('Working with devshells')]
+[doc('Switch to a different dev shell environment')]
 change-devshell shell="default":
   @{{root-dir}}/scripts/dev-shell/change-devshell.sh {{shell}}
 
-# List available dev shell environments
+[group('Working with devshells')]
+[doc('List available dev shell environments')]
 list-devshells:
   @{{root-dir}}/scripts/dev-shell/list-devshells.sh
 
-# List available process compose environments
+[group('Working with process-compose environments')]
+[doc('List available process-compose environments')]
 list-environments:
   #!/usr/bin/env bash
   nix eval --impure -L --json --apply builtins.attrNames \
@@ -22,7 +25,8 @@ list-environments:
     2>/dev/null \
     | jq -r '.[]'
 
-# Build process compose artifacts for a specific environment or all environments
+[group('Working with process-compose environments')]
+[doc('Build process-compose artifacts for a specific environment or all environments')]
 build-environment environment="all":
   #!/usr/bin/env bash
   set -euo pipefail
@@ -37,7 +41,8 @@ build-environment environment="all":
   fi
   echo "Process Compose artifacts copied to {{process-compose-artifacts-dir}}"
 
-# Start a specific process compose environment
+[group('Working with process-compose environments')]
+[doc('Start a process-compose environment')]
 start-environment environment:
   #!/usr/bin/env bash
   PC_FILE="{{process-compose-artifacts-dir}}/process-compose-{{environment}}.yaml"
@@ -47,6 +52,8 @@ start-environment environment:
 
   process-compose -f "$PC_FILE"
 
+[group('Working with typescript')]
+[doc('Build single TypeScript package or all packages')]
 build-ts package="all":
   #!/usr/bin/env bash
   set -euo pipefail
@@ -60,11 +67,15 @@ build-ts package="all":
     yarn build:recursive {{package}}
   fi
 
+[group('Working with typescript')]
+[doc('Run all TypeScript tests')]
 test-ts:
   yarn test-single @blocksense/base-utils
   yarn test-single @blocksense/config-types
   yarn test-single @blocksense/data-feeds-config-generator
 
+[group('Working with oracles')]
+[doc('Build a specific oracle')]
 build-oracle oracle-name:
   #!/usr/bin/env bash
   set -euo pipefail
@@ -72,6 +83,8 @@ build-oracle oracle-name:
   cd "{{root-dir}}/apps/oracles/{{oracle-name}}"
   RUST_LOG=trigger=trace "${SPIN:-spin}" build
 
+[group('Working with oracles')]
+[doc('Start a specific oracle')]
 start-oracle oracle-name:
   #!/usr/bin/env bash
   set -euo pipefail
@@ -81,9 +94,13 @@ start-oracle oracle-name:
   cd "{{root-dir}}/apps/oracles/{{oracle-name}}"
   RUST_LOG=trigger=info "${SPIN:-spin}" build --up
 
+[group('blocksense')]
+[doc('Build Blocksense')]
 build-blocksense:
   @{{root-dir}}/scripts/build-blocksense.sh
 
+[group('blocksense')]
+[doc('Build Blocksense and start the default process-compose environment')]
 start-blocksense:
   #!/usr/bin/env bash
   set -euo pipefail
@@ -91,6 +108,8 @@ start-blocksense:
   just build-blocksense
   process-compose up
 
+[group('General')]
+[doc('Run a command to clean the repository of untracked files')]
 clean:
   git clean -fdx \
     -e .env \
@@ -100,6 +119,8 @@ clean:
     -e .pre-commit-config.yaml \
     -- {{root-dir}}
 
+[group('Working with evm contracts')]
+[doc('Deploy EVM contracts to a specific network')]
 [working-directory: 'libs/ts/contracts']
 deploy-evm-contracts network-name:
   yarn hardhat deploy --networks {{network-name}}

--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,7 @@
 root-dir := justfile_directory()
 spin-data-dir := root-dir + "/target/spin-artifacts"
 system := `nix eval --raw --impure --expr 'builtins.currentSystem'`
-PROCESS_COMPOSE_ARTIFACTS_DIR := "$GIT_ROOT/config/generated/process-compose"
+process-compose-artifacts-dir := root-dir + "/config/generated/process-compose"
 
 default:
   @just --list
@@ -29,18 +29,18 @@ build-environment environment="all":
   if [[ {{environment}} == "all" ]]; then
     nix build --impure -L --json .#allProcessComposeFiles \
       | jq -r '.[0].outputs.out' \
-      | xargs -I{} cp -rfs {}/. {{PROCESS_COMPOSE_ARTIFACTS_DIR}}
+      | xargs -I{} cp -rfs {}/. {{process-compose-artifacts-dir}}
   else
     nix build --impure -L --json .#legacyPackages.{{system}}.process-compose-environments.{{environment}} \
       | jq -r '.[0].outputs.out' \
-      | xargs -I{} cp -rfs {} {{PROCESS_COMPOSE_ARTIFACTS_DIR}}/{{environment}}-process-compose.yaml
+      | xargs -I{} cp -rfs {} {{process-compose-artifacts-dir}}/{{environment}}-process-compose.yaml
   fi
-  echo "Process Compose artifacts copied to {{PROCESS_COMPOSE_ARTIFACTS_DIR}}"
+  echo "Process Compose artifacts copied to {{process-compose-artifacts-dir}}"
 
 # Start a specific process compose environment
 start-environment environment:
   #!/usr/bin/env bash
-  PC_FILE="{{PROCESS_COMPOSE_ARTIFACTS_DIR}}/{{environment}}-process-compose.yaml"
+  PC_FILE="{{process-compose-artifacts-dir}}/{{environment}}-process-compose.yaml"
   if ! test -f "$PC_FILE"; then
     just build-environment {{environment}}
   fi

--- a/nix/test-environments/default.nix
+++ b/nix/test-environments/default.nix
@@ -28,7 +28,7 @@
         (
           set -x
           ${lib.concatMapStringsSep "\n" (
-            x: "cp ${x.value} $out/${x.name}-process-compose.yaml"
+            x: "cp ${x.value} $out/process-compose-${x.name}.yaml"
           ) allEnvironments}
         )
       '';


### PR DESCRIPTION
### Summary

This PR introduces two cleanup refactors to improve naming clarity and consistency when working with process-compose environments, addressing the latest review of https://github.com/blocksense-network/blocksense/pull/1439.

Also introduces [groups](https://github.com/casey/just#groups) and [documentation-comments](https://github.com/casey/just?tab=readme-ov-file#documentation-comments) to the just commands

### Changes

#### 1. `Justfile`: idiomatic variable naming

* Replaces the shell-style constant `PROCESS_COMPOSE_ARTIFACTS_DIR` with a more idiomatic Just variable: `process-compose-artifacts-dir`.
* Uses `root-dir` for consistent path resolution instead of relying on `$GIT_ROOT`.

#### 2. Generated process compose yaml files names update

* Changes the generated artifact filenames from `<env>-process-compose.yaml` to `process-compose-<env>.yaml`.
* This affects both the Nix environment generator (`allProcessComposeFiles`) and the `build-environment` + `start-environment` Justfile recipes.

#### 3. Document commands and add them to groups.
This is useful when using the `just --list` command:

| Before                        | After                                            |
|------------------------------|---------------------------------------------------------------------|
| ![image](https://github.com/user-attachments/assets/8ee52118-4f12-4ef7-9734-d05298401e79) | ![image](https://github.com/user-attachments/assets/eb16301e-a006-4b84-9d77-0b8c0bc24e31) |

