### PR TITLE
[docs.ws]: Fix sidebar expand/collapse behavior

### DIFF
--- a/libs/ts/nextra-theme-docs/src/components/sidebar.tsx
+++ b/libs/ts/nextra-theme-docs/src/components/sidebar.tsx
@@ -403,7 +403,6 @@ export const Sidebar: FC<{ toc: Heading[] }> = ({ toc }) => {
           'x:max-md:hidden x:flex x:flex-col',
           'x:h-[calc(100dvh-var(--nextra-menu-height))]',
           'x:top-(--nextra-navbar-height) x:shrink-0',
-          isExpanded ? 'x:w-68' : 'x:w-20',
           hideSidebar ? 'x:hidden' : 'x:sticky',
         )}
       >


### PR DESCRIPTION
This PR aims to fix the issues with sidebar not expanding properly after collapse.

* **Before :**
<img width="858" height="1927" alt="Screenshot From 2025-07-11 12-16-11" src="https://github.com/user-attachments/assets/d9efb733-a49f-499c-8b9b-455a44e7ebf3" />

* **After :**
<img width="858" height="1927" alt="image" src="https://github.com/user-attachments/assets/0e51d34c-28fb-4e1f-abaf-83be35359822" />

