### PR TITLE
[docs-ui]: Use `#1f1f1f` as new bg-color for dark theme

### DIFF
--- a/libs/ts/docs-ui/blocksense-theme/variables.css
+++ b/libs/ts/docs-ui/blocksense-theme/variables.css
@@ -17,7 +17,7 @@
   --breakpoint-3xl: 1920px;
 
   --bg-color: #fffbfa;
-  --bg-color-dark: #2b2929;
+  --bg-color-dark: #1f1f1f;
 
   --focus-border-color: #2fa6ff;
   --transparent-color: transparent;


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/3fa6d39d-1c05-42a4-ab17-06a8b4a34601)

After:
![image](https://github.com/user-attachments/assets/57544198-dd36-402b-aec0-ce61b47613e1)
