### PR TITLE
Hstaykov/aggregated updates to publishers

### DIFF
--- a/apps/sequencer/src/feeds/votes_result_sender.rs
+++ b/apps/sequencer/src/feeds/votes_result_sender.rs
@@ -133,7 +133,7 @@ async fn aggregated_updates_to_publishers(
             {
                 Ok(_) => {
                     info!(
-                        "sent aggregated updates to publishers for block_height = {block_height}."
+                        "sent aggregated updates to publishers for block_height: {block_height}."
                     );
                 }
                 Err(e) => {
@@ -142,7 +142,7 @@ async fn aggregated_updates_to_publishers(
             }
         }
         Err(e) => {
-            error!("Could not serialize updates = {updates:?} due to: {e}")
+            error!("Could not serialize updates: {updates:?} due to Error: {e}")
         }
     };
 }
@@ -365,7 +365,7 @@ async fn send_to_msg_stream(
             Ok(())
         }
         Err(e) => {
-            eyre::bail!("Failed to send batch of aggregated feed values for network: {net}, topic: {topic}, block height: {block_height} to kafka endpoint! {e:?}");
+            eyre::bail!("Failed to send batch of aggregated feed values for network: {net}, topic: {topic}, block height: {block_height} to kafka endpoint! Error: {e:?}");
         }
     }
 }

--- a/libs/data_feeds/src/feeds_processing.rs
+++ b/libs/data_feeds/src/feeds_processing.rs
@@ -17,6 +17,13 @@ pub struct VotedFeedUpdate {
     pub end_slot_timestamp: Timestamp,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EncodedVotedFeedUpdate {
+    pub feed_id: u32,
+    pub value: Vec<u8>,
+    pub end_slot_timestamp: Timestamp,
+}
+
 #[derive(Debug, Clone)]
 pub struct VotedFeedUpdateWithProof {
     pub update: VotedFeedUpdate,
@@ -177,6 +184,12 @@ pub fn naive_packing(
 pub struct BatchedAggegratesToSend {
     pub block_height: u64,
     pub updates: Vec<VotedFeedUpdate>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct EncodedBatchedAggegratesToSend {
+    pub block_height: u64,
+    pub updates: Vec<EncodedVotedFeedUpdate>,
 }
 
 #[derive(Clone, Debug)]

--- a/libs/data_feeds/src/feeds_processing.rs
+++ b/libs/data_feeds/src/feeds_processing.rs
@@ -173,7 +173,7 @@ pub fn naive_packing(
     feed_result.as_bytes(digits_in_fraction, timestamp)
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct BatchedAggegratesToSend {
     pub block_height: u64,
     pub updates: Vec<VotedFeedUpdate>,


### PR DESCRIPTION
In this PR we introduce a new Kafka topic to stream the updates that have to be published by relayers to supported blockchain networks.