### PR TITLE
[nix/process-compose/e2e-tests]: Make FEEDS_CONFIG_DIR configurable via environment variable

### DIFF
--- a/apps/e2e-tests/src/process-compose/config/feeds_config_v2.json
+++ b/apps/e2e-tests/src/process-compose/config/feeds_config_v2.json
@@ -1,0 +1,1349 @@
+{
+  "feeds": [
+    {
+      "id": "0",
+      "full_name": "BTC / USD",
+      "description": "Price of Bitcoin in USD",
+      "type": "price-feed",
+      "oracle_id": "cex-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 10000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "BTC",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": ["BTCUSDC", "BTCUSDT"]
+            },
+            "BinanceUS": {
+              "symbol": ["BTCUSD", "BTCUSDC", "BTCUSDT"]
+            },
+            "Bitfinex": {
+              "symbol": ["tBTCUSD"]
+            },
+            "Bitget": {
+              "symbol": ["BTCUSDC", "BTCUSDT"]
+            },
+            "Bybit": {
+              "symbol": ["BTCUSDC", "BTCUSDT"]
+            },
+            "Coinbase": {
+              "id": ["BTC-USD", "BTC-USDT"]
+            },
+            "CryptoCom": {
+              "symbol": ["BTC_USD", "BTC_USDT"]
+            },
+            "GateIo": {
+              "id": ["BTC_USDC", "BTC_USDT"]
+            },
+            "Gemini": {
+              "symbol": ["BTCUSD", "BTCUSDT"]
+            },
+            "KuCoin": {
+              "symbol": ["BTC-USDC", "BTC-USDT"]
+            },
+            "MEXC": {
+              "symbol": ["BTCUSDC", "BTCUSDT"]
+            },
+            "OKX": {
+              "instId": ["BTC-USD", "BTC-USDC", "BTC-USDT"]
+            },
+            "Upbit": {
+              "market": ["USDT-BTC"]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": ["BTC", "BTC", "BTC", "BTC", "BTC"],
+              "id": [1, 31469, 31652, 32295, 34316]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "BTC / USD"
+        }
+      }
+    },
+    {
+      "id": "3",
+      "full_name": "ETH / USD",
+      "description": "Price of Ethereum in USD",
+      "type": "price-feed",
+      "oracle_id": "cex-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 10000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ETH",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": ["ETHUSDC", "ETHUSDT"]
+            },
+            "BinanceUS": {
+              "symbol": ["ETHUSD", "ETHUSDC", "ETHUSDT"]
+            },
+            "Bitfinex": {
+              "symbol": ["tETHUSD"]
+            },
+            "Bitget": {
+              "symbol": ["ETHUSDC", "ETHUSDT"]
+            },
+            "Bybit": {
+              "symbol": ["ETHUSDC", "ETHUSDT"]
+            },
+            "Coinbase": {
+              "id": ["ETH-USD", "ETH-USDT"]
+            },
+            "CryptoCom": {
+              "symbol": ["ETH_USD", "ETH_USDT"]
+            },
+            "GateIo": {
+              "id": ["ETH_USDC", "ETH_USDT"]
+            },
+            "Gemini": {
+              "symbol": ["ETHUSD", "ETHUSDT"]
+            },
+            "Kraken": {
+              "pair": ["ETHUSDC", "ETHUSDT", "XETHZUSD"],
+              "wsname": ["ETH/USD", "ETH/USDC", "ETH/USDT"]
+            },
+            "KuCoin": {
+              "symbol": ["ETH-USDC", "ETH-USDT"]
+            },
+            "MEXC": {
+              "symbol": ["ETHUSDC", "ETHUSDT"]
+            },
+            "OKX": {
+              "instId": ["ETH-USD", "ETH-USDC", "ETH-USDT"]
+            },
+            "Upbit": {
+              "market": ["USDT-ETH"]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": ["ETH", "ETH", "ETH"],
+              "id": [1027, 29991, 33661]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "ETH / USD"
+        }
+      }
+    },
+    {
+      "id": "7",
+      "full_name": "USDT / USD",
+      "description": "Price of Tether USD in USD",
+      "type": "price-feed",
+      "oracle_id": "cex-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 10000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "USDT",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "BinanceUS": {
+              "symbol": ["USDTUSD"]
+            },
+            "Coinbase": {
+              "id": ["USDT-USD", "USDT-USDC"]
+            },
+            "CryptoCom": {
+              "symbol": ["USDT_USD"]
+            },
+            "GateIo": {
+              "id": ["USDT_USD"]
+            },
+            "Gemini": {
+              "symbol": ["USDTUSD"]
+            },
+            "Kraken": {
+              "pair": ["USDTZUSD"],
+              "wsname": ["USDT/USD"]
+            },
+            "KuCoin": {
+              "symbol": ["USDT-USDC"]
+            },
+            "OKX": {
+              "instId": ["USDT-USD"]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": ["USDT"],
+              "id": [825]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "USDT / USD"
+        }
+      }
+    },
+    {
+      "id": "13",
+      "full_name": "BNB / USD",
+      "description": "Price of BNB in USD",
+      "type": "price-feed",
+      "oracle_id": "cex-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 10000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "BNB",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": ["BNBUSDC", "BNBUSDT"]
+            },
+            "BinanceUS": {
+              "symbol": ["BNBUSD", "BNBUSDT"]
+            },
+            "Bitget": {
+              "symbol": ["BNBUSDC", "BNBUSDT"]
+            },
+            "Bybit": {
+              "symbol": ["BNBUSDC", "BNBUSDT"]
+            },
+            "GateIo": {
+              "id": ["BNB_USDC", "BNB_USDT"]
+            },
+            "Kraken": {
+              "pair": ["BNBUSD", "BNBUSDC", "BNBUSDT"],
+              "wsname": ["BNB/USD", "BNB/USDC", "BNB/USDT"]
+            },
+            "KuCoin": {
+              "symbol": ["BNB-USDC", "BNB-USDT"]
+            },
+            "MEXC": {
+              "symbol": ["BNBUSDC", "BNBUSDT"]
+            },
+            "OKX": {
+              "instId": ["BNB-USD", "BNB-USDT"]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": ["BNB"],
+              "id": [1839]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "BNB / USD"
+        }
+      }
+    },
+    {
+      "id": "16",
+      "full_name": "SOL / USD",
+      "description": "Price of Solana in USD",
+      "type": "price-feed",
+      "oracle_id": "cex-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 10000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "SOL",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": ["SOLUSDC", "SOLUSDT"]
+            },
+            "BinanceUS": {
+              "symbol": ["SOLUSD", "SOLUSDC", "SOLUSDT"]
+            },
+            "Bitfinex": {
+              "symbol": ["tSOLUSD"]
+            },
+            "Bitget": {
+              "symbol": ["SOLUSDC", "SOLUSDT"]
+            },
+            "Bybit": {
+              "symbol": ["SOLUSDC", "SOLUSDT"]
+            },
+            "Coinbase": {
+              "id": ["SOL-USD", "SOL-USDT"]
+            },
+            "CryptoCom": {
+              "symbol": ["SOL_USD", "SOL_USDT"]
+            },
+            "GateIo": {
+              "id": ["SOL_USDC", "SOL_USDT"]
+            },
+            "Gemini": {
+              "symbol": ["SOLUSD"]
+            },
+            "Kraken": {
+              "pair": ["SOLUSD", "SOLUSDC", "SOLUSDT"],
+              "wsname": ["SOL/USD", "SOL/USDC", "SOL/USDT"]
+            },
+            "KuCoin": {
+              "symbol": ["SOL-USDC", "SOL-USDT"]
+            },
+            "MEXC": {
+              "symbol": ["SOLUSDC", "SOLUSDT"]
+            },
+            "OKX": {
+              "instId": ["SOL-USD", "SOL-USDC", "SOL-USDT"]
+            },
+            "Upbit": {
+              "market": ["USDT-SOL"]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": ["SOL", "SOL", "SOL"],
+              "id": [16116, 28825, 5426]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "SOL / USD"
+        }
+      }
+    },
+    {
+      "id": "19",
+      "full_name": "USDC / USD",
+      "description": "Price of Circle USD in USD",
+      "type": "price-feed",
+      "oracle_id": "cex-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 10000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "USDC",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": ["USDCUSDT"]
+            },
+            "BinanceUS": {
+              "symbol": ["USDCUSD", "USDCUSDT"]
+            },
+            "Bitget": {
+              "symbol": ["USDCUSDT"]
+            },
+            "Bybit": {
+              "symbol": ["USDCUSDT"]
+            },
+            "GateIo": {
+              "id": ["USDC_USDT"]
+            },
+            "Gemini": {
+              "symbol": ["USDCUSD"]
+            },
+            "Kraken": {
+              "pair": ["USDCUSD", "USDCUSDT"],
+              "wsname": ["USDC/USD", "USDC/USDT"]
+            },
+            "KuCoin": {
+              "symbol": ["USDC-USDT"]
+            },
+            "MEXC": {
+              "symbol": ["USDCUSDT"]
+            },
+            "OKX": {
+              "instId": ["USDC-USDT"]
+            },
+            "Upbit": {
+              "market": ["USDT-USDC"]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": ["USDC"],
+              "id": [3408]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "USDC / USD"
+        }
+      }
+    },
+    {
+      "id": "32",
+      "full_name": "wBTC / USD",
+      "description": "Price of Wrapped Bitcoin in USD",
+      "type": "price-feed",
+      "oracle_id": "cex-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 10000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "wBTC",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": ["WBTCUSDT"]
+            },
+            "Bitget": {
+              "symbol": ["WBTCUSDT"]
+            },
+            "Bybit": {
+              "symbol": ["WBTCUSDT"]
+            },
+            "CryptoCom": {
+              "symbol": ["WBTC_USD"]
+            },
+            "GateIo": {
+              "id": ["WBTC_USDT"]
+            },
+            "Kraken": {
+              "pair": ["WBTCUSD"],
+              "wsname": ["WBTC/USD"]
+            },
+            "KuCoin": {
+              "symbol": ["WBTC-USDT"]
+            },
+            "MEXC": {
+              "symbol": ["WBTCUSDC", "WBTCUSDT"]
+            },
+            "OKX": {
+              "instId": ["WBTC-USD", "WBTC-USDC", "WBTC-USDT"]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": ["WBTC"],
+              "id": [3717]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "wBTC/USD-RefPrice-mainnet-production"
+        }
+      }
+    },
+    {
+      "id": "35",
+      "full_name": "LINK / USD",
+      "description": "Price of Chainlink in USD",
+      "type": "price-feed",
+      "oracle_id": "cex-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 10000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "LINK",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": ["LINKUSDC", "LINKUSDT"]
+            },
+            "BinanceUS": {
+              "symbol": ["LINKUSD", "LINKUSDT"]
+            },
+            "Bitfinex": {
+              "symbol": ["tLINK:USD"]
+            },
+            "Bitget": {
+              "symbol": ["LINKUSDC", "LINKUSDT"]
+            },
+            "Bybit": {
+              "symbol": ["LINKUSDC", "LINKUSDT"]
+            },
+            "Coinbase": {
+              "id": ["LINK-USD", "LINK-USDT"]
+            },
+            "CryptoCom": {
+              "symbol": ["LINK_USD", "LINK_USDT"]
+            },
+            "GateIo": {
+              "id": ["LINK_USDC", "LINK_USDT"]
+            },
+            "Gemini": {
+              "symbol": ["LINKUSD"]
+            },
+            "Kraken": {
+              "pair": ["LINKUSD", "LINKUSDC", "LINKUSDT"],
+              "wsname": ["LINK/USD", "LINK/USDC", "LINK/USDT"]
+            },
+            "KuCoin": {
+              "symbol": ["LINK-USDC", "LINK-USDT"]
+            },
+            "MEXC": {
+              "symbol": ["LINKUSDC", "LINKUSDT"]
+            },
+            "OKX": {
+              "instId": ["LINK-USD", "LINK-USDC", "LINK-USDT"]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": ["LINK"],
+              "id": [1975]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "LINK / USD"
+        }
+      }
+    },
+    {
+      "id": "91",
+      "full_name": "UNI / USD",
+      "description": "Price of Uniswap in USD",
+      "type": "price-feed",
+      "oracle_id": "cex-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 10000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "UNI",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": ["UNIUSDC", "UNIUSDT"]
+            },
+            "BinanceUS": {
+              "symbol": ["UNIUSD", "UNIUSDT"]
+            },
+            "Bitfinex": {
+              "symbol": ["tUNIUSD"]
+            },
+            "Bitget": {
+              "symbol": ["UNIUSDC", "UNIUSDT"]
+            },
+            "Bybit": {
+              "symbol": ["UNIUSDC", "UNIUSDT"]
+            },
+            "Coinbase": {
+              "id": ["UNI-USD"]
+            },
+            "CryptoCom": {
+              "symbol": ["UNI_USD", "UNI_USDT"]
+            },
+            "GateIo": {
+              "id": ["UNI_USDC", "UNI_USDT"]
+            },
+            "Gemini": {
+              "symbol": ["UNIUSD"]
+            },
+            "Kraken": {
+              "pair": ["UNIUSD"],
+              "wsname": ["UNI/USD"]
+            },
+            "KuCoin": {
+              "symbol": ["UNI-USDT"]
+            },
+            "MEXC": {
+              "symbol": ["UNIUSDC", "UNIUSDT"]
+            },
+            "OKX": {
+              "instId": ["UNI-USD", "UNI-USDC", "UNI-USDT"]
+            },
+            "Upbit": {
+              "market": ["USDT-UNI"]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": ["UNI", "UNI", "UNI"],
+              "id": [33433, 4307, 7083]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "UNI / USD"
+        }
+      }
+    },
+    {
+      "id": "114",
+      "full_name": "AAVE / USD",
+      "description": "Price of Aave in USD",
+      "type": "price-feed",
+      "oracle_id": "cex-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 10000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "AAVE",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": ["AAVEUSDC", "AAVEUSDT"]
+            },
+            "BinanceUS": {
+              "symbol": ["AAVEUSD", "AAVEUSDT"]
+            },
+            "Bitfinex": {
+              "symbol": ["tAAVE:USD"]
+            },
+            "Bitget": {
+              "symbol": ["AAVEUSDC", "AAVEUSDT"]
+            },
+            "Bybit": {
+              "symbol": ["AAVEUSDC", "AAVEUSDT"]
+            },
+            "Coinbase": {
+              "id": ["AAVE-USD"]
+            },
+            "CryptoCom": {
+              "symbol": ["AAVE_USD", "AAVE_USDT"]
+            },
+            "GateIo": {
+              "id": ["AAVE_USDT"]
+            },
+            "Gemini": {
+              "symbol": ["AAVEUSD"]
+            },
+            "Kraken": {
+              "pair": ["AAVEUSD"],
+              "wsname": ["AAVE/USD"]
+            },
+            "KuCoin": {
+              "symbol": ["AAVE-USDT"]
+            },
+            "MEXC": {
+              "symbol": ["AAVEUSDC", "AAVEUSDT"]
+            },
+            "OKX": {
+              "instId": ["AAVE-USD", "AAVE-USDC", "AAVE-USDT"]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": ["AAVE"],
+              "id": [7278]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "AAVE / USD"
+        }
+      }
+    },
+    {
+      "id": "121",
+      "full_name": "TAO / USD",
+      "description": "Price of Bittensor in USD",
+      "type": "price-feed",
+      "oracle_id": "cex-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 10000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "TAO",
+          "quote": "USD"
+        },
+        "decimals": 18,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": ["TAOUSDC", "TAOUSDT"]
+            },
+            "Bitget": {
+              "symbol": ["TAOUSDC", "TAOUSDT"]
+            },
+            "Coinbase": {
+              "id": ["TAO-USD"]
+            },
+            "CryptoCom": {
+              "symbol": ["TAO_USD"]
+            },
+            "GateIo": {
+              "id": ["TAO_USDT"]
+            },
+            "Kraken": {
+              "pair": ["TAOUSD"],
+              "wsname": ["TAO/USD"]
+            },
+            "KuCoin": {
+              "symbol": ["TAO-USDC", "TAO-USDT"]
+            },
+            "MEXC": {
+              "symbol": ["TAOUSDC", "TAOUSDT"]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": ["TAO"],
+              "id": [22974]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "TAO/USD-RefPrice-DS-Premium-Global-003"
+        }
+      }
+    },
+    {
+      "id": "347",
+      "full_name": "1INCH / USD",
+      "description": "Price of 1inch in USD",
+      "type": "price-feed",
+      "oracle_id": "cex-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 10000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "1INCH",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": ["1INCHUSDT"]
+            },
+            "BinanceUS": {
+              "symbol": ["1INCHUSD", "1INCHUSDT"]
+            },
+            "Bitget": {
+              "symbol": ["1INCHUSDT"]
+            },
+            "Bybit": {
+              "symbol": ["1INCHUSDT"]
+            },
+            "Coinbase": {
+              "id": ["1INCH-USD"]
+            },
+            "CryptoCom": {
+              "symbol": ["1INCH_USD", "1INCH_USDT"]
+            },
+            "GateIo": {
+              "id": ["1INCH_USDT"]
+            },
+            "Kraken": {
+              "pair": ["1INCHUSD"],
+              "wsname": ["1INCH/USD"]
+            },
+            "KuCoin": {
+              "symbol": ["1INCH-USDT"]
+            },
+            "MEXC": {
+              "symbol": ["1INCHUSDT"]
+            },
+            "OKX": {
+              "instId": ["1INCH-USDC", "1INCH-USDT"]
+            }
+          },
+          "aggregators": {
+            "CoinMarketCap": {
+              "symbol": ["1INCH"],
+              "id": [8104]
+            }
+          }
+        },
+        "compatibility_info": {
+          "chainlink": "1INCH / USD"
+        }
+      }
+    },
+    {
+      "id": "50000",
+      "full_name": "USDT / USD Peg-aware",
+      "description": "Peg-aware price of USDT in USD",
+      "type": "price-feed",
+      "oracle_id": "cex-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 30000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "USDT",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "BinanceUS": {
+              "symbol": ["USDTUSD"]
+            },
+            "Coinbase": {
+              "id": ["USDT-USD", "USDT-USDC"]
+            },
+            "CryptoCom": {
+              "symbol": ["USDT_USD"]
+            },
+            "GateIo": {
+              "id": ["USDT_USD"]
+            },
+            "Gemini": {
+              "symbol": ["USDTUSD"]
+            },
+            "Kraken": {
+              "pair": ["USDTZUSD"],
+              "wsname": ["USDT/USD"]
+            },
+            "KuCoin": {
+              "symbol": ["USDT-USDC"]
+            },
+            "OKX": {
+              "instId": ["USDT-USD"]
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "50001",
+      "full_name": "USDC / USD Peg-aware",
+      "description": "Peg-aware price of Circle USD (USDC) in USD",
+      "type": "price-feed",
+      "oracle_id": "cex-price-feeds",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 30000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "USDC",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": {
+          "exchanges": {
+            "Binance": {
+              "symbol": ["USDCUSDT"]
+            },
+            "BinanceUS": {
+              "symbol": ["USDCUSD", "USDCUSDT"]
+            },
+            "Bitget": {
+              "symbol": ["USDCUSDT"]
+            },
+            "Bybit": {
+              "symbol": ["USDCUSDT"]
+            },
+            "GateIo": {
+              "id": ["USDC_USDT"]
+            },
+            "Gemini": {
+              "symbol": ["USDCUSD"]
+            },
+            "Kraken": {
+              "pair": ["USDCUSD", "USDCUSDT"],
+              "wsname": ["USDC/USD", "USDC/USDT"]
+            },
+            "KuCoin": {
+              "symbol": ["USDC-USDT"]
+            },
+            "MEXC": {
+              "symbol": ["USDCUSDT"]
+            },
+            "OKX": {
+              "instId": ["USDC-USDT"]
+            },
+            "Upbit": {
+              "market": ["USDT-USDC"]
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "100002",
+      "full_name": "YUSD / USDC",
+      "description": "YieldFi YUSD exchangeRate call on ETH mainnet at 0x19Ebd191f7A24ECE672ba13A302212b5eF7F35cb",
+      "type": "price-feed",
+      "oracle_id": "eth-rpc",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 10000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "YUSD",
+          "quote": "USDC"
+        },
+        "decimals": 6,
+        "category": "",
+        "market_hours": "Crypto",
+        "arguments": {
+          "divisor": 1000000,
+          "contracts": [
+            {
+              "rpc_urls": [
+                "https://eth.llamarpc.com",
+                "https://rpc.eth.gateway.fm",
+                "https://ethereum-rpc.publicnode.com"
+              ],
+              "address": "0x19Ebd191f7A24ECE672ba13A302212b5eF7F35cb",
+              "label": "YieldFi yUSD",
+              "method_name": "exchangeRate"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "100003",
+      "full_name": "ynBNBx / WBNB",
+      "description": "YieldNest Restaked BNB / Wrapped BNB Redemption Rate. YieldNest convertToAssets call on BNB chain 0x32c830f5c34122c6afb8ae87aba541b7900a2c5f",
+      "type": "price-feed",
+      "oracle_id": "eth-rpc",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 10000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "ynBNBx",
+          "quote": "WBNB"
+        },
+        "decimals": 0,
+        "category": "",
+        "market_hours": "Crypto",
+        "arguments": {
+          "contracts": [
+            {
+              "rpc_urls": [
+                "https://binance.llamarpc.com",
+                "https://bsc.meowrpc.com",
+                "https://bsc.drpc.org"
+              ],
+              "address": "0x32c830f5c34122c6afb8ae87aba541b7900a2c5f",
+              "label": "yBNBx",
+              "method_name": "convertToAssets",
+              "param1": "1000000000000000000"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "1000000",
+      "full_name": "WMON / USD",
+      "description": "Price of Wrapped Monad in USD on Monad Testnet",
+      "type": "price-feed",
+      "oracle_id": "gecko-terminal",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 10000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "WMON",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": [
+          {
+            "network": "monad-testnet",
+            "pool": "0x264e9b75723d75e3c607627d8e21d2c758db4c80",
+            "reverse": true,
+            "min_volume_usd": 200000
+          },
+          {
+            "network": "monad-testnet",
+            "pool": "0x8552706d9a27013f20ea0f9df8e20b61e283d2d3",
+            "reverse": true,
+            "min_volume_usd": 200000
+          },
+          {
+            "network": "monad-testnet",
+            "pool": "0x5323821de342c56b80c99fbc7cd725f2da8eb87b",
+            "reverse": true,
+            "min_volume_usd": 200000
+          },
+          {
+            "network": "monad-testnet",
+            "pool": "0x6e4b7be5ef7f8950c76baa0bd90125bc9b33c8db",
+            "reverse": true,
+            "min_volume_usd": 200000
+          },
+          {
+            "network": "monad-testnet",
+            "pool": "0x212fde77a42d55f980d0a0304e7eebe1e999c60f",
+            "reverse": true,
+            "min_volume_usd": 200000
+          },
+          {
+            "network": "monad-testnet",
+            "pool": "0xc0ce32eee0eb8bf24fa2b00923a78abc5002f91e",
+            "reverse": true,
+            "min_volume_usd": 200000
+          },
+          {
+            "network": "monad-testnet",
+            "pool": "0x786f4aa162457ecdf8fa4657759fa3e86c9394ff",
+            "reverse": true,
+            "min_volume_usd": 200000
+          },
+          {
+            "network": "monad-testnet",
+            "pool": "0xf2afc5aa9965cdb2d4be94823c98411291b61297",
+            "reverse": true,
+            "min_volume_usd": 200000
+          },
+          {
+            "network": "monad-testnet",
+            "pool": "0xf22d36b6bee8a7fd51def4e3badf35a8733b284f",
+            "reverse": true,
+            "min_volume_usd": 200000
+          },
+          {
+            "network": "monad-testnet",
+            "pool": "0xe8a806ae6ecb1f02063e21c6f0579b145399ee5f",
+            "reverse": true,
+            "min_volume_usd": 200000
+          }
+        ]
+      }
+    },
+    {
+      "id": "1000003",
+      "full_name": "CHOG / USD",
+      "description": "Price of CHOG in USD on Monad Testnet (0xE0590015A873bF326bd645c3E1266d4db41C4E6B)",
+      "type": "price-feed",
+      "oracle_id": "gecko-terminal",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 10000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0001,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "CHOG",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": [
+          {
+            "network": "monad-testnet",
+            "pool": "0x4d2e4c5ff07d1c82d512335dea0a1aa82c031a86",
+            "reverse": false,
+            "min_volume_usd": 10000
+          },
+          {
+            "network": "monad-testnet",
+            "pool": "0x1076ad67c1f8ecaeeaabbdf28577fe5b7ccd5e03",
+            "reverse": false,
+            "min_volume_usd": 10000
+          },
+          {
+            "network": "monad-testnet",
+            "pool": "0x48f7d84b7f9e86324ad4c68c9941a2c4ea781217",
+            "reverse": false,
+            "min_volume_usd": 10000
+          },
+          {
+            "network": "monad-testnet",
+            "pool": "0x7aab85507e595d4debd8ec66b04fd9b9f6d36890",
+            "reverse": false,
+            "min_volume_usd": 10000
+          },
+          {
+            "network": "monad-testnet",
+            "pool": "0x9ddb0832edf80dce1768a594faedaa7978a3e118",
+            "reverse": false,
+            "min_volume_usd": 10000
+          },
+          {
+            "network": "monad-testnet",
+            "pool": "0xc0ce32eee0eb8bf24fa2b00923a78abc5002f91e",
+            "reverse": false,
+            "min_volume_usd": 10000
+          }
+        ]
+      }
+    },
+    {
+      "id": "1000008",
+      "full_name": "cbBTC / USD",
+      "description": "Price of Coinbase Wrapped BTC (cbBTC) in USD",
+      "type": "price-feed",
+      "oracle_id": "gecko-terminal",
+      "value_type": "numerical",
+      "stride": 0,
+      "quorum": {
+        "percentage": 75,
+        "aggregation": "median"
+      },
+      "schedule": {
+        "interval_ms": 90000,
+        "heartbeat_ms": 3600000,
+        "deviation_percentage": 0.1,
+        "first_report_start_unix_time_ms": 0
+      },
+      "additional_feed_info": {
+        "pair": {
+          "base": "cbBTC",
+          "quote": "USD"
+        },
+        "decimals": 8,
+        "category": "Crypto",
+        "market_hours": "Crypto",
+        "arguments": [
+          {
+            "network": "base",
+            "pool": "0x70acdf2ad0bf2402c957154f944c19ef4e1cbae1",
+            "reverse": false,
+            "min_volume_usd": 1000000
+          },
+          {
+            "network": "base",
+            "pool": "0x4e962bb3889bf030368f56810a9c96b83cb3e778",
+            "reverse": false,
+            "min_volume_usd": 1000000
+          },
+          {
+            "network": "base",
+            "pool": "0xc211e1f853a898bd1302385ccde55f33a8c4b3f3",
+            "reverse": false,
+            "min_volume_usd": 1000000
+          },
+          {
+            "network": "base",
+            "pool": "0xfbb6eed8e7aa03b138556eedaf5d271a5e1e43ef",
+            "reverse": false,
+            "min_volume_usd": 1000000
+          },
+          {
+            "network": "base",
+            "pool": "0xb94b22332abf5f89877a14cc88f2abc48c34b3df",
+            "reverse": false,
+            "min_volume_usd": 1000000
+          },
+          {
+            "network": "base",
+            "pool": "0x8c7080564b5a792a33ef2fd473fba6364d5495e5",
+            "reverse": false,
+            "min_volume_usd": 1000000
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/apps/e2e-tests/src/process-compose/helpers.ts
+++ b/apps/e2e-tests/src/process-compose/helpers.ts
@@ -1,9 +1,10 @@
 import { ParseResult, Schema as S } from 'effect';
-import { $ } from 'execa';
+import { $, execa } from 'execa';
 
 import { logMessage } from '../utils/logs';
 
 import { arrayToObject } from '@blocksense/base-utils/array-iter';
+import { rootDir } from '@blocksense/base-utils/env';
 
 const ProcessComposeStatusSchema = S.mutable(
   S.Array(
@@ -39,8 +40,11 @@ export async function parseProcessesStatus() {
 }
 
 export async function startEnvironment(testEnvironment: string): Promise<void> {
-  logTestEnvironmentInfo('Starting', testEnvironment);
-  await $`just start-environment ${testEnvironment} --detached`;
+  await execa('just', ['start-environment', testEnvironment, '--detached'], {
+    env: {
+      FEEDS_CONFIG_DIR: `${rootDir}/apps/e2e-tests/src/process-compose/config`,
+    },
+  });
 }
 
 export async function stopEnvironment(): Promise<void> {

--- a/nix/modules/blocksense/backends/process-compose.nix
+++ b/nix/modules/blocksense/backends/process-compose.nix
@@ -19,6 +19,12 @@ let
 
   mkCargoTargetExePath = executable-name: "${config.devenv.root}/target/release/${executable-name}";
 
+  feedsConfigDir =
+    if builtins.getEnv "FEEDS_CONFIG_DIR" != "" then
+      builtins.getEnv "FEEDS_CONFIG_DIR"
+    else
+      "${config.devenv.root}/config";
+
   logsConfig = {
     fields_order = [
       "message"
@@ -110,7 +116,7 @@ let
         timeout_seconds = 30;
       };
       environment = [
-        "FEEDS_CONFIG_DIR=${../../../../config}"
+        "FEEDS_CONFIG_DIR=${feedsConfigDir}"
         "SEQUENCER_CONFIG_DIR=${cfg.config-dir}"
         "SEQUENCER_LOG_LEVEL=${lib.toUpper cfg.sequencer.log-level}"
       ];


### PR DESCRIPTION

## Make `FEEDS_CONFIG_DIR` configurable and use `feeds_config_v2` in e2e tests

### Summary

This PR improves configuration flexibility for the Blocksense `process-compose` environment by allowing the `FEEDS_CONFIG_DIR` to be supplied via an environment variable, and introduces a new `feeds_config_v2.json` for use in E2E tests.

### Changes

* **Nix module (`process-compose.nix`)**

  * Replaces hardcoded `FEEDS_CONFIG_DIR` path with a dynamic value using `builtins.getEnv` + fallback to `${config.devenv.root}/config`.
  * This allows overriding the feed config path at evaluation time (requires running with `--impure`).
* **E2E test setup**

  * Adds a new `feeds_config_v2.json` file.
  * Updates `startEnvironment` helper to explicitly set the `FEEDS_CONFIG_DIR` via the environment using `execa`.

### How to use

To override the feeds config path, set the environment variable before running:

```sh
FEEDS_CONFIG_DIR=./config just start-environment example-setup-03  
```
