### PR TITLE
[nix/example-setup-01]: Add missing `allowed-outbound-host` of `eth-rpc`

### DIFF
--- a/nix/test-environments/example-setup-01.nix
+++ b/nix/test-environments/example-setup-01.nix
@@ -199,6 +199,7 @@ in
       eth-rpc = {
         exec-interval = 10;
         allowed-outbound-hosts = [
+          "https://arbitrum-one-rpc.publicnode.com"
           "https://eth.llamarpc.com"
           "https://rpc.eth.gateway.fm"
           "https://ethereum-rpc.publicnode.com"


### PR DESCRIPTION
### Motivation:

Saw the following log when testing oracles
![image](https://github.com/user-attachments/assets/2d709043-0355-4087-acfe-1b5385119731)
