### PR TITLE
[direnv]: Improve `direnv` Developer Experience

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -9,3 +9,6 @@ fi
 dotenv_if_exists
 
 use flake ".#${DEV_SHELL:-default}" --impure
+if [[ "$NIX_DIRENV_DID_FALLBACK" = 1 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
### Improve `direnv` Stability and Developer Experience

---

### Changes

#### 1. **Upgrade `nix-direnv` to v3.1.0**

Brings in the latest improvements and fixes from upstream.

---

#### 2. **Reduce Terminal Noise from `direnv`**

* Sets `DIRENV_LOG_FORMAT=""` to suppress verbose output like `direnv: export +VAR -VAR ...`.
* Prevents scrollback clutter, especially useful in setups that export many variables.

Here’s what `direnv reload` looks like before and after:

| Before                                                                                     | After                                                                                     |
| ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
| ![before](https://github.com/user-attachments/assets/65f1b7b0-a1e6-444d-9ab1-3bfe350c8c84) | ![after](https://github.com/user-attachments/assets/4ec0908c-12f0-4943-93b8-c2cd72be6e31) |

---

#### 3. **Exit on Fallback Activation**

* Adds a guard for `NIX_DIRENV_DID_FALLBACK=1`, which signals that `nix-direnv` failed to load the expected environment.
* If this fallback is triggered, we now exit to avoid silently entering a broken or stale shell.
* This makes failures explicit and prevents subtle bugs caused by partially loaded environments (e.g., when `devShell` builds fail).

Example:

| Before                                                                                     | After                                                                                     |
| ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
| ![before](https://github.com/user-attachments/assets/4872f22d-6375-4aaf-9138-950055ef096e) | ![after](https://github.com/user-attachments/assets/40582600-6f2b-4b55-9bff-f7b3b2d49907) |

---

### Why This Matters

* Without the fallback check, it's easy to end up in a broken shell without noticing — leading to subtle and frustrating bugs.
* Silencing the env var spam helps focus attention on meaningful errors or output. In practice, this means you’ll actually **see** when your shell fails to load instead of losing it in a sea of `export` logs.

