### PR TITLE
[example-setup-03/e2e-tests]:  Add pegging tests and simplify feed configuration

### DIFF
--- a/apps/e2e-tests/src/process-compose/e2e.spec.ts
+++ b/apps/e2e-tests/src/process-compose/e2e.spec.ts
@@ -7,8 +7,14 @@ import { getProcessComposeLogsFiles } from '@blocksense/base-utils/env';
 import { fetchAndDecodeJSON } from '@blocksense/base-utils/http';
 import { entriesOf, mapValuePromises } from '@blocksense/base-utils';
 import { AggregatedDataFeedStoreConsumer } from '@blocksense/contracts/viem';
-import type { SequencerConfigV2 } from '@blocksense/config-types/node-config';
-import { SequencerConfigV2Schema } from '@blocksense/config-types/node-config';
+import type {
+  SequencerConfigV2,
+  NewFeedsConfig,
+} from '@blocksense/config-types';
+import {
+  SequencerConfigV2Schema,
+  NewFeedsConfigSchema,
+} from '@blocksense/config-types';
 
 import {
   parseProcessesStatus,
@@ -19,11 +25,13 @@ import { expectedPCStatuses03 } from './expected';
 
 describe.sequential('E2E Tests with process-compose', async () => {
   const sequencerConfigUrl = 'http://127.0.0.1:5553/get_sequencer_config';
+  const sequencerFeedsConfigUrl = 'http://127.0.0.1:5553/get_feeds_config';
   const network = 'ink_sepolia';
 
   let sequencerConfig: SequencerConfigV2;
+  let feedsConfig: NewFeedsConfig;
   let ADFSConsumer;
-  let allowFeeds: Array<bigint>;
+  let feedIds: Array<bigint>;
   let initialPrices: Record<string, number>;
 
   beforeAll(async () => {
@@ -58,23 +66,29 @@ describe.sequential('E2E Tests with process-compose', async () => {
       sequencerConfigUrl,
     );
 
+    feedsConfig = await fetchAndDecodeJSON(
+      NewFeedsConfigSchema,
+      sequencerFeedsConfigUrl,
+    );
+
     expect(sequencerConfig).toBeTypeOf('object');
 
     // Collect initial information for the feeds and their prices
     const url = sequencerConfig.providers[network].url;
     const contractAddress = sequencerConfig.providers[network]
       .contract_address as `0x${string}`;
-    allowFeeds =
-      sequencerConfig?.providers?.[network]?.allow_feeds?.map(feedId =>
-        BigInt(feedId),
-      ) ?? [];
+    const allow_feeds = sequencerConfig.providers[network].allow_feeds;
+
+    feedIds = allow_feeds?.length
+      ? (allow_feeds as Array<bigint>)
+      : feedsConfig.feeds.map(feed => feed.id);
 
     ADFSConsumer = AggregatedDataFeedStoreConsumer.createConsumerByRpcUrl(
       contractAddress,
       url,
     );
 
-    initialPrices = allowFeeds.reduce(
+    initialPrices = feedIds.reduce(
       (acc, feedId) => {
         acc[feedId.toString()] = 0;
         return acc;

--- a/apps/e2e-tests/src/process-compose/e2e.spec.ts
+++ b/apps/e2e-tests/src/process-compose/e2e.spec.ts
@@ -125,6 +125,12 @@ describe.sequential('E2E Tests with process-compose', async () => {
     );
 
     for (const [id, price] of entriesOf(currentPrices)) {
+      // Pegged asset with 10% tolerance should be pegged
+      // Pegged asset with 0.000001% tolerance should not be pegged
+      if (id === '50000') {
+        expect(price).toEqual(1 * 10 ** 8);
+        continue;
+      }
       expect(price).not.toEqual(initialPrices[id]);
     }
   });

--- a/nix/test-environments/example-setup-03.nix
+++ b/nix/test-environments/example-setup-03.nix
@@ -61,113 +61,14 @@ in
           contract-version = 2;
           transaction-gas-limit = 20000000;
           impersonated-anvil-account = impersonationAddress;
-          allow-feeds = [
-            # cex-price-feeds oracle feeds
-            0 # BTC / USD
-            3 # ETH / USD
-            7 # USDT / USD
-            13 # BNB / USD
-            16 # SOL / USD
-            19 # USDC / USD
-            32 # wBTC / USD
-            35 # LINK / USD
-            91 # UNI / USD
-            114 # AAVE / USD
-            121 # TAO / USD
-            347 # 1INCH / USD
-            50000 # USDT / USD Pegged
-            50001 # USDC / USD Pegged
-
-            # exsat-holdings oracle feeds
-            # Very slow oracle, not suitable for fast setup
-            # 100000 # ExSat BTC
-
-            # eth-rpc oracle feeds
-            100002 # YieldFi yUSD (yUSD) exchangeRate on ETH mainnet
-            100003 # ynBNB MAX (ynBNBx) - YieldNest convertToAssets on BNB
-
-            # gecko-terminal oracle feeds
-            1000000 # WMON / USD
-            1000003 # CHOG / USD
-            1000008 # cbBTC/ USD
-
-            # stock-price-feeds oracle feeds
-            # At this point we don't have API keys in the e2e test set
-            # 2000000 # IBIT / USD
-            # 2000001 # SPY / USD
-          ];
           publishing-criteria = [
             {
-              feed-id = 0; # BTC / USD
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
-              feed-id = 3; # ETH / USD
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
-              feed-id = 7; # USDT / USD
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
-              feed-id = 13; # BNB / USD
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
-              feed-id = 16; # SOL / USD
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
-              feed-id = 19; # USDC / USD
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
-              feed-id = 32; # wBTC / USD
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
-              feed-id = 35; # LINK / USD
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
-              feed-id = 91; # UNI / USD
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
-              feed-id = 114; # AAVE / USD
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
-              feed-id = 121; # TAO / USD
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
-              feed-id = 347; # 1INCH / USD
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
               feed-id = 50000; # USDT / USD Pegged
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
               peg-to-value = 1.00;
               peg-tolerance-percentage = 0.1;
             }
             {
               feed-id = 50001; # USDC / USD Pegged
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
               peg-to-value = 1.00;
               peg-tolerance-percentage = 0.1;
             }

--- a/nix/test-environments/example-setup-03.nix
+++ b/nix/test-environments/example-setup-03.nix
@@ -65,37 +65,12 @@ in
             {
               feed-id = 50000; # USDT / USD Pegged
               peg-to-value = 1.00;
-              peg-tolerance-percentage = 0.1;
+              peg-tolerance-percentage = 10.0; # 10% tolerance assures that the price will be pegged
             }
             {
               feed-id = 50001; # USDC / USD Pegged
               peg-to-value = 1.00;
-              peg-tolerance-percentage = 0.1;
-            }
-            {
-              feed-id = 100002; # YieldFi yUSD (yUSD) exchangeRate on ETH mainnet
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
-              feed-id = 100003; # ynBNB MAX (ynBNBx) - YieldNest convertToAssets on BNB
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
-              feed-id = 1000000; # WMON / USD
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
-              feed-id = 1000003; # CHOG / USD
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
-            }
-            {
-              feed-id = 1000008; # cbBTC / USD
-              skip-publish-if-less-then-percentage = 0.001;
-              always-publish-heartbeat-ms = 20000;
+              peg-tolerance-percentage = 0.000001; # 0.000001% tolerance assures that the price will not be pegged
             }
           ];
         };


### PR DESCRIPTION
### **Add pegging tests and simplify feed configuration**

#### **Summary**

This PR introduces end-to-end tests for pegged asset functionality and simplifies feed configuration in the E2E test environment by:

* Adding logic to automatically collect feed IDs from the feeds config when `allow-feeds` is an empty array.
* Refactoring the test environment setup to reduce unnecessary feed declarations.
* Testing price behavior of pegged assets with differing tolerance levels.

---

#### **Key Changes**

##### **E2E Test Enhancements**

*  Added support in `e2e.spec.ts` to:

  * Load feed config from `/get_feeds_config` if `allow_feeds` is empty.
  * Add assertion logic to test pegging:

    * Feed `50000` (USDT) with **10% tolerance** is expected to remain pegged.
    * Feed `50001` (USDC) with **0.000001% tolerance** is expected **not** to be pegged.

##### **Test Environment Simplification**

* Cleaned up excessive `allow-feeds` and `publishing-criteria` blocks.
* Retained only the minimal pegged feed configurations for USDT and USDC with different tolerance levels.

[BSN-3299: Remove allow_feeds from example-setup-03 ](https://coda.io/d/_d6vM0kjfQP6#_tuk5j/r3299&view=full)
