### PR TITLE
[data-providers-sdk/oracles]: Support Multiple API Keys in PricesFetcher

### DIFF
--- a/apps/oracles/stock-price-feeds/src/fetch_prices.rs
+++ b/apps/oracles/stock-price-feeds/src/fetch_prices.rs
@@ -16,7 +16,7 @@ use blocksense_data_providers_sdk::price_data::{
 
 use crate::{
     types::{Capabilities, ResourceData, ResourcePairData},
-    utils::get_api_key,
+    utils::get_api_keys,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -57,17 +57,17 @@ pub async fn get_prices(
     let futures_set = FuturesUnordered::from_iter([
         fetch::<AlphaVantagePriceFetcher>(
             &symbols.alpha_vantage,
-            get_api_key(capabilities, "ALPHAVANTAGE_API_KEY"),
+            get_api_keys(capabilities, &["ALPHAVANTAGE_API_KEY"]),
         ),
         fetch::<YFPriceFetcher>(
             &symbols.yahoo_finance,
-            get_api_key(capabilities, "YAHOO_FINANCE_API_KEY"),
+            get_api_keys(capabilities, &["YAHOO_FINANCE_API_KEY"]),
         ),
         fetch::<TwelveDataPriceFetcher>(
             &symbols.twelvedata,
-            get_api_key(capabilities, "TWELVEDATA_API_KEY"),
+            get_api_keys(capabilities, &["TWELVEDATA_API_KEY"]),
         ),
-        fetch::<FMPPriceFetcher>(&symbols.fmp, get_api_key(capabilities, "FMP_API_KEY")),
+        fetch::<FMPPriceFetcher>(&symbols.fmp, get_api_keys(capabilities, &["FMP_API_KEY"])),
     ]);
 
     let fetched_provider_prices = fetch_all_prices(futures_set).await;

--- a/apps/oracles/stock-price-feeds/src/utils.rs
+++ b/apps/oracles/stock-price-feeds/src/utils.rs
@@ -1,11 +1,19 @@
 #![allow(unused_imports)]
+use std::collections::HashMap;
+
 use chrono::{Datelike, NaiveTime, TimeZone};
 use chrono_tz::US::Eastern;
 
 use crate::types::Capabilities;
 
-pub fn get_api_key<'a>(capabilities: &'a Capabilities, key: &str) -> Option<&'a str> {
-    capabilities.get(key).map(|s| s.as_str())
+pub fn get_api_keys(capabilities: &Capabilities, keys: &[&str]) -> Option<HashMap<String, String>> {
+    keys.iter()
+        .map(|&key| {
+            capabilities
+                .get(key)
+                .map(|value| (key.to_string(), value.clone()))
+        })
+        .collect()
 }
 
 pub fn markets_are_closed(now_et: chrono::DateTime<chrono_tz::Tz>) -> bool {
@@ -22,18 +30,24 @@ pub fn markets_are_closed(now_et: chrono::DateTime<chrono_tz::Tz>) -> bool {
 }
 
 #[test]
-fn test_get_api_key() {
+fn test_get_api_keys() {
     let mut capabilities = Capabilities::new();
     capabilities.insert("API_KEY".to_string(), "test_key".to_string());
 
-    let result = get_api_key(&capabilities, "API_KEY");
-    assert_eq!(result, Some("test_key"));
+    let result = get_api_keys(&capabilities, &["API_KEY"]);
+    assert_eq!(
+        result,
+        Some(HashMap::from([(
+            "API_KEY".to_string(),
+            "test_key".to_string()
+        )]))
+    );
 
-    let result = get_api_key(&capabilities, "NON_EXISTENT_KEY");
+    let result = get_api_keys(&capabilities, &["NON_EXISTENT_KEY"]);
     assert_eq!(result, None);
 
     let empty_capabilities = Capabilities::new();
-    let result = get_api_key(&empty_capabilities, "API_KEY");
+    let result = get_api_keys(&empty_capabilities, &["API_KEY"]);
     assert_eq!(result, None);
 }
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/binance.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/binance.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use futures::{future::LocalBoxFuture, FutureExt};
 
@@ -28,7 +30,7 @@ pub struct BinancePriceFetcher<'a> {
 impl<'a> PricesFetcher<'a> for BinancePriceFetcher<'a> {
     const NAME: &'static str = "Binance";
 
-    fn new(symbols: &'a [String], _api_key: Option<&'a str>) -> Self {
+    fn new(symbols: &'a [String], _api_keys: Option<HashMap<String, String>>) -> Self {
         Self { symbols }
     }
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/binance_us.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/binance_us.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use futures::{future::LocalBoxFuture, FutureExt};
 
@@ -28,7 +30,7 @@ pub struct BinanceUsPriceFetcher<'a> {
 impl<'a> PricesFetcher<'a> for BinanceUsPriceFetcher<'a> {
     const NAME: &'static str = "Binance US";
 
-    fn new(symbols: &'a [String], _api_key: Option<&'a str>) -> Self {
+    fn new(symbols: &'a [String], _api_keys: Option<HashMap<String, String>>) -> Self {
         Self { symbols }
     }
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/bitfinex.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/bitfinex.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use futures::{future::LocalBoxFuture, FutureExt};
 
@@ -48,7 +50,7 @@ pub struct BitfinexPriceFetcher<'a> {
 impl<'a> PricesFetcher<'a> for BitfinexPriceFetcher<'a> {
     const NAME: &'static str = "Bitfinex";
 
-    fn new(symbols: &'a [String], _api_key: Option<&'a str>) -> Self {
+    fn new(symbols: &'a [String], _api_keys: Option<HashMap<String, String>>) -> Self {
         Self { symbols }
     }
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/bitget.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/bitget.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use futures::{future::LocalBoxFuture, FutureExt};
 
@@ -29,7 +31,7 @@ pub struct BitgetPriceFetcher;
 impl PricesFetcher<'_> for BitgetPriceFetcher {
     const NAME: &'static str = "Bitget";
 
-    fn new(_symbols: &[String], _api_key: Option<&str>) -> Self {
+    fn new(_symbols: &[String], _api_keys: Option<HashMap<String, String>>) -> Self {
         Self
     }
     fn fetch(&self) -> LocalBoxFuture<Result<PairPriceData>> {

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/bybit.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/bybit.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use futures::{future::LocalBoxFuture, FutureExt};
 
@@ -37,7 +39,7 @@ pub struct BybitPriceFetcher;
 impl PricesFetcher<'_> for BybitPriceFetcher {
     const NAME: &'static str = "Bybit";
 
-    fn new(_symbols: &[String], _api_key: Option<&str>) -> Self {
+    fn new(_symbols: &[String], _api_keys: Option<HashMap<String, String>>) -> Self {
         Self
     }
     fn fetch(&self) -> LocalBoxFuture<Result<PairPriceData>> {

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/coinbase.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/coinbase.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use futures::{
     future::LocalBoxFuture,
@@ -28,7 +30,7 @@ pub struct CoinbasePriceFetcher<'a> {
 impl<'a> PricesFetcher<'a> for CoinbasePriceFetcher<'a> {
     const NAME: &'static str = "Coinbase";
 
-    fn new(symbols: &'a [String], _api_key: Option<&'a str>) -> Self {
+    fn new(symbols: &'a [String], _api_keys: Option<HashMap<String, String>>) -> Self {
         Self { symbols }
     }
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/crypto_com_exchange.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/crypto_com_exchange.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use futures::{future::LocalBoxFuture, FutureExt};
 
@@ -33,7 +35,7 @@ pub struct CryptoComPriceFetcher;
 impl PricesFetcher<'_> for CryptoComPriceFetcher {
     const NAME: &'static str = "Crypto.com";
 
-    fn new(_symbols: &[String], _api_key: Option<&str>) -> Self {
+    fn new(_symbols: &[String], _api_keys: Option<HashMap<String, String>>) -> Self {
         Self
     }
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/gate_io.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/gate_io.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use futures::{future::LocalBoxFuture, FutureExt};
 
@@ -24,7 +26,7 @@ pub struct GateIoPriceFetcher;
 impl PricesFetcher<'_> for GateIoPriceFetcher {
     const NAME: &'static str = "Gate.io";
 
-    fn new(_symbols: &[String], _api_key: Option<&str>) -> Self {
+    fn new(_symbols: &[String], _api_keys: Option<HashMap<String, String>>) -> Self {
         Self
     }
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/gemini.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/gemini.rs
@@ -1,10 +1,11 @@
+use std::{collections::HashMap, ops::Deref};
+
 use anyhow::Result;
 use futures::{
     future::LocalBoxFuture,
     stream::{FuturesUnordered, StreamExt},
     FutureExt,
 };
-use std::{collections::HashMap, ops::Deref};
 
 use serde::Deserialize;
 use serde_json::Value;
@@ -28,7 +29,7 @@ pub struct GeminiPriceFetcher<'a> {
 impl<'a> PricesFetcher<'a> for GeminiPriceFetcher<'a> {
     const NAME: &'static str = "Gemini";
 
-    fn new(symbols: &'a [String], _api_key: Option<&'a str>) -> Self {
+    fn new(symbols: &'a [String], _api_keys: Option<HashMap<String, String>>) -> Self {
         Self { symbols }
     }
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/kraken.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/kraken.rs
@@ -40,7 +40,7 @@ pub struct KrakenPriceFetcher;
 impl PricesFetcher<'_> for KrakenPriceFetcher {
     const NAME: &'static str = "Kraken";
 
-    fn new(_symbols: &[String], _api_key: Option<&str>) -> Self {
+    fn new(_symbols: &[String], _api_keys: Option<HashMap<String, String>>) -> Self {
         Self
     }
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/kucoin.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/kucoin.rs
@@ -1,5 +1,7 @@
 use std::str::FromStr;
 
+use std::collections::HashMap;
+
 use anyhow::Result;
 use futures::{future::LocalBoxFuture, FutureExt};
 
@@ -47,7 +49,7 @@ pub struct KuCoinPriceFetcher;
 impl PricesFetcher<'_> for KuCoinPriceFetcher {
     const NAME: &'static str = "KuCoin";
 
-    fn new(_symbols: &[String], _api_key: Option<&str>) -> Self {
+    fn new(_symbols: &[String], _api_keys: Option<HashMap<String, String>>) -> Self {
         Self
     }
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/mexc.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/mexc.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use futures::{future::LocalBoxFuture, FutureExt};
 
@@ -25,7 +27,7 @@ pub struct MEXCPriceFetcher;
 impl PricesFetcher<'_> for MEXCPriceFetcher {
     const NAME: &'static str = "MEXC";
 
-    fn new(_symbols: &[String], _api_key: Option<&str>) -> Self {
+    fn new(_symbols: &[String], _api_keys: Option<HashMap<String, String>>) -> Self {
         Self
     }
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/okx.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/okx.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use futures::{future::LocalBoxFuture, FutureExt};
 
@@ -29,7 +31,7 @@ pub struct OKXPriceFetcher;
 impl PricesFetcher<'_> for OKXPriceFetcher {
     const NAME: &'static str = "OKX";
 
-    fn new(_symbols: &[String], _api_key: Option<&str>) -> Self {
+    fn new(_symbols: &[String], _api_keys: Option<HashMap<String, String>>) -> Self {
         Self
     }
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/upbit.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/upbit.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 
 use futures::{future::LocalBoxFuture, FutureExt};
@@ -23,7 +25,7 @@ pub struct UpBitPriceFetcher<'a> {
 impl<'a> PricesFetcher<'a> for UpBitPriceFetcher<'a> {
     const NAME: &'static str = "UpBit";
 
-    fn new(symbols: &'a [String], _api_key: Option<&'a str>) -> Self {
+    fn new(symbols: &'a [String], _api_keys: Option<HashMap<String, String>>) -> Self {
         Self { symbols }
     }
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/stock_markets/twelvedata.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/stock_markets/twelvedata.rs
@@ -22,24 +22,23 @@ type TwelveDataResponse = HashMap<String, PriceData>;
 
 pub struct TwelveDataPriceFetcher<'a> {
     pub symbols: &'a [String],
-    api_key: Option<&'a str>,
+    api_keys: Option<HashMap<String, String>>,
 }
 
 impl<'a> PricesFetcher<'a> for TwelveDataPriceFetcher<'a> {
     const NAME: &'static str = "twelvedata";
 
-    fn new(symbols: &'a [String], api_key: Option<&'a str>) -> Self {
-        Self { symbols, api_key }
+    fn new(symbols: &'a [String], api_keys: Option<HashMap<String, String>>) -> Self {
+        Self { symbols, api_keys }
     }
 
     fn fetch(&self) -> LocalBoxFuture<Result<PairPriceData>> {
         async {
-            let api_key = match self.api_key {
-                Some(key) => key,
-                None => {
-                    return Err(Error::msg("API key is required for TwelveData"));
-                }
-            };
+            let api_key = self
+                .api_keys
+                .as_ref()
+                .and_then(|map| map.get("TWELVEDATA_API_KEY"))
+                .ok_or_else(|| Error::msg("Missing TWELVEDATA_API_KEY"))?;
 
             let all_symbols = self.symbols.join(",");
 

--- a/libs/data_providers_sdk/src/price_data/traits/prices_fetcher.rs
+++ b/libs/data_providers_sdk/src/price_data/traits/prices_fetcher.rs
@@ -19,23 +19,19 @@ pub type PairPriceData = HashMap<TradingPairSymbol, PricePoint>;
 pub trait PricesFetcher<'a> {
     const NAME: &'static str;
 
-    fn new(symbols: &'a [String], api_key: Option<&'a str>) -> Self;
+    fn new(symbols: &'a [String], api_keys: Option<HashMap<String, String>>) -> Self;
     fn fetch(&self) -> LocalBoxFuture<Result<PairPriceData>>;
 }
 
 pub fn fetch<'a, PF>(
     symbols: &'a [String],
-    api_key: Option<&'a str>,
+    api_keys: Option<HashMap<String, String>>,
 ) -> LocalBoxFuture<'a, (&'static str, Result<PairPriceData>)>
 where
     PF: PricesFetcher<'a>,
 {
     async move {
-        let fetcher = match api_key {
-            Some(key) => PF::new(symbols, Some(key)),
-            None => PF::new(symbols, None),
-        };
-
+        let fetcher = PF::new(symbols, api_keys);
         let res = fetcher.fetch().await;
         (PF::NAME, res)
     }


### PR DESCRIPTION
### Refactor: Support Multiple API Keys in `PricesFetcher`

This PR updates the `PricesFetcher` trait and all implementations to support **multiple API keys** instead of a single one. This makes the fetcher interfaces more flexible and consistent with providers that may require more than one credential or future expansion.

---

###  What's Changed

* `PricesFetcher::new()` now takes `Option<HashMap<String, String>>` instead of `Option<&str>`
* All exchange and stock market fetchers updated to support the new `api_keys` format
* Introduced helper `get_api_keys()` in `stock-price-feeds` to fetch multiple keys from `Capabilities`
* Updated unit tests accordingly (renamed `test_get_api_key` → `test_get_api_keys`)
* Graceful error handling added when required keys (e.g., `ALPHAVANTAGE_API_KEY`) are missing
* All internal fetcher instantiations updated to the new `api_keys` format

---

### Why It Matters

This refactor enables:

* Future-proofing for APIs that may require multiple credentials (e.g., key + secret)
