### PR TITLE
[e2e-test]: Add sequencer config and price update tests. Update `example-setup-03`.

### DIFF
--- a/apps/e2e-tests/package.json
+++ b/apps/e2e-tests/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@blocksense/base-utils": "workspace:*",
+    "@blocksense/config-types": "workspace:*",
     "@blocksense/contracts": "workspace:*",
     "@types/node": "^22.3.0",
     "effect": "^3.15.1",

--- a/apps/e2e-tests/package.json
+++ b/apps/e2e-tests/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@blocksense/base-utils": "workspace:*",
+    "@blocksense/contracts": "workspace:*",
     "@types/node": "^22.3.0",
     "effect": "^3.7.0",
     "execa": "^9.5.2",

--- a/apps/e2e-tests/package.json
+++ b/apps/e2e-tests/package.json
@@ -11,7 +11,7 @@
     "@blocksense/base-utils": "workspace:*",
     "@blocksense/contracts": "workspace:*",
     "@types/node": "^22.3.0",
-    "effect": "^3.7.0",
+    "effect": "^3.15.1",
     "execa": "^9.5.2",
     "tsx": "^4.17.0",
     "typescript": "^5.5.4",

--- a/apps/e2e-tests/src/process-compose/e2e.spec.ts
+++ b/apps/e2e-tests/src/process-compose/e2e.spec.ts
@@ -4,6 +4,11 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { loopWhile, sleep } from '@blocksense/base-utils/async';
 import { getProcessComposeLogsFiles } from '@blocksense/base-utils/env';
+import { fetchAndDecodeJSON } from '@blocksense/base-utils/http';
+import { entriesOf, mapValuePromises } from '@blocksense/base-utils';
+import { AggregatedDataFeedStoreConsumer } from '@blocksense/contracts/viem';
+import type { SequencerConfigV2 } from '@blocksense/config-types/node-config';
+import { SequencerConfigV2Schema } from '@blocksense/config-types/node-config';
 
 import {
   parseProcessesStatus,
@@ -13,6 +18,14 @@ import {
 import { expectedPCStatuses03 } from './expected';
 
 describe.sequential('E2E Tests with process-compose', async () => {
+  const sequencerConfigUrl = 'http://127.0.0.1:5553/get_sequencer_config';
+  const network = 'ink_sepolia';
+
+  let sequencerConfig: SequencerConfigV2;
+  let ADFSConsumer;
+  let allowFeeds: Array<bigint>;
+  let initialPrices: Record<string, number>;
+
   beforeAll(async () => {
     await startEnvironment('example-setup-03');
   });
@@ -39,6 +52,44 @@ describe.sequential('E2E Tests with process-compose', async () => {
     expect(equal).toBe(true);
   });
 
+  test('Test sequencer config is available and in correct format', async () => {
+    sequencerConfig = await fetchAndDecodeJSON(
+      SequencerConfigV2Schema,
+      sequencerConfigUrl,
+    );
+
+    expect(sequencerConfig).toBeTypeOf('object');
+
+    // Collect initial information for the feeds and their prices
+    const url = sequencerConfig.providers[network].url;
+    const contractAddress = sequencerConfig.providers[network]
+      .contract_address as `0x${string}`;
+    allowFeeds =
+      sequencerConfig?.providers?.[network]?.allow_feeds?.map(feedId =>
+        BigInt(feedId),
+      ) ?? [];
+
+    ADFSConsumer = AggregatedDataFeedStoreConsumer.createConsumerByRpcUrl(
+      contractAddress,
+      url,
+    );
+
+    initialPrices = allowFeeds.reduce(
+      (acc, feedId) => {
+        acc[feedId.toString()] = 0;
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
+    initialPrices = await mapValuePromises(
+      initialPrices,
+      async (feedId, _) =>
+        await ADFSConsumer.getLatestSingleData(feedId).then(res =>
+          Number(res.slice(0, 50)),
+        ),
+    );
+  });
+
   test('Test processes state after 2 mins', async () => {
     // TODO: (EmilIvanichkovv): Consider reading `the total_tx_sent` metrics from the sequencer instead of wait for something unspecified to happen.
     // Wait for the processes to work for 5 minutes
@@ -48,6 +99,20 @@ describe.sequential('E2E Tests with process-compose', async () => {
     const processes = await parseProcessesStatus();
 
     expect(processes).toEqual(expectedPCStatuses03);
+  });
+
+  test('Test prices are updated', async () => {
+    const currentPrices = await mapValuePromises(
+      initialPrices,
+      async (feedId, _) =>
+        await ADFSConsumer.getLatestSingleData(feedId).then(res =>
+          Number(res.slice(0, 50)),
+        ),
+    );
+
+    for (const [id, price] of entriesOf(currentPrices)) {
+      expect(price).not.toEqual(initialPrices[id]);
+    }
   });
 
   describe.sequential('Reporter behavior based on logs', async () => {

--- a/config/feeds_config_v2.json
+++ b/config/feeds_config_v2.json
@@ -41106,7 +41106,7 @@
           "base": "YUSD",
           "quote": "USDC"
         },
-        "decimals": 0,
+        "decimals": 6,
         "category": "",
         "market_hours": "Crypto",
         "arguments": {

--- a/nix/test-environments/example-setup-03.nix
+++ b/nix/test-environments/example-setup-03.nix
@@ -79,21 +79,22 @@ in
             50001 # USDC / USD Pegged
 
             # exsat-holdings oracle feeds
-            100000 # ExSat BTC
+            # Very slow oracle, not suitable for fast setup
+            # 100000 # ExSat BTC
 
             # eth-rpc oracle feeds
-            100001 # ynETH MAX (ynETHx) - YieldNest convertToAssets on ETH
             100002 # YieldFi yUSD (yUSD) exchangeRate on ETH mainnet
             100003 # ynBNB MAX (ynBNBx) - YieldNest convertToAssets on BNB
 
             # gecko-terminal oracle feeds
             1000000 # WMON / USD
-            1000001 # USDZ / USD
             1000003 # CHOG / USD
+            1000008 # cbBTC/ USD
 
             # stock-price-feeds oracle feeds
-            2000000 # IBIT / USD
-            2000001 # SPY / USD
+            # At this point we don't have API keys in the e2e test set
+            # 2000000 # IBIT / USD
+            # 2000001 # SPY / USD
           ];
           publishing-criteria = [
             {
@@ -171,16 +172,6 @@ in
               peg-tolerance-percentage = 0.1;
             }
             {
-              feed-id = 100000; # ExSat BTC
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
-              feed-id = 100001; # ynETH MAX (ynETHx) - YieldNest convertToAssets on ETH
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
               feed-id = 100002; # YieldFi yUSD (yUSD) exchangeRate on ETH mainnet
               skip-publish-if-less-then-percentage = 0.001;
               always-publish-heartbeat-ms = 20000;
@@ -196,22 +187,12 @@ in
               always-publish-heartbeat-ms = 20000;
             }
             {
-              feed-id = 1000001; # USDZ / USD
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
               feed-id = 1000003; # CHOG / USD
               skip-publish-if-less-then-percentage = 0.001;
               always-publish-heartbeat-ms = 20000;
             }
             {
-              feed-id = 2000000; # IBIT / USD
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
-              feed-id = 2000001; # SPY / USD
+              feed-id = 1000008; # cbBTC / USD
               skip-publish-if-less-then-percentage = 0.001;
               always-publish-heartbeat-ms = 20000;
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2565,6 +2565,7 @@ __metadata:
   resolution: "@blocksense/e2e-tests@workspace:apps/e2e-tests"
   dependencies:
     "@blocksense/base-utils": "workspace:*"
+    "@blocksense/config-types": "workspace:*"
     "@blocksense/contracts": "workspace:*"
     "@types/node": "npm:^22.3.0"
     "@vitest/coverage-v8": "npm:^3.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2568,7 +2568,7 @@ __metadata:
     "@blocksense/contracts": "workspace:*"
     "@types/node": "npm:^22.3.0"
     "@vitest/coverage-v8": "npm:^3.2.4"
-    effect: "npm:^3.7.0"
+    effect: "npm:^3.15.1"
     execa: "npm:^9.5.2"
     tsx: "npm:^4.17.0"
     typescript: "npm:^5.5.4"
@@ -18278,16 +18278,6 @@ __metadata:
     "@standard-schema/spec": "npm:^1.0.0"
     fast-check: "npm:^3.23.1"
   checksum: 10c0/45947604b1e070fadea0bdb68f710b737a44c1ee0e39ad900ce9f65c5265ca79d3018a76c9475dce5d70425430990416772416b92cb167f2a1aff854aa4c75a4
-  languageName: node
-  linkType: hard
-
-"effect@npm:^3.7.0":
-  version: 3.14.8
-  resolution: "effect@npm:3.14.8"
-  dependencies:
-    "@standard-schema/spec": "npm:^1.0.0"
-    fast-check: "npm:^3.23.1"
-  checksum: 10c0/00583e632a1b432af0d80825d591714e3ed4f6a76c0d8abbc2dfc88d6e9fb5ee7e0c9ef4fa9dd1d139ebbfa9ce54ed5eabe1c302f7bf4a310a771f286f9b18c6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2565,6 +2565,7 @@ __metadata:
   resolution: "@blocksense/e2e-tests@workspace:apps/e2e-tests"
   dependencies:
     "@blocksense/base-utils": "workspace:*"
+    "@blocksense/contracts": "workspace:*"
     "@types/node": "npm:^22.3.0"
     "@vitest/coverage-v8": "npm:^3.2.4"
     effect: "npm:^3.7.0"


### PR DESCRIPTION
### **Description**

This PR introduces end-to-end tests for validating the sequencer configuration and ensuring feed prices are actively updated. Key changes include:

* ✅ **Added** test to fetch and validate sequencer config.
* ✅ **Introduced** new test to assert price updates across allowed feeds.
* ✅ **Created** `getPricesInfo` utility for streamlined onchain price retrieval.
* 🔧 **Refactored** test environment (`example-setup-03`) to remove feeds not suitable for fast e2e tests (e.g., slow or unsupported due to missing API keys).
* 🛠️ **Fixed** incorrect decimals for feed `100002 - YUSD / USDC`.
* ⬆️ **Upgraded** `effect` from `3.7.0` to `3.15.1` in `e2e-tests`.
* 📦 **Installed** `@blocksense/contracts` dependency to support onchain queries in tests.

[BSN-3279: Use Viem wrappers to read data from RPCs where the sequencer is pushing data](https://coda.io/d/_d6vM0kjfQP6#_tuk5j/r3279&view=full)
