### PR TITLE
[e2e-tests]: Refactor e2e tests' infrastructure with `Effect`

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -83,7 +83,7 @@ test-ts:
   yarn workspace @blocksense/e2e-tests run test:unit
 
 test-e2e:
-  yarn workspace @blocksense/e2e-tests run test
+  yarn workspace @blocksense/e2e-tests run test:process-compose-e2e
 
 [group('Working with oracles')]
 [doc('Build a specific oracle')]

--- a/apps/e2e-tests/package.json
+++ b/apps/e2e-tests/package.json
@@ -12,6 +12,7 @@
     "@blocksense/base-utils": "workspace:*",
     "@blocksense/config-types": "workspace:*",
     "@blocksense/contracts": "workspace:*",
+    "@effect/language-service": "^0.31.2",
     "@effect/platform": "^0.90.0",
     "@effect/vitest": "^0.25.0",
     "@types/node": "^22.3.0",

--- a/apps/e2e-tests/src/process-compose/e2e.spec.ts
+++ b/apps/e2e-tests/src/process-compose/e2e.spec.ts
@@ -1,166 +1,184 @@
+import { Effect, pipe } from 'effect';
+import { afterAll, beforeAll, describe, expect, it } from '@effect/vitest';
 import { deepStrictEqual } from 'assert';
-import { execa } from 'execa';
-import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { loopWhile, sleep } from '@blocksense/base-utils/async';
 import { getProcessComposeLogsFiles } from '@blocksense/base-utils/env';
-import { fetchAndDecodeJSON } from '@blocksense/base-utils/http';
 import { entriesOf, mapValuePromises } from '@blocksense/base-utils';
 import { AggregatedDataFeedStoreConsumer } from '@blocksense/contracts/viem';
-import type {
-  SequencerConfigV2,
-  NewFeedsConfig,
-} from '@blocksense/config-types';
-import {
-  SequencerConfigV2Schema,
-  NewFeedsConfigSchema,
-} from '@blocksense/config-types';
 
-import {
-  parseProcessesStatus,
-  startEnvironment,
-  stopEnvironment,
-} from './helpers';
+import { parseProcessesStatus } from './helpers';
 import { expectedPCStatuses03 } from './expected';
+import type { ProcessComposeService } from './types';
+import {
+  RGLogChecker,
+  RGLogCheckerLive,
+  ProcessCompose,
+  ProcessComposeLive,
+  Sequencer,
+  SequencerLive,
+} from './types';
 
-describe.sequential('E2E Tests with process-compose', async () => {
-  const sequencerConfigUrl = 'http://127.0.0.1:5553/get_sequencer_config';
-  const sequencerFeedsConfigUrl = 'http://127.0.0.1:5553/get_feeds_config';
+describe.sequential('E2E Tests with process-compose', () => {
   const network = 'ink_sepolia';
 
-  let sequencerConfig: SequencerConfigV2;
-  let feedsConfig: NewFeedsConfig;
-  let ADFSConsumer;
   let feedIds: Array<bigint>;
+  let processCompose: ProcessComposeService;
+  let ADFSConsumer;
   let initialPrices: Record<string, number>;
 
-  beforeAll(async () => {
-    await startEnvironment('example-setup-03');
-  });
+  beforeAll(() =>
+    pipe(
+      ProcessCompose,
+      Effect.provide(ProcessComposeLive),
+      Effect.tap(pc => pc.start('example-setup-03')),
+      Effect.tap(pc => (processCompose = pc)),
+      Effect.runPromise,
+    ),
+  );
 
-  afterAll(async () => {
-    await stopEnvironment();
-  });
+  afterAll(() => pipe(processCompose.stop(), Effect.runPromise));
 
-  test('Test processes state shortly after start', async () => {
-    const equal = await loopWhile(
-      (equal: boolean) => !equal,
-      async () => {
-        try {
-          const processes = await parseProcessesStatus();
-          deepStrictEqual(processes, expectedPCStatuses03);
-          return true;
-        } catch {
-          return false;
-        }
-      },
-      1000,
-      10,
-    );
-    expect(equal).toBe(true);
-  });
-
-  test('Test sequencer config is available and in correct format', async () => {
-    sequencerConfig = await fetchAndDecodeJSON(
-      SequencerConfigV2Schema,
-      sequencerConfigUrl,
-    );
-
-    feedsConfig = await fetchAndDecodeJSON(
-      NewFeedsConfigSchema,
-      sequencerFeedsConfigUrl,
-    );
-
-    expect(sequencerConfig).toBeTypeOf('object');
-
-    // Collect initial information for the feeds and their prices
-    const url = sequencerConfig.providers[network].url;
-    const contractAddress = sequencerConfig.providers[network]
-      .contract_address as `0x${string}`;
-    const allow_feeds = sequencerConfig.providers[network].allow_feeds;
-
-    feedIds = allow_feeds?.length
-      ? (allow_feeds as Array<bigint>)
-      : feedsConfig.feeds.map(feed => feed.id);
-
-    ADFSConsumer = AggregatedDataFeedStoreConsumer.createConsumerByRpcUrl(
-      contractAddress,
-      url,
-    );
-
-    initialPrices = feedIds.reduce(
-      (acc, feedId) => {
-        acc[feedId.toString()] = 0;
-        return acc;
-      },
-      {} as Record<string, number>,
-    );
-    initialPrices = await mapValuePromises(
-      initialPrices,
-      async (feedId, _) =>
-        await ADFSConsumer.getLatestSingleData(feedId).then(res =>
-          Number(res.slice(0, 50)),
+  it.effect('Test processes state shortly after start', () =>
+    Effect.gen(function* () {
+      const equal = yield* Effect.promise(() =>
+        loopWhile(
+          (equal: boolean) => !equal,
+          async () => {
+            try {
+              const processes = await parseProcessesStatus();
+              deepStrictEqual(processes, expectedPCStatuses03);
+              return true;
+            } catch {
+              return false;
+            }
+          },
+          1000,
+          10,
         ),
-    );
-  });
+      );
 
-  test('Test processes state after 2 mins', async () => {
+      expect(equal).toBeTruthy();
+    }),
+  );
+
+  it.effect('Test sequencer config is available and in correct format', () =>
+    Effect.gen(function* () {
+      const sequencer = yield* Sequencer;
+      const sequencerConfig = yield* sequencer.getConfig();
+
+      expect(sequencerConfig).toBeTypeOf('object');
+      return sequencerConfig;
+    }).pipe(
+      Effect.tap(config =>
+        Effect.gen(function* () {
+          // Collect initial information for the feeds and their prices
+          const url = config.providers[network].url;
+          const contractAddress = config.providers[network]
+            .contract_address as `0x${string}`;
+          const allow_feeds = config.providers[network].allow_feeds;
+
+          const sequencer = yield* Sequencer;
+          const feedsConfig = yield* sequencer.getFeedsConfig();
+
+          feedIds = allow_feeds?.length
+            ? (allow_feeds as Array<bigint>)
+            : feedsConfig.feeds.map(feed => feed.id);
+
+          ADFSConsumer = yield* Effect.sync(() =>
+            AggregatedDataFeedStoreConsumer.createConsumerByRpcUrl(
+              contractAddress,
+              url,
+            ),
+          );
+
+          initialPrices = feedIds.reduce(
+            (acc, feedId) => {
+              acc[feedId.toString()] = 0;
+              return acc;
+            },
+            {} as Record<string, number>,
+          );
+
+          initialPrices = yield* Effect.promise(() =>
+            mapValuePromises(
+              initialPrices,
+              async (feedId, _) =>
+                await ADFSConsumer.getLatestSingleData(feedId).then(res =>
+                  Number(res.slice(0, 50)),
+                ),
+            ),
+          );
+        }),
+      ),
+      Effect.provide(SequencerLive),
+    ),
+  );
+
+  it.effect('Test processes state after 2 mins', () =>
     // TODO: (EmilIvanichkovv): Consider reading `the total_tx_sent` metrics from the sequencer instead of wait for something unspecified to happen.
-    // Wait for the processes to work for 5 minutes
-    await sleep(2 * 60 * 1000);
+    Effect.gen(function* () {
+      // Effect.sleep() uses fake timers and we cannot test real time passage
+      yield* Effect.tryPromise(() => sleep(2 * 60 * 1000));
 
-    // Get the processes status
-    const processes = await parseProcessesStatus();
+      const processes = yield* Effect.tryPromise(() => parseProcessesStatus());
 
-    expect(processes).toEqual(expectedPCStatuses03);
-  });
+      expect(processes).toEqual(expectedPCStatuses03);
+    }),
+  );
 
-  test('Test prices are updated', async () => {
-    const currentPrices = await mapValuePromises(
-      initialPrices,
-      async (feedId, _) =>
-        await ADFSConsumer.getLatestSingleData(feedId).then(res =>
-          Number(res.slice(0, 50)),
+  it.effect('Test prices are updated', () =>
+    Effect.gen(function* () {
+      const currentPrices = yield* Effect.promise(() =>
+        mapValuePromises(
+          initialPrices,
+          async (feedId, _) =>
+            await ADFSConsumer.getLatestSingleData(feedId).then(res =>
+              Number(res.slice(0, 50)),
+            ),
         ),
-    );
+      );
 
-    for (const [id, price] of entriesOf(currentPrices)) {
-      // Pegged asset with 10% tolerance should be pegged
-      // Pegged asset with 0.000001% tolerance should not be pegged
-      if (id === '50000') {
-        expect(price).toEqual(1 * 10 ** 8);
-        continue;
+      for (const [id, price] of entriesOf(currentPrices)) {
+        // Pegged asset with 10% tolerance should be pegged
+        // Pegged asset with 0.000001% tolerance should not be pegged
+        if (id === '50000') {
+          expect(price).toEqual(1 * 10 ** 8);
+          continue;
+        }
+        expect(price).not.toEqual(initialPrices[id]);
       }
-      expect(price).not.toEqual(initialPrices[id]);
-    }
-  });
+    }),
+  );
 
-  describe.sequential('Reporter behavior based on logs', async () => {
+  describe.sequential('Reporter behavior based on logs', () => {
     const reporterLogsFile =
       getProcessComposeLogsFiles('example-setup-03')['reporter-a'];
 
-    test('Reporter should NOT panic', async () => {
-      const result = await execa('rg', ['-i', 'panic', reporterLogsFile], {
-        reject: false,
-      });
-      expect(result.exitCode).toBe(1);
-    });
+    it.effect('Reporter should NOT panic', () =>
+      Effect.gen(function* () {
+        const rgLogChecker = yield* RGLogChecker;
+        const result = yield* rgLogChecker.assertDoesNotContain({
+          file: reporterLogsFile,
+          pattern: 'panic',
+          caseInsensitive: true,
+        });
 
-    test('Reporter should NOT receive errors from Sequencer', async () => {
-      const result = await execa(
-        'rg',
-        [
-          '-i',
-          '--pcre2',
-          'Sequencer responded with status=(?!200)\\d+',
-          reporterLogsFile,
-        ],
-        {
-          reject: false,
-        },
-      );
+        expect(result).toBe(1);
+      }).pipe(Effect.provide(RGLogCheckerLive)),
+    );
 
-      expect(result.exitCode).toBe(1);
-    });
+    it.effect('Reporter should NOT receive errors from Sequencer', () =>
+      Effect.gen(function* () {
+        const rgLogChecker = yield* RGLogChecker;
+        const result = yield* rgLogChecker.assertDoesNotContain({
+          file: reporterLogsFile,
+          pattern: 'Sequencer responded with status=(?!200)\\d+',
+          flags: ['--pcre2'],
+        });
+
+        expect(result).toBe(1);
+      }).pipe(Effect.provide(RGLogCheckerLive)),
+    );
   });
 });

--- a/apps/e2e-tests/src/process-compose/helpers.ts
+++ b/apps/e2e-tests/src/process-compose/helpers.ts
@@ -40,6 +40,7 @@ export async function parseProcessesStatus() {
 }
 
 export async function startEnvironment(testEnvironment: string): Promise<void> {
+  logTestEnvironmentInfo('Starting', testEnvironment);
   await execa('just', ['start-environment', testEnvironment, '--detached'], {
     env: {
       FEEDS_CONFIG_DIR: `${rootDir}/apps/e2e-tests/src/process-compose/config`,

--- a/apps/e2e-tests/src/process-compose/types.ts
+++ b/apps/e2e-tests/src/process-compose/types.ts
@@ -1,0 +1,130 @@
+import { Context, Data, Effect, Layer } from 'effect';
+import { execa } from 'execa';
+
+import { fetchAndDecodeJSON } from '@blocksense/base-utils/http';
+import {
+  startEnvironment,
+  stopEnvironment,
+  parseProcessesStatus,
+} from './helpers';
+import type { SequencerConfigV2 } from '@blocksense/config-types/node-config';
+import { SequencerConfigV2Schema } from '@blocksense/config-types/node-config';
+import type { NewFeedsConfig } from '@blocksense/config-types';
+import { NewFeedsConfigSchema } from '@blocksense/config-types';
+
+// --- Services Definition ---
+export class ProcessCompose extends Context.Tag('@e2e-tests/ProcessCompose')<
+  ProcessCompose,
+  {
+    readonly start: (name: string) => Effect.Effect<void, Error, never>;
+    readonly stop: () => Effect.Effect<void, Error, never>;
+    readonly parseStatus: () => Effect.Effect<
+      Record<string, { status: string; exit_code: number }>,
+      Error,
+      never
+    >;
+  }
+>() {}
+
+export type ProcessComposeService = Context.Tag.Service<ProcessCompose>;
+
+export class Sequencer extends Context.Tag('@e2e-tests/Sequencer')<
+  Sequencer,
+  {
+    readonly configUrl: string;
+    readonly feedsConfigUrl: string;
+    readonly getConfig: () => Effect.Effect<SequencerConfigV2, Error, never>;
+    readonly getFeedsConfig: () => Effect.Effect<NewFeedsConfig, Error, never>;
+  }
+>() {}
+
+export class RGLogChecker extends Context.Tag('@e2e-tests/RGLogChecker')<
+  RGLogChecker,
+  {
+    readonly assertDoesNotContain: (args: {
+      readonly file: string;
+      readonly pattern: string;
+      readonly caseInsensitive?: boolean;
+      readonly flags?: Array<string>;
+    }) => Effect.Effect<void, RGLogCheckerError>;
+  }
+>() {}
+
+export class RGLogCheckerError extends Data.TaggedError(
+  '@e2e-tests/RGLogCheckerError',
+)<{
+  cause: unknown;
+}> {}
+
+// --- Layers Definition ---
+export const ProcessComposeLive = Layer.succeed(
+  ProcessCompose,
+  ProcessCompose.of({
+    start: (env: string = 'example-setup-03') =>
+      Effect.tryPromise({
+        try: () => startEnvironment(env),
+        catch: error => new Error(`Failed to start environment: ${error}`),
+      }),
+    stop: () =>
+      Effect.tryPromise({
+        try: () => stopEnvironment(),
+        catch: error => new Error(`Failed to stop environment: ${error}`),
+      }),
+    parseStatus: () =>
+      Effect.tryPromise({
+        try: () => parseProcessesStatus(),
+        catch: error => new Error(`Failed to parse processes status: ${error}`),
+      }),
+  }),
+);
+
+export const SequencerLive = Layer.effect(
+  Sequencer,
+  Effect.gen(function* () {
+    const configUrl = yield* Effect.succeed(
+      'http://127.0.0.1:5553/get_sequencer_config',
+    );
+    const feedsConfigUrl = yield* Effect.succeed(
+      'http://127.0.0.1:5553/get_feeds_config',
+    );
+
+    return Sequencer.of({
+      configUrl,
+      feedsConfigUrl,
+      getConfig: () =>
+        Effect.tryPromise({
+          try: () => fetchAndDecodeJSON(SequencerConfigV2Schema, configUrl),
+          catch: error =>
+            new Error(`Failed to fetch sequencer config: ${error}`),
+        }),
+      getFeedsConfig: () =>
+        Effect.tryPromise({
+          try: () => fetchAndDecodeJSON(NewFeedsConfigSchema, feedsConfigUrl),
+          catch: error => new Error(`Failed to fetch feeds config: ${error}`),
+        }),
+    });
+  }),
+);
+
+export const RGLogCheckerLive = Layer.succeed(
+  RGLogChecker,
+  RGLogChecker.of({
+    assertDoesNotContain: ({ caseInsensitive, file, flags, pattern }) =>
+      Effect.tryPromise({
+        try: () => {
+          const args = ['--quiet'];
+          if (caseInsensitive) args.push('-i');
+          if (flags) flags.forEach(f => args.push(f));
+          args.push(pattern, file);
+
+          return execa('rg', args, { reject: false });
+        },
+        catch: unknown => new RGLogCheckerError({ cause: unknown }),
+      }).pipe(Effect.map(result => result.exitCode)),
+  }),
+);
+
+// TODO: (danielstoyanov) Define custom error types for Services and Layers
+// class ExampleError extends Data.TaggedError('@e2e-tests/ExampleError')<{
+//   readonly message: string;
+// }> {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2569,6 +2569,7 @@ __metadata:
     "@blocksense/base-utils": "workspace:*"
     "@blocksense/config-types": "workspace:*"
     "@blocksense/contracts": "workspace:*"
+    "@effect/language-service": "npm:^0.31.2"
     "@effect/platform": "npm:^0.90.0"
     "@effect/vitest": "npm:^0.25.0"
     "@types/node": "npm:^22.3.0"
@@ -3432,6 +3433,15 @@ __metadata:
   bin:
     effect-language-service: cli.js
   checksum: 10c0/81a05ec17e30637663a8828a95dd175db2a5e55fd6990950a63d3429938fc273072005822422e527cdc2a199e45da9bbc43bceacd390b1c3290caee4e85d65af
+  languageName: node
+  linkType: hard
+
+"@effect/language-service@npm:^0.31.2":
+  version: 0.31.2
+  resolution: "@effect/language-service@npm:0.31.2"
+  bin:
+    effect-language-service: cli.js
+  checksum: 10c0/5714e1a1accc48636279afb0ab600907debf354cd034148bb36b76787f74080a7d60ec41032e87c091cf1ea299714a3746d86b902757bf73388eca097c467a6e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Refactor e2e-tests to use Effect & add @effect/vitest dependency

## Summary

This PR refactors the `e2e.spec.ts` end-to-end tests to fully utilize the `effect` library for handling asynchronous operations and effects, improving composability and test clarity. Additionally, it installs and integrates the `@effect/vitest` testing utilities to enable effect-aware test definitions and better integration with Vitest.

## Changes

- Rewrote `apps/e2e-tests/src/process-compose/e2e.spec.ts`:
  - Replaced traditional async/await and direct promises with Effect-based `Effect.gen`, `Effect.promise`, and other combinators.
  - Introduced `Effect`-based service abstractions (`ProcessCompose`, `Sequencer`, `LogChecker`) in a new `types.ts` file for cleaner dependency injection.
  - Replaced manual environment startup/shutdown (`startEnvironment`, `stopEnvironment`) with Effect-provided services.
  - Converted Vitest `test` to `it.effect` from `@effect/vitest` for better integration with Effect.
  - Improved log assertions by using a new `LogChecker` service wrapping `ripgrep` calls as Effects.
  - Made tests more declarative and composable using Effect APIs.
  - Removed direct `execa` calls from the tests and encapsulated them into Effect services.
  - Preserved all original test intentions and assertions.

- Added `apps/e2e-tests/src/process-compose/types.ts` defining:
  - Effect service interfaces and live layers for `ProcessCompose`, `Sequencer`, and `LogChecker`.
  - Custom error class for log checking failures.
  - Effect wrappers around existing helpers and external utilities like `execa`.

- Installed new dependency `@effect/vitest@^0.25.0` in `apps/e2e-tests/package.json` and updated `yarn.lock` accordingly.

## TODOs
- [x]  Define custom error types - #FUTURE PR WITH IMPROVEMENTS
- [x]  Make use of `HttpClient` - twin of fetchAndDecodeJson but with Effect - #FUTURE PR WITH IMPROVEMENTS

## How to Test

- Run `yarn install` in `apps/e2e-tests` to install new dependencies.
- Run `just test-e2e`

---

This refactor lays groundwork for more idiomatic Effect usage across the project’s e2e tests and improves maintainability going forward.
