### PR TITLE
fix(spin-plugin): calculate `sha256` hashes at build-time

### DIFF
--- a/nix/pkgs/spin-plugin/default.nix
+++ b/nix/pkgs/spin-plugin/default.nix
@@ -1,9 +1,17 @@
 {
+  # Lib
+  lib,
+
+  # Helpers
   hostPlatform,
   runCommand,
-  spin,
   writers,
-  lib,
+
+  # Packages
+  spin,
+  jq,
+  moreutils, # sponge
+
   ...
 }:
 manifestArgs:
@@ -44,42 +52,70 @@ let
     }
     .${hostPlatform.parsed.cpu.name};
 
-  mkSpinPackageDescription =
-    pkg:
-    let
-      # Given a path, which is the result of an expression like "${pkg}", e.g.:
-      # /nix/store/yyrbizpsm928xsy8izd3qhwc21ynysw4-blocksense-dev/bin/trigger-oracle
-      # ^^^^^^^----------- dirname                                     ^------------- basename
+  packagelessManifest = lib.pipe manifest [
+    (attrs: attrs // { packages = [ ]; })
+    (writers.writeJSON "${manifest.name}.json")
+  ];
 
-      # We should create an archive with the following structure:
-      # ./trigger-oracle
-      # To do so, we need to change dir `-C` to the dirname and specify the basename.
-      basename = builtins.baseNameOf pkg;
-      dirname = builtins.dirOf pkg;
-      archive = runCommand "${basename}-spin-plugin-archive.tar.gz" { } ''
-        tar czf "$out" -C "${dirname}" "${basename}"
-      '';
-    in
-    {
-      inherit os arch;
-      url = "file://${archive}";
-      sha256 = builtins.hashFile "sha256" archive;
-    };
-
-  spinManifestJson = writers.writeJSON "${manifest.name}.json" (
-    manifest
-    // {
-      packages = builtins.map mkSpinPackageDescription manifest.packages;
-    }
-  );
-
-  spinStateDir =
-    let
-      stateDir = runCommand "" { } ''
+  vendoredSpinPlugins =
+    runCommand "vendored-spin-plugins"
+      {
+        nativeBuildInputs = [
+          jq
+          moreutils
+        ];
+      } # bash
+      ''
         mkdir -p $out
-        SPIN_DATA_DIR=$out ${spin} plugin install --yes --file ${spinManifestJson}
+
+        # Serialize all of the manifest but the original `packages` array (since its a list of Nix paths)
+        manifest_path=./spin_manifest.json
+        cp --no-preserve=mode ${packagelessManifest} "$manifest_path"
+
+        # Re-add all packages, `tar`-ing then up and calculating their `sha256sum`s at **build-time** (not eval-time!)
+        ${lib.pipe manifest.packages [
+          (lib.map (
+            pkgPath:
+            let
+              # Given a path, which is the result of an expression like "${pkg}", e.g.:
+              # /nix/store/yyrbizpsm928xsy8izd3qhwc21ynysw4-blocksense-dev/bin/trigger-oracle
+              # ^^^^^^^----------- dirname                                     ^------------- basename
+
+              # We should create an archive with the following structure:
+              # ./trigger-oracle
+              # To do so, we need to change dir `-C` to the dirname and specify the basename.
+              basename = builtins.baseNameOf pkgPath;
+              dirname = builtins.dirOf pkgPath;
+              archive = runCommand "${basename}-spin-plugin-archive.tar.gz" { } ''
+                tar czf "$out" -C ${dirname} ${basename}
+              '';
+              basenameOffset = lib.pipe basename [
+                builtins.stringLength
+                (lib.flip lib.strings.replicate "#")
+              ];
+            in
+            # bash
+            ''
+              ###################${basenameOffset}####
+              ### ADDING PACKAGE ${basename} ###
+              ###################${basenameOffset}####
+
+              # To avoid quoting hell we construct the new `package` entry using `jq -n`
+              package_obj=$(jq -n \
+                --arg os ${os} \
+                --arg arch ${arch} \
+                --arg url file://${archive} \
+                --arg sha256 "$(sha256sum ${archive} | cut -d' ' -f1)" \
+                '{os: $os, arch: $arch, url: $url, sha256: $sha256}')
+
+              # Then we insert it back into the json
+              jq --argjson package_obj "$package_obj" '.packages += [$package_obj]' "$manifest_path" | sponge "$manifest_path"
+            ''
+          ))
+          (lib.concatStringsSep "\n")
+        ]}
+
+        SPIN_DATA_DIR=$out ${spin} plugin install --yes --file "$manifest_path"
       '';
-    in
-    stateDir;
 in
-spinStateDir
+vendoredSpinPlugins


### PR DESCRIPTION
This fixes a reproducibility oversight caused by us running a
`builtins.hashFile` on the output of the `spin` plugin derivation which,
by being a Rust derivation, is not (currently) reproducible.

We still do the `tar`-ing in separate derivations thus we do packages
iteration in `Nix`-land (with a big `lib.concatStringsSep` to combine the
resulting scripts), but we do the hashing (now a `sha256sum` call,
instead of a `builtins.hashFile "sha256"`) in `Bash`-land, which removes
our previous erroneous content-addressation of the `spin` plugin.

We now use `jq` to reconstruct the `packages` `JSON` array by starting
out with a `JSON`-ified `manifest` with an empty `packages` array and
slowly doing `jq '.packages += [{ ... }]'` calls over it, thus giving us
a place to do build-time calculation of the `spin` plugins' tarballs'
`sha256` hashes.
