### PR TITLE
feat(base-utils): Add `mapValues`, `mapEntries`, `filterEntries`, and `mapValuePromises` and enable test coverage

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -65,6 +65,8 @@ build-ts package="all":
     yarn build-single @blocksense/contracts
     yarn build-single @blocksense/data-feeds-config-generator
     yarn build-single @blocksense/changelog-generator
+    yarn build-single @blocksense/chain-interactions
+    yarn build-single @blocksense/avm-relayer
   else
     yarn build:recursive {{package}}
   fi
@@ -75,6 +77,9 @@ test-ts:
   yarn test-single @blocksense/base-utils
   yarn test-single @blocksense/config-types
   yarn test-single @blocksense/data-feeds-config-generator
+  yarn test-single @blocksense/changelog-generator
+  yarn test-single @blocksense/chain-interactions
+  yarn test-single @blocksense/avm-relayer
 
 test-e2e:
   yarn workspace @blocksense/e2e-tests run test

--- a/apps/avm-relayer/package.json
+++ b/apps/avm-relayer/package.json
@@ -11,11 +11,10 @@
     "build:ts": "tsup",
     "lint": "yarn run -T eslint \"**/{src,test,examples,scripts,dtslint}/**/*.{ts,mjs}\"",
     "lint-fix": "yarn lint --fix",
-    "test": "vitest run",
-    "coverage": "vitest run --coverage",
+    "test": "vitest run --typecheck --coverage",
     "copy-package-json": "tsx scripts/copy-package-json.ts",
     "changeset-version": "changeset version && node scripts/version.mjs",
-    "changeset-publish": "yarn build && TEST_DIST= yarn vitest && changeset publish"
+    "changeset-publish": "yarn build && TEST_DIST= yarn test && changeset publish"
   },
   "dependencies": {
     "@aztec/accounts": "0.87.9",

--- a/apps/avm-relayer/package.json
+++ b/apps/avm-relayer/package.json
@@ -39,7 +39,7 @@
     "@effect/language-service": "^0.20.1",
     "@effect/vitest": "0.23.5",
     "@types/node": "^24.0.4",
-    "@vitest/coverage-v8": "^3.2.3",
+    "@vitest/coverage-v8": "^3.2.4",
     "ts-node": "^10.9.2",
     "tsup": "^8.5.0",
     "tsx": "^4.19.1",

--- a/apps/avm-relayer/test/relayer.test.ts
+++ b/apps/avm-relayer/test/relayer.test.ts
@@ -1,18 +1,31 @@
-import { beforeAll, describe, expect, test } from '@effect/vitest';
-import type { AccountWallet, PXE } from '@aztec/aztec.js';
+import { beforeAll, describe, expect, test, assert } from '@effect/vitest';
+import * as S from 'effect/Schema';
+import {
+  createPXEClient,
+  waitForPXE,
+  type AccountWallet,
+  type PXE,
+} from '@aztec/aztec.js';
 import { getInitialTestAccountsWallets } from '@aztec/accounts/testing';
-import { setupSandbox } from '../src/utils';
 
-let pxe: PXE;
-let _wallets: Array<AccountWallet> = [];
+const pxeUrl = S.is(S.URL)(process.env['PXE_URL'])
+  ? process.env['PXE_URL']
+  : null;
 
-beforeAll(async () => {
-  pxe = await setupSandbox();
+describe.skipIf(!pxeUrl)('AVM Relayer', () => {
+  let pxe: PXE;
+  let wallets: Array<AccountWallet> = [];
 
-  _wallets = await getInitialTestAccountsWallets(pxe);
-});
+  beforeAll(async () => {
+    assert(pxeUrl, 'PXE_URL must be set for AVM Relayer tests');
+    pxe = createPXEClient(pxeUrl);
+    await waitForPXE(pxe);
+    wallets = await getInitialTestAccountsWallets(pxe);
+    console.log(
+      `Available wallets: ${wallets.map(w => w.getAddress()).join('\n')}`,
+    );
+  });
 
-describe('AVM Relayer', () => {
   test('should pass', () => {
     expect(true).toBe(true);
   });

--- a/apps/chain-interactions/package.json
+++ b/apps/chain-interactions/package.json
@@ -11,11 +11,10 @@
     "build:ts": "tsup",
     "lint": "yarn run -T eslint \"**/{src,test,examples,scripts,dtslint}/**/*.{ts,mjs}\"",
     "lint-fix": "yarn lint --fix",
-    "test": "vitest run",
-    "coverage": "vitest run --coverage",
+    "test": "vitest run --typecheck --coverage",
     "copy-package-json": "tsx scripts/copy-package-json.ts",
     "changeset-version": "changeset version && node scripts/version.mjs",
-    "changeset-publish": "yarn build && TEST_DIST= yarn vitest && changeset publish"
+    "changeset-publish": "yarn build && TEST_DIST= yarn test && changeset publish"
   },
   "dependencies": {
     "@effect/cli": "0.63.9",

--- a/apps/chain-interactions/package.json
+++ b/apps/chain-interactions/package.json
@@ -36,7 +36,7 @@
     "@effect/language-service": "^0.20.1",
     "@effect/vitest": "0.23.5",
     "@types/node": "^22.5.2",
-    "@vitest/coverage-v8": "^3.2.3",
+    "@vitest/coverage-v8": "^3.2.4",
     "tsup": "^8.5.0",
     "tsx": "^4.19.1",
     "typescript": "5.8.3",

--- a/apps/changelog-generator/package.json
+++ b/apps/changelog-generator/package.json
@@ -11,11 +11,10 @@
     "build:ts": "tsup",
     "lint": "yarn run -T eslint \"**/{src,test,examples,scripts,dtslint}/**/*.{ts,mjs}\"",
     "lint-fix": "yarn lint --fix",
-    "test": "vitest run",
-    "coverage": "vitest run --coverage",
+    "test": "vitest run --typecheck --coverage",
     "copy-package-json": "tsx scripts/copy-package-json.ts",
     "changeset-version": "changeset version && node scripts/version.mjs",
-    "changeset-publish": "yarn build && TEST_DIST= yarn vitest && changeset publish"
+    "changeset-publish": "yarn build && TEST_DIST= yarn test && changeset publish"
   },
   "dependencies": {
     "@blocksense/base-utils": "workspace:^",

--- a/apps/changelog-generator/package.json
+++ b/apps/changelog-generator/package.json
@@ -38,7 +38,7 @@
     "@effect/language-service": "^0.20.1",
     "@effect/vitest": "0.23.5",
     "@types/node": "^22.5.2",
-    "@vitest/coverage-v8": "^3.2.3",
+    "@vitest/coverage-v8": "^3.2.4",
     "tsup": "^8.5.0",
     "tsx": "^4.19.1",
     "typescript": "5.8.3",

--- a/apps/data-feeds-config-generator/package.json
+++ b/apps/data-feeds-config-generator/package.json
@@ -25,7 +25,7 @@
     "get-providers-data": "yarn ts scripts/get-providers-data.ts",
     "fetch-symbols": "yarn ts src/data-services/fetchers/scripts/fetch-symbols.ts",
     "update-exchanges-argument-config": "yarn ts scripts/update-exchanges-argument-config.ts",
-    "test": "yarn vitest --typecheck -w false"
+    "test": "vitest run --typecheck --coverage"
   },
   "devDependencies": {
     "@blocksense/base-utils": "workspace:*",

--- a/apps/data-feeds-config-generator/package.json
+++ b/apps/data-feeds-config-generator/package.json
@@ -33,6 +33,7 @@
     "@octokit/rest": "^21.1.1",
     "@types/keccak": "^3",
     "@types/node": "^22.10.2",
+    "@vitest/coverage-v8": "^3.2.4",
     "effect": "^3.15.1",
     "glob": "^11.0.0",
     "keccak": "^3.0.4",

--- a/apps/docs.blocksense.network/package.json
+++ b/apps/docs.blocksense.network/package.json
@@ -11,7 +11,7 @@
     "dev-watch": "yarn watch:docs-theme & next",
     "ready-dev-go": "yarn build:with-deps && yarn dev",
     "start": "next start",
-    "test": "yarn vitest -w false",
+    "test": "vitest run --typecheck --coverage",
     "ts": "yarn node --import tsx",
     "watch:docs-theme": "nodemon -w ../../libs/docs-theme -e js,jsx,ts,tsx,css --exec 'yarn workspace @blocksense/docs-theme build'"
   },

--- a/apps/e2e-tests/package.json
+++ b/apps/e2e-tests/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "scripts": {
     "ts": "yarn node --import tsx",
-    "test": "yarn vitest -w false",
+    "test": "vitest run --typecheck --coverage",
     "test:process-compose-e2e": "yarn test src/process-compose/e2e.spec.ts"
   },
   "dependencies": {

--- a/apps/e2e-tests/package.json
+++ b/apps/e2e-tests/package.json
@@ -15,5 +15,8 @@
     "tsx": "^4.17.0",
     "typescript": "^5.5.4",
     "vitest": "^3.2.4"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^3.2.4"
   }
 }

--- a/libs/ts/base-utils/package.json
+++ b/libs/ts/base-utils/package.json
@@ -100,6 +100,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
+    "@vitest/coverage-v8": "3.1.3",
     "glob": "^11.0.0",
     "tsx": "^4.19.2",
     "typescript": "5.8.3",

--- a/libs/ts/base-utils/package.json
+++ b/libs/ts/base-utils/package.json
@@ -96,7 +96,7 @@
   "scripts": {
     "build": "yarn run rollup:build-workspace",
     "ts": "yarn node --import tsx",
-    "test": "yarn vitest --typecheck -w false"
+    "test": "vitest run --typecheck --coverage"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/libs/ts/base-utils/src/array-iter.spec-d.ts
+++ b/libs/ts/base-utils/src/array-iter.spec-d.ts
@@ -1,8 +1,24 @@
-import { describe, expectTypeOf, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import { tuple } from './array-iter';
+import { filterEntries, tuple } from './array-iter';
 
 describe('`base-utils/array-iter` type level tests', () => {
+  describe('filterEntries', () => {
+    it('should filter entries based on key and value predicates', () => {
+      const obj = { a: 1, b: '2', c: 3, d: '4' };
+      const result = filterEntries(
+        obj,
+        key => key === 'a' || key === 'c',
+        value => typeof value === 'number',
+      );
+      expectTypeOf(result).toEqualTypeOf<{
+        a: number;
+        c: number;
+      }>();
+      expect(result).toEqual({ a: 1, c: 3 });
+    });
+  });
+
   describe('`tuple`', () => {
     it('should preserve literal types', () => {
       const x = tuple('a', 'b', 'c');

--- a/libs/ts/base-utils/src/array-iter.spec.ts
+++ b/libs/ts/base-utils/src/array-iter.spec.ts
@@ -2,8 +2,12 @@ import { describe, expect, test } from 'vitest';
 import {
   arrayToObject,
   entriesOf,
+  filterEntries,
   fromEntries,
   keysOf,
+  mapEntries,
+  mapValuePromises,
+  mapValues,
   tuple,
   valuesOf,
 } from './array-iter';
@@ -105,6 +109,66 @@ describe('`base-utils/array-iter` tests', () => {
 
     test('should return an empty object for an empty array', () => {
       expect(fromEntries([])).toEqual({});
+    });
+  });
+
+  describe('mapValues', () => {
+    test('should create a new object with transformed values', () => {
+      const obj = { a: 1, b: 2 };
+      const result = mapValues(obj, (key, value) => `${key}-${value * 2}`);
+      expect(result).toEqual({ a: 'a-2', b: 'b-4' });
+    });
+
+    test('should return an empty object for an empty object', () => {
+      expect(mapValues({}, () => 'whatever')).toEqual({});
+    });
+  });
+
+  describe('mapEntries', () => {
+    test('should create a new object with transformed keys and values', () => {
+      const obj = { a: 1, b: 2 };
+      const result = mapEntries(obj, (key, value) => [`key_${key}`, value * 2]);
+      expect(result).toEqual({ key_a: 2, key_b: 4 });
+    });
+
+    test('should return an empty object for an empty object', () => {
+      expect(mapEntries({}, () => ['a', 1])).toEqual({});
+    });
+  });
+
+  describe('filterEntries', () => {
+    test('should filter entries of an object based on a predicate', () => {
+      const obj = { a: 1, b: '2', c: 3, d: '4' };
+      const result = filterEntries(
+        obj,
+        key => key === 'a' || key === 'c',
+        value => typeof value === 'number',
+      );
+      expect(result).toEqual({ a: 1, c: 3 });
+    });
+
+    test('should return an empty object if no entries match', () => {
+      const obj = { a: '1', b: '2' };
+      const result = filterEntries(
+        obj,
+        (pair): pair is [string, number] => typeof pair[1] === 'number',
+      );
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('mapValuePromises', () => {
+    test('should map values to promises and resolve to a new object', async () => {
+      const obj = { a: 1, b: 2 };
+      const result = await mapValuePromises(obj, async (key, value) => {
+        return Promise.resolve(`${key}-${value * 2}`);
+      });
+      expect(result).toEqual({ a: 'a-2', b: 'b-4' });
+    });
+
+    test('should handle empty object', async () => {
+      const result = await mapValuePromises({}, async () => Promise.resolve(1));
+      expect(result).toEqual({});
     });
   });
 

--- a/libs/ts/base-utils/src/array-iter.spec.ts
+++ b/libs/ts/base-utils/src/array-iter.spec.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from 'vitest';
-import { arrayToObject } from './array-iter';
+import {
+  arrayToObject,
+  entriesOf,
+  fromEntries,
+  keysOf,
+  tuple,
+  valuesOf,
+} from './array-iter';
 
 describe('`base-utils/array-iter` tests', () => {
   describe('arrayToObject', () => {
@@ -48,6 +55,63 @@ describe('`base-utils/array-iter` tests', () => {
         x: { data: { foo: 'bar' } },
         y: { data: { foo: 'baz' } },
       });
+    });
+  });
+
+  describe('keysOf', () => {
+    test('should return an array of a given object keys', () => {
+      const obj = { a: 1, b: '2', c: true };
+      expect(keysOf(obj)).toEqual(['a', 'b', 'c']);
+    });
+
+    test('should return an empty array for an empty object', () => {
+      expect(keysOf({})).toEqual([]);
+    });
+  });
+
+  describe('valuesOf', () => {
+    test('should return an array of a given object values', () => {
+      const obj = { a: 1, b: '2', c: true };
+      expect(valuesOf(obj)).toEqual([1, '2', true]);
+    });
+
+    test('should return an empty array for an empty object', () => {
+      expect(valuesOf({})).toEqual([]);
+    });
+  });
+
+  describe('entriesOf', () => {
+    test('should return an array of a given object entries', () => {
+      const obj = { a: 1, b: '2' };
+      expect(entriesOf(obj)).toEqual([
+        ['a', 1],
+        ['b', '2'],
+      ]);
+    });
+
+    test('should return an empty array for an empty object', () => {
+      expect(entriesOf({})).toEqual([]);
+    });
+  });
+
+  describe('fromEntries', () => {
+    test('should transform a list of key-value pairs into an object', () => {
+      const entries: [string, number][] = [
+        ['a', 1],
+        ['b', 2],
+      ];
+      expect(fromEntries(entries)).toEqual({ a: 1, b: 2 });
+    });
+
+    test('should return an empty object for an empty array', () => {
+      expect(fromEntries([])).toEqual({});
+    });
+  });
+
+  describe('tuple', () => {
+    test('should create a tuple from arguments', () => {
+      expect(tuple('a')).toEqual(['a']);
+      expect(tuple('a', 'b', 1)).toEqual(['a', 'b', 1]);
     });
   });
 });

--- a/libs/ts/base-utils/src/array-iter.ts
+++ b/libs/ts/base-utils/src/array-iter.ts
@@ -1,23 +1,59 @@
 import { Literal, LiteralTuple, NonEmptyTuple } from './type-level';
 
+/**
+ * Returns an array of a given object's own enumerable string-keyed property
+ * names. This is a typed version of `Object.keys`.
+ * @template K - The type of the keys.
+ * @param {Record<K, unknown>} obj - The object to get the keys from.
+ * @returns {K[]} An array of the object's keys.
+ */
 export function keysOf<K extends string>(obj: Record<K, unknown>): K[] {
   return Object.keys(obj) as K[];
 }
 
+/**
+ * Returns an array of a given object's own enumerable string-keyed property
+ * values. This is a typed version of `Object.values`.
+ * @template K - The type of the keys.
+ * @template V - The type of the values.
+ * @param {Record<K, V>} obj - The object to get the values from.
+ * @returns {V[]} An array of the object's values.
+ */
 export function valuesOf<K extends string, V>(obj: Record<K, V>): V[] {
   return Object.values(obj) as V[];
 }
 
+/**
+ * Returns an array of a given object's own enumerable string-keyed property
+ * [key, value] pairs.
+ * This is a typed version of `Object.entries`.
+ * @template K - The type of the keys.
+ * @template V - The type of the values.
+ * @param {Record<K, V>} obj - The object to get the entries from.
+ * @returns {[K, V][]} An array of the object's [key, value] pairs.
+ */
 export function entriesOf<K extends string, V>(obj: Record<K, V>): [K, V][] {
   return Object.entries(obj) as [K, V][];
 }
 
+/**
+ * Transforms a list of key-value pairs into an object.
+ * This is a typed version of `Object.fromEntries`.
+ * @template K - The type of the keys.
+ * @template V - The type of the values.
+ * @param {[K, V][]} entries - An array of key-value pairs.
+ * @returns {Record<K, V>} The new object.
+ */
 export function fromEntries<K extends string, V>(
   entries: [K, V][],
 ): Record<K, V> {
   return Object.fromEntries(entries) as Record<K, V>;
 }
 
+/**
+ * Creates a tuple from a list of arguments, ensuring literal types are
+ * preserved.
+ */
 export function tuple<Args extends NonEmptyTuple<T>, T extends Literal>(
   ...args: Args
 ): Args;
@@ -26,16 +62,20 @@ export function tuple<Args extends LiteralTuple>(...args: Args): Args {
 }
 
 /**
- * Converts an array of objects into a record, using a specified field as the key.
+ * Converts an array of objects into a record, using a specified field as the
+ * key.
  *
  * @template T - The shape of each object in the input array.
  * @template K - The key of each object to use as the record key.
- * @template R - The shape of the resulting values in the record (defaults to T without the key field).
+ * @template R - The shape of the resulting values in the record (defaults to T
+ * without the key field).
  *
  * @param {T[]} arr - The input array of objects.
- * @param {K} keyField - The key within each object to use as the output record's key.
+ * @param {K} keyField - The key within each object to use as the output
+ * record's key.
  *
- * @returns {Record<string, R>} A record object with keys from `keyField` and values as the rest of the object.
+ * @returns {Record<string, R>} A record object with keys from `keyField` and
+ * values as the rest of the object.
  *
  * @example
  * const input = [

--- a/libs/ts/config-types/package.json
+++ b/libs/ts/config-types/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "build": "yarn run rollup:build-workspace",
     "ts": "yarn node --import tsx",
-    "test": "yarn vitest -w false --passWithNoTests"
+    "test": "vitest run --typecheck --coverage"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/libs/ts/config-types/package.json
+++ b/libs/ts/config-types/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
+    "@vitest/coverage-v8": "^3.2.4",
     "glob": "^11.0.0",
     "tsx": "^4.19.2",
     "typescript": "5.8.3",

--- a/libs/ts/contracts/package.json
+++ b/libs/ts/contracts/package.json
@@ -29,9 +29,9 @@
   },
   "scripts": {
     "clean": "git clean -fdx -e .env",
-    "build": "hardhat compile && yarn build:typecheck",
+    "build": "yarn build:hardhat && yarn build:lib",
+    "build:hardhat": "hardhat compile && yarn build:typecheck",
     "build:lib": "TS_CONFIG_NAME=tsconfig.lib.json yarn run rollup:build-workspace",
-    "build:all": "yarn build && yarn build:lib",
     "sol-reflect": "hardhat reflect",
     "test": "hardhat test",
     "test:fork": "FORKING=true hardhat test --grep '@fork'",

--- a/libs/ts/onchain-interactions/package.json
+++ b/libs/ts/onchain-interactions/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@types/express": "^5",
     "@types/yargs": "^17.0.33",
+    "@vitest/coverage-v8": "^3.2.4",
     "tsx": "^4.19.2"
   }
 }

--- a/libs/ts/ui/package.json
+++ b/libs/ts/ui/package.json
@@ -25,6 +25,7 @@
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
     "eslint-plugin-storybook": "^9.0.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2292,7 +2292,7 @@ __metadata:
     "@effect/typeclass": "npm:^0.35.5"
     "@effect/vitest": "npm:0.23.5"
     "@types/node": "npm:^24.0.4"
-    "@vitest/coverage-v8": "npm:^3.2.3"
+    "@vitest/coverage-v8": "npm:^3.2.4"
     effect: "npm:^3.15.1"
     ts-node: "npm:^10.9.2"
     tsup: "npm:^8.5.0"
@@ -2326,6 +2326,7 @@ __metadata:
   resolution: "@blocksense/base-utils@workspace:libs/ts/base-utils"
   dependencies:
     "@types/node": "npm:^22.10.2"
+    "@vitest/coverage-v8": "npm:3.1.3"
     effect: "npm:^3.15.1"
     glob: "npm:^11.0.0"
     tslib: "npm:^2.8.1"
@@ -2354,7 +2355,7 @@ __metadata:
     "@effect/typeclass": "npm:^0.35.5"
     "@effect/vitest": "npm:0.23.5"
     "@types/node": "npm:^22.5.2"
-    "@vitest/coverage-v8": "npm:^3.2.3"
+    "@vitest/coverage-v8": "npm:^3.2.4"
     effect: "npm:^3.15.1"
     tsup: "npm:^8.5.0"
     tsx: "npm:^4.19.1"
@@ -2386,7 +2387,7 @@ __metadata:
     "@effect/typeclass": "npm:^0.35.5"
     "@effect/vitest": "npm:0.23.5"
     "@types/node": "npm:^22.5.2"
-    "@vitest/coverage-v8": "npm:^3.2.3"
+    "@vitest/coverage-v8": "npm:^3.2.4"
     effect: "npm:^3.15.1"
     tsup: "npm:^8.5.0"
     tsx: "npm:^4.19.1"
@@ -2405,6 +2406,7 @@ __metadata:
     "@octokit/request-error": "npm:^7.0.0"
     "@octokit/rest": "npm:21.1.1"
     "@types/node": "npm:^22.10.2"
+    "@vitest/coverage-v8": "npm:^3.2.4"
     effect: "npm:^3.15.1"
     glob: "npm:^11.0.0"
     tslib: "npm:^2.8.1"
@@ -2470,6 +2472,7 @@ __metadata:
     "@octokit/rest": "npm:^21.1.1"
     "@types/keccak": "npm:^3"
     "@types/node": "npm:^22.10.2"
+    "@vitest/coverage-v8": "npm:^3.2.4"
     effect: "npm:^3.15.1"
     glob: "npm:^11.0.0"
     keccak: "npm:^3.0.4"
@@ -2563,6 +2566,7 @@ __metadata:
   dependencies:
     "@blocksense/base-utils": "workspace:*"
     "@types/node": "npm:^22.3.0"
+    "@vitest/coverage-v8": "npm:^3.2.4"
     effect: "npm:^3.7.0"
     execa: "npm:^9.5.2"
     tsx: "npm:^4.17.0"
@@ -2681,6 +2685,7 @@ __metadata:
     "@types/express": "npm:^5"
     "@types/node": "npm:^22.10.1"
     "@types/yargs": "npm:^17.0.33"
+    "@vitest/coverage-v8": "npm:^3.2.4"
     axios: "npm:^1.7.9"
     chalk: "npm:^5.3.0"
     chalk-template: "npm:^1.1.0"
@@ -2766,6 +2771,7 @@ __metadata:
     "@types/node": "npm:^24"
     "@types/react": "npm:^19"
     "@types/react-dom": "npm:^19"
+    "@vitest/coverage-v8": "npm:^3.2.4"
     eslint: "npm:^9"
     eslint-config-next: "npm:15.3.4"
     eslint-plugin-storybook: "npm:^9.0.14"
@@ -13411,9 +13417,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/coverage-v8@npm:^3.2.3":
-  version: 3.2.3
-  resolution: "@vitest/coverage-v8@npm:3.2.3"
+"@vitest/coverage-v8@npm:3.1.3":
+  version: 3.1.3
+  resolution: "@vitest/coverage-v8@npm:3.1.3"
+  dependencies:
+    "@ampproject/remapping": "npm:^2.3.0"
+    "@bcoe/v8-coverage": "npm:^1.0.2"
+    debug: "npm:^4.4.0"
+    istanbul-lib-coverage: "npm:^3.2.2"
+    istanbul-lib-report: "npm:^3.0.1"
+    istanbul-lib-source-maps: "npm:^5.0.6"
+    istanbul-reports: "npm:^3.1.7"
+    magic-string: "npm:^0.30.17"
+    magicast: "npm:^0.3.5"
+    std-env: "npm:^3.9.0"
+    test-exclude: "npm:^7.0.1"
+    tinyrainbow: "npm:^2.0.0"
+  peerDependencies:
+    "@vitest/browser": 3.1.3
+    vitest: 3.1.3
+  peerDependenciesMeta:
+    "@vitest/browser":
+      optional: true
+  checksum: 10c0/82b5c33ae258832d98d42f24402708bc89dcf7e7c21a9e869dca3860040f57dbefc1bcdea0648e1683e6d07a03fe953c17b99981905be7b95a67bceffea52e68
+  languageName: node
+  linkType: hard
+
+"@vitest/coverage-v8@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/coverage-v8@npm:3.2.4"
   dependencies:
     "@ampproject/remapping": "npm:^2.3.0"
     "@bcoe/v8-coverage": "npm:^1.0.2"
@@ -13429,12 +13461,12 @@ __metadata:
     test-exclude: "npm:^7.0.1"
     tinyrainbow: "npm:^2.0.0"
   peerDependencies:
-    "@vitest/browser": 3.2.3
-    vitest: 3.2.3
+    "@vitest/browser": 3.2.4
+    vitest: 3.2.4
   peerDependenciesMeta:
     "@vitest/browser":
       optional: true
-  checksum: 10c0/b0b3c90bab5cda8cbb7568aae9dec3a6440c40b9cdd03475f0ad5aa6089b4ce3dc25ac4cd1ca6d973a21aab1d8676005e2feb82a2d71ca8fb6d1c742dd031589
+  checksum: 10c0/cae3e58d81d56e7e1cdecd7b5baab7edd0ad9dee8dec9353c52796e390e452377d3f04174d40b6986b17c73241a5e773e422931eaa8102dcba0605ff24b25193
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR introduces several improvements to the `base-utils` package and enhances the testing infrastructure by enabling code coverage reporting and improving CI stability.

---
## ✨ `base-utils` Enhancements

The `@blocksense/base-utils` package has been updated with new object manipulation utilities, better documentation, and increased test coverage.

* **New Utility Functions**:
    * `mapValues`: Creates a new object by transforming the values of the original.
    * `mapEntries`: Creates a new object by transforming both keys and values.
    * `filterEntries`: Provides type-safe filtering of an object's entries based on key and value predicates.
    * `mapValuePromises`: Asynchronously maps object values to promises and resolves them into a new object.
* **Improved Test Coverage**: Added comprehensive tests for existing utilities (`keysOf`, `valuesOf`, `entriesOf`, `fromEntries`, `tuple`, etc.) to ensure reliability.
* **Enhanced Documentation**: Added JSDoc comments to all functions in `array-iter.ts` for improved developer experience and IDE support.

---
## 🛠️ Build & Testing Improvements

This PR focuses on improving code quality and CI robustness.

* **Code Coverage Enabled**: All `vitest`-based `test` scripts now automatically generate a code coverage report via the `--coverage` flag. The `@vitest/coverage-v8` dependency has been added to all relevant workspaces to support this.
* **CI Stability**: The `avm-relayer` tests are now conditionally skipped if the `PXE_URL` environment variable is not defined. This fixes a build issue and prevents CI failures when the Aztec Sandbox environment is not available.