### PR TITLE
[just]: Make `clean` command remove `yarn` artifacts as well

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -115,7 +115,6 @@ clean:
   git clean -fdx \
     -e .env \
     -e .direnv \
-    -e .yarn \
     -e .vscode \
     -e .pre-commit-config.yaml \
     -- {{root-dir}}


### PR DESCRIPTION
This fixes a weird issue where `yarn test` in the contracts workspace failed because it could not find `libudev.so`. This was due to the fact that `.yarn/unplugged` contained old native node modules which were linked to an old version of the devshell.