### PR TITLE
[e2e-tests]: Implement Prometheus metrics fetcher utility

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -80,6 +80,7 @@ test-ts:
   yarn test-single @blocksense/changelog-generator
   yarn test-single @blocksense/chain-interactions
   yarn test-single @blocksense/avm-relayer
+  yarn workspace @blocksense/e2e-tests run test:unit
 
 test-e2e:
   yarn workspace @blocksense/e2e-tests run test

--- a/apps/e2e-tests/@types/parse-prometheus-text-format.d.ts
+++ b/apps/e2e-tests/@types/parse-prometheus-text-format.d.ts
@@ -1,0 +1,1 @@
+declare module 'parse-prometheus-text-format';

--- a/apps/e2e-tests/package.json
+++ b/apps/e2e-tests/package.json
@@ -11,6 +11,8 @@
     "@blocksense/base-utils": "workspace:*",
     "@blocksense/config-types": "workspace:*",
     "@blocksense/contracts": "workspace:*",
+    "@effect/platform": "^0.90.0",
+    "@effect/vitest": "^0.25.0",
     "@types/node": "^22.3.0",
     "effect": "^3.15.1",
     "execa": "^9.5.2",

--- a/apps/e2e-tests/package.json
+++ b/apps/e2e-tests/package.json
@@ -14,6 +14,7 @@
     "@types/node": "^22.3.0",
     "effect": "^3.15.1",
     "execa": "^9.5.2",
+    "parse-prometheus-text-format": "^1.1.1",
     "tsx": "^4.17.0",
     "typescript": "^5.5.4",
     "vitest": "^3.2.4"

--- a/apps/e2e-tests/package.json
+++ b/apps/e2e-tests/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "ts": "yarn node --import tsx",
     "test": "vitest run --typecheck --coverage",
+    "test:unit": "yarn vitest -w false src/utils",
     "test:process-compose-e2e": "yarn test src/process-compose/e2e.spec.ts"
   },
   "dependencies": {

--- a/apps/e2e-tests/src/utils/metrics/index.ts
+++ b/apps/e2e-tests/src/utils/metrics/index.ts
@@ -1,0 +1,2 @@
+export * from './metrics-fetcher';
+export * from './types';

--- a/apps/e2e-tests/src/utils/metrics/metrics-fetcher.spec.ts
+++ b/apps/e2e-tests/src/utils/metrics/metrics-fetcher.spec.ts
@@ -1,0 +1,112 @@
+import { Effect } from 'effect';
+import { afterAll, describe, expect, it, vi } from '@effect/vitest';
+import { HttpClientError } from '@effect/platform';
+
+import { getMetrics } from './metrics-fetcher';
+import { ParseMetricsError } from './types';
+
+describe('Metrics fetcher tests', () => {
+  const test_url = 'http://localhost:8080/metrics';
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it.effect(
+    'should return PrometheusMetrics on successful fetch and parse',
+    () =>
+      Effect.gen(function* () {
+        vi.stubGlobal(
+          'fetch',
+          vi.fn().mockResolvedValue({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                `
+            # HELP l2_chain_id The chain ID of the L2 chain.
+            # TYPE l2_chain_id gauge
+            l2_chain_id 12345
+            `,
+              ),
+          }),
+        );
+
+        const result = yield* getMetrics(test_url);
+
+        expect(result).toEqual([
+          {
+            name: 'l2_chain_id',
+            help: 'The chain ID of the L2 chain.',
+            type: 'GAUGE',
+            metrics: [{ value: 12345 }],
+          },
+        ]);
+      }),
+  );
+
+  it.effect(
+    'should return HttpClientError.ResponseError on fetch failure',
+    () =>
+      Effect.gen(function* () {
+        const mockError = new Error('Network error');
+
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(mockError));
+
+        const result = yield* Effect.flip(getMetrics(test_url));
+        expect(result).toBeInstanceOf(HttpClientError.RequestError);
+        expect(result._tag).toBe('RequestError');
+      }),
+  );
+
+  it.effect(
+    'should return @e2e-tests/ParseMetricsError on invalid prometheus format',
+    () =>
+      Effect.gen(function* () {
+        const mockMetrics = 'invalid metrics';
+        const mockResponse = {
+          ok: true,
+          text: () => Promise.resolve(mockMetrics),
+        };
+
+        vi.stubGlobal(
+          'fetch',
+          vi.fn().mockResolvedValue({
+            ok: true,
+            text: () => Promise.resolve(mockResponse),
+          }),
+        );
+
+        const result = yield* Effect.flip(getMetrics(test_url));
+
+        expect(result).toBeInstanceOf(ParseMetricsError);
+        expect(result._tag).toBe('@e2e-tests/ParseMetricsError');
+      }),
+  );
+
+  it.effect('should return ParseError on schema validation failure', () =>
+    Effect.gen(function* () {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              `
+              # HELP l2_chain_id The chain ID of the L2 chain.
+              # TYPE l2_chain_id gauge
+              l2_chain_id "invalid_value"
+              `,
+            ),
+        }),
+      );
+
+      const result = yield* Effect.flip(getMetrics(test_url));
+
+      // The metric type is gauge, but the value is a string, which is invalid.
+      expect(result.message).toMatch(
+        /Unable to decode "\\".*?\\"" into a number/,
+      );
+      expect(result._tag).toBe('ParseError');
+    }),
+  );
+});

--- a/apps/e2e-tests/src/utils/metrics/metrics-fetcher.ts
+++ b/apps/e2e-tests/src/utils/metrics/metrics-fetcher.ts
@@ -1,0 +1,36 @@
+import { Effect, Schema as S } from 'effect';
+import type { ParseError } from 'effect/ParseResult';
+import type { HttpClientError } from '@effect/platform';
+import { FetchHttpClient, HttpClientRequest } from '@effect/platform';
+import { HttpClient } from '@effect/platform/HttpClient';
+import parsePrometheusTextFormat from 'parse-prometheus-text-format';
+
+import type { PrometheusMetrics } from './types';
+import { ParseMetricsError, PrometheusMetricsSchema } from './types';
+
+export const getMetrics = (
+  url: string,
+): Effect.Effect<
+  PrometheusMetrics,
+  ParseMetricsError | HttpClientError.HttpClientError | ParseError
+> => {
+  return Effect.gen(function* () {
+    const client = yield* HttpClient;
+    const request = HttpClientRequest.get(url).pipe(
+      HttpClientRequest.setHeader('Accept', 'application/json'),
+    );
+    const response = yield* client.execute(request);
+    const metricsAsStr = yield* response.text;
+
+    const parsedMetrics = yield* Effect.tryPromise({
+      try: () => Promise.resolve(parsePrometheusTextFormat(metricsAsStr)),
+      catch: error => new ParseMetricsError({ message: `${error}` }),
+    });
+
+    const decodedMetrics = yield* S.decodeUnknown(PrometheusMetricsSchema)(
+      parsedMetrics,
+    );
+
+    return decodedMetrics;
+  }).pipe(Effect.provide(FetchHttpClient.layer));
+};

--- a/apps/e2e-tests/src/utils/metrics/types.ts
+++ b/apps/e2e-tests/src/utils/metrics/types.ts
@@ -1,0 +1,32 @@
+import { Data, Schema as S } from 'effect';
+
+// Metric type definitions
+const Labels = S.Record({
+  key: S.String,
+  value: S.String,
+});
+
+const MetricSchema = S.Struct({
+  value: S.NumberFromString,
+  labels: S.optional(Labels),
+});
+
+const MetricType = S.Literal('COUNTER', 'GAUGE', 'HISTOGRAM', 'SUMMARY');
+
+const PrometheusMetricSchema = S.Struct({
+  name: S.String,
+  help: S.String,
+  type: MetricType,
+  metrics: S.Array(MetricSchema),
+});
+
+export const PrometheusMetricsSchema = S.Array(PrometheusMetricSchema);
+
+export type PrometheusMetrics = typeof PrometheusMetricsSchema.Type;
+
+// Error types definitions
+export class ParseMetricsError extends Data.TaggedError(
+  '@e2e-tests/ParseMetricsError',
+)<{
+  readonly message: string; // 'Failed to parse the Prometheus text format!'
+}> {}

--- a/apps/e2e-tests/tsconfig.json
+++ b/apps/e2e-tests/tsconfig.json
@@ -5,6 +5,6 @@
     "rootDir": "src",
     "declarationDir": "dist/types"
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "@types/**/*.d.ts"],
   "exclude": ["**/*.spec.ts", "dist"]
 }

--- a/libs/ts/base-utils/package.json
+++ b/libs/ts/base-utils/package.json
@@ -107,6 +107,7 @@
     "vitest": "^3.1.2"
   },
   "dependencies": {
+    "@effect/platform": "^0.90.0",
     "effect": "^3.15.1",
     "tslib": "^2.8.1"
   }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@blocksense/base-utils": "workspace:*",
     "@effect/eslint-plugin": "^0.3.2",
+    "@effect/language-service": "^0.28.2",
     "@eslint/compat": "1.3.0",
     "@eslint/eslintrc": "3.3.1",
     "@eslint/js": "9.28.0",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -42,7 +42,22 @@
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "skipDefaultLibCheck": true
+    "skipDefaultLibCheck": true,
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "diagnostics": true,
+        "diagnosticSeverity": {
+          "floatingEffect": "warning"
+        },
+        "quickinfo": true,
+        "completions": true,
+        "goto": true,
+        "allowedDuplicatedPackages": [],
+        "barrelImportPackages": [],
+        "namespaceImportPackages": []
+      }
+    ]
   },
   "exclude": [".yarn/unplugged", "tmp"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2585,6 +2585,7 @@ __metadata:
   dependencies:
     "@blocksense/base-utils": "workspace:*"
     "@effect/eslint-plugin": "npm:^0.3.2"
+    "@effect/language-service": "npm:^0.28.2"
     "@eslint/compat": "npm:1.3.0"
     "@eslint/eslintrc": "npm:3.3.1"
     "@eslint/js": "npm:9.28.0"
@@ -3419,6 +3420,15 @@ __metadata:
   version: 0.20.1
   resolution: "@effect/language-service@npm:0.20.1"
   checksum: 10c0/faba9c1668db16e612dfd4c7ab97ac71afa1a8c7845bdf3a3e5b52f93a28d003ec19d2ac3790f7e35b5a94a22745093892683085025e55d205a9006376bd8f13
+  languageName: node
+  linkType: hard
+
+"@effect/language-service@npm:^0.28.2":
+  version: 0.28.2
+  resolution: "@effect/language-service@npm:0.28.2"
+  bin:
+    effect-language-service: cli.js
+  checksum: 10c0/81a05ec17e30637663a8828a95dd175db2a5e55fd6990950a63d3429938fc273072005822422e527cdc2a199e45da9bbc43bceacd390b1c3290caee4e85d65af
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2325,6 +2325,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@blocksense/base-utils@workspace:libs/ts/base-utils"
   dependencies:
+    "@effect/platform": "npm:^0.90.0"
     "@types/node": "npm:^22.10.2"
     "@vitest/coverage-v8": "npm:3.1.3"
     effect: "npm:^3.15.1"
@@ -3490,6 +3491,20 @@ __metadata:
   peerDependencies:
     effect: ^3.14.13
   checksum: 10c0/0865c0280d6f7b94580fba31f111b591f0702a2838ddd3615fa750154133bad6cdbfc26f1e958dbd8c1bfe61df05dd3e4e8c734bb7af900a362542f37128d133
+  languageName: node
+  linkType: hard
+
+"@effect/platform@npm:^0.90.0":
+  version: 0.90.0
+  resolution: "@effect/platform@npm:0.90.0"
+  dependencies:
+    "@opentelemetry/semantic-conventions": "npm:^1.33.0"
+    find-my-way-ts: "npm:^0.1.6"
+    msgpackr: "npm:^1.11.4"
+    multipasta: "npm:^0.2.7"
+  peerDependencies:
+    effect: ^3.17.0
+  checksum: 10c0/a3e611cdfa9fb82ee8df00d017f3df6323e057e2399af20f454b3b368ef7dbf6ca44deeb0d753bd16103cee845f6634b352397507d0a67ac64641f64f4b6b846
   languageName: node
   linkType: hard
 
@@ -20688,6 +20703,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"find-my-way-ts@npm:^0.1.6":
+  version: 0.1.6
+  resolution: "find-my-way-ts@npm:0.1.6"
+  checksum: 10c0/16ad4b15275b56ee0ec361d0c61afbdff4c75bd0ac04112f6910f188cb1058096ba63529c2363914da6bb60266aa4def1025af04af26368ff87eb0df52f2862f
+  languageName: node
+  linkType: hard
+
 "find-replace@npm:^3.0.0":
   version: 3.0.0
   resolution: "find-replace@npm:3.0.0"
@@ -26313,6 +26335,13 @@ __metadata:
   version: 0.2.5
   resolution: "multipasta@npm:0.2.5"
   checksum: 10c0/f0790b1bdfc6b84ae6139982ead353957b668fe54fec8a4d93c19e9d051b02c837c93fbdff10b26bff2dbfcf7792c6435c27786c14ad82a0fb33b939c1bf96c6
+  languageName: node
+  linkType: hard
+
+"multipasta@npm:^0.2.7":
+  version: 0.2.7
+  resolution: "multipasta@npm:0.2.7"
+  checksum: 10c0/15917ac88aeefa5b8afac44b90d1e9d0d0ec7148b51e0766f07a69a220ecebcb6404539a856c45aa85a3d7fe517bc58febe81437146705f17ecd2961dc0b9fa5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2572,6 +2572,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:^3.2.4"
     effect: "npm:^3.15.1"
     execa: "npm:^9.5.2"
+    parse-prometheus-text-format: "npm:^1.1.1"
     tsx: "npm:^4.17.0"
     typescript: "npm:^5.5.4"
     vitest: "npm:^3.2.4"
@@ -27761,6 +27762,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-prometheus-text-format@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "parse-prometheus-text-format@npm:1.1.1"
+  dependencies:
+    shallow-equal: "npm:^1.2.0"
+  checksum: 10c0/394e5939efc8b36fa9299c158b057750313a098cd38164fbd46bb6f25fabbb4ab270916fc06d0d3c7fa1402cf90fedfa81ee5fa3bf2b8d9e09ba6d9364a6a6ed
+  languageName: node
+  linkType: hard
+
 "parse5@npm:^7.0.0":
   version: 7.1.2
   resolution: "parse5@npm:7.1.2"
@@ -30840,6 +30850,13 @@ __metadata:
   dependencies:
     buffer: "npm:6.0.3"
   checksum: 10c0/d3c1542e30977c421957e87ceca699931dfca3f61e9f25d407efb3fd0dfdfa3eb274342bd905b46d4d862eeb741dd168c9a43a36b068436d63b818471be33e94
+  languageName: node
+  linkType: hard
+
+"shallow-equal@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "shallow-equal@npm:1.2.1"
+  checksum: 10c0/51e03abadd97c9ebe590547d92db9148446962a3f23a3a0fb1ba2fccab80af881eef0ff1f8ccefd3f066c0bc5a4c8ca53706194813b95c8835fa66448a843a26
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2569,6 +2569,8 @@ __metadata:
     "@blocksense/base-utils": "workspace:*"
     "@blocksense/config-types": "workspace:*"
     "@blocksense/contracts": "workspace:*"
+    "@effect/platform": "npm:^0.90.0"
+    "@effect/vitest": "npm:^0.25.0"
     "@types/node": "npm:^22.3.0"
     "@vitest/coverage-v8": "npm:^3.2.4"
     effect: "npm:^3.15.1"
@@ -3570,6 +3572,16 @@ __metadata:
     effect: ^3.16.5
     vitest: ^3.0.0
   checksum: 10c0/503ba6106f5b2c280a0bb70eea7607da8ca67adb4434d516093682f2f7b41e15f2398e7549ff7f43deccc9a2e83c6f95d353f1b6e3e89d3cf4d3912987ba8885
+  languageName: node
+  linkType: hard
+
+"@effect/vitest@npm:^0.25.0":
+  version: 0.25.0
+  resolution: "@effect/vitest@npm:0.25.0"
+  peerDependencies:
+    effect: ^3.17.0
+    vitest: ^3.2.0
+  checksum: 10c0/fe24cb402a2099ac726dc5b0fdced8e4ad430e652aa815f1d77081a0c596a99414c705cdbf2b1831e009069acce04ecdab505657882f5eb934f1bf662bfc0f90
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Task: [BSN-3278: Implement utility functions for reading the metrics of process](https://coda.io/d/_d6vM0kjfQP6#_tuk5j/r3278&view=full)
---
### Summary

This PR introduces a utility to fetch and parse Prometheus metrics in the `e2e-tests` package. It enables end-to-end tests to programmatically access and validate metrics exposed by services, supporting better observability and test automation.

---

### ✨ What's New

#### 🚀 Feature

- **`getMetrics(url)`**:
  - Fetches raw metrics from a Prometheus-compatible `/metrics` endpoint.
  - Parses Prometheus text format using `parse-prometheus-text-format`.
  - Validates data structure using `effect` schemas.

- **Robust error handling** with:
  - `HttpClientError.HttpClientError` (from `HttpClientError`, `@effect/platform`)
  - `ParseMetricsError` (our custom error for handling 3rd party call)
  - `ParseError` (from `effect`)

#### 🧪 Testing

- Added unit tests in `metrics-fetcher.spec.ts` covering:
  - ✅ Successful fetch & parse
  - ❌ Network failure
  - ❌ Invalid Prometheus format
  - ❌ Schema validation failure

#### 🔧 Project Configuration

- Added new script:  
  ```json
  "test:unit": "yarn vitest -w false src/utils"
