### PR TITLE
refactor(contracts): Remove block number from upgradeable proxy natspec

### DIFF
--- a/libs/ts/contracts/contracts/UpgradeableProxyADFS.sol
+++ b/libs/ts/contracts/contracts/UpgradeableProxyADFS.sol
@@ -25,14 +25,10 @@ pragma solidity ^0.8.28;
 ///
 /// Storage layout:
 ///   * Management space: [0 to 2**128-2**116)
-///              0x0000 - latest blocknumber (used by the implementation)
-///              0x0001 - implementation slot (used by this contract)
-///              0x0002 - admin slot (used by this contract)
-///                 ... - additional management space reserved for ADFS
-///   *  ADFS data space: [2**128-2**116 to 2**160)
+///   * ADFS data space:  [2**128-2**116 to 2**160)
 ///
 /// This contract intentionally deviates from the EIP-1967 slot scheme.
-/// It was co-designed with ADFS to accomodate its custom low-level
+/// It was co-designed with ADFS to accommodate its custom low-level
 /// storage management requirements.
 ///
 /// Note that this deviation has implications on storage isolation and


### PR DESCRIPTION
New salt:
- local `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266` for multisig `0x2DCe5D714Fe5eAE59a59940D0f5365F211110a05`: **`0xc1945d492a891c2a334d9396a470f5ccf294f0c5e0c7b4ebd0a4caba75788762`** -> `0xADF5aad5678f80110f9Ead077D91817bDde235Bc`
- testnet `0xd756119012CcabBC59910dE0ecEbE406B5b952bE` for multisig `0x53AdbDAA3EE8725De80Bf97173B1f1A0a48036De`: **`0x2c8218120b56642dfe422ab6fea501f3addf867d6e9ac8335abcba33ec033f5d`** -> `0xADF5aab911b08C78688CafcD865b605101a840E7`
- mainnet `0x421D7821121AE6e17C3dB72Cb5635Cc62df5F8aa` for multisig `0xe029f9EE758c61Ec8613c8a4F1122239d96473eb`: **`0x9a86ab80c0e8777c9de8cca57d101ad892f096d265e0cc068a207ed1ab616a25`** -> `0xADF5aaeB747a2797b45bca4e3C0c6C8bBDAfBf27`