### PR TITLE
[e2e tests]: Make tests rely on `updates to network` metric

### DIFF
--- a/apps/e2e-tests/src/process-compose/config/feeds_config_v2.json
+++ b/apps/e2e-tests/src/process-compose/config/feeds_config_v2.json
@@ -15,7 +15,7 @@
       "schedule": {
         "interval_ms": 10000,
         "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {
@@ -95,7 +95,7 @@
       "schedule": {
         "interval_ms": 10000,
         "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {
@@ -179,7 +179,7 @@
       "schedule": {
         "interval_ms": 10000,
         "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {
@@ -245,7 +245,7 @@
       "schedule": {
         "interval_ms": 10000,
         "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {
@@ -314,7 +314,7 @@
       "schedule": {
         "interval_ms": 10000,
         "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {
@@ -398,7 +398,7 @@
       "schedule": {
         "interval_ms": 10000,
         "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {
@@ -473,7 +473,7 @@
       "schedule": {
         "interval_ms": 10000,
         "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {
@@ -542,7 +542,7 @@
       "schedule": {
         "interval_ms": 10000,
         "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {
@@ -623,7 +623,7 @@
       "schedule": {
         "interval_ms": 10000,
         "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {
@@ -707,7 +707,7 @@
       "schedule": {
         "interval_ms": 10000,
         "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {
@@ -788,7 +788,7 @@
       "schedule": {
         "interval_ms": 10000,
         "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {
@@ -854,7 +854,7 @@
       "schedule": {
         "interval_ms": 10000,
         "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {
@@ -927,9 +927,9 @@
         "aggregation": "median"
       },
       "schedule": {
-        "interval_ms": 30000,
+        "interval_ms": 10000,
         "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {
@@ -984,9 +984,9 @@
         "aggregation": "median"
       },
       "schedule": {
-        "interval_ms": 30000,
+        "interval_ms": 10000,
         "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {
@@ -1038,49 +1038,6 @@
       }
     },
     {
-      "id": "100002",
-      "full_name": "YUSD / USDC",
-      "description": "YieldFi YUSD exchangeRate call on ETH mainnet at 0x19Ebd191f7A24ECE672ba13A302212b5eF7F35cb",
-      "type": "price-feed",
-      "oracle_id": "eth-rpc",
-      "value_type": "numerical",
-      "stride": 0,
-      "quorum": {
-        "percentage": 75,
-        "aggregation": "median"
-      },
-      "schedule": {
-        "interval_ms": 10000,
-        "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
-        "first_report_start_unix_time_ms": 0
-      },
-      "additional_feed_info": {
-        "pair": {
-          "base": "YUSD",
-          "quote": "USDC"
-        },
-        "decimals": 6,
-        "category": "",
-        "market_hours": "Crypto",
-        "arguments": {
-          "divisor": 1000000,
-          "contracts": [
-            {
-              "rpc_urls": [
-                "https://eth.llamarpc.com",
-                "https://rpc.eth.gateway.fm",
-                "https://ethereum-rpc.publicnode.com"
-              ],
-              "address": "0x19Ebd191f7A24ECE672ba13A302212b5eF7F35cb",
-              "label": "YieldFi yUSD",
-              "method_name": "exchangeRate"
-            }
-          ]
-        }
-      }
-    },
-    {
       "id": "100003",
       "full_name": "ynBNBx / WBNB",
       "description": "YieldNest Restaked BNB / Wrapped BNB Redemption Rate. YieldNest convertToAssets call on BNB chain 0x32c830f5c34122c6afb8ae87aba541b7900a2c5f",
@@ -1095,7 +1052,7 @@
       "schedule": {
         "interval_ms": 10000,
         "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {
@@ -1138,7 +1095,7 @@
       "schedule": {
         "interval_ms": 10000,
         "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {
@@ -1228,7 +1185,7 @@
       "schedule": {
         "interval_ms": 10000,
         "heartbeat_ms": 60000,
-        "deviation_percentage": 0.0001,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {
@@ -1292,9 +1249,9 @@
         "aggregation": "median"
       },
       "schedule": {
-        "interval_ms": 90000,
-        "heartbeat_ms": 3600000,
-        "deviation_percentage": 0.1,
+        "interval_ms": 10000,
+        "heartbeat_ms": 60000,
+        "deviation_percentage": 0.0000001,
         "first_report_start_unix_time_ms": 0
       },
       "additional_feed_info": {

--- a/apps/e2e-tests/src/process-compose/helpers.ts
+++ b/apps/e2e-tests/src/process-compose/helpers.ts
@@ -1,13 +1,10 @@
-import { Effect, ParseResult, Schema as S } from 'effect';
+import { ParseResult, Schema as S } from 'effect';
 import { $, execa } from 'execa';
 
 import { logMessage } from '../utils/logs';
 
 import { arrayToObject } from '@blocksense/base-utils/array-iter';
 import { rootDir } from '@blocksense/base-utils/env';
-import { getMetrics } from '../utils/metrics/metrics-fetcher';
-import type { UpdatesToNetwork } from './types';
-import { UpdatesToNetworkMetric } from './types';
 
 const ProcessComposeStatusSchema = S.mutable(
   S.Array(
@@ -66,31 +63,4 @@ export function logTestEnvironmentInfo(
     `${status} test environment ${name}`,
     `${status} time: ${time.toDateString()} ${time.toTimeString()}`,
   );
-}
-
-export function fetchUpdatesToNetworksMetric() {
-  return Effect.gen(function* () {
-    const metrics = yield* getMetrics('http://127.0.0.1:5551/metrics');
-    const updatesToNetworks = metrics.filter(
-      metric => metric.name === 'updates_to_networks',
-    )[0];
-    if (!updatesToNetworks) return null;
-
-    const decoded = S.decodeUnknownSync(UpdatesToNetworkMetric)(
-      updatesToNetworks,
-    );
-    return decoded.metrics.reduce((acc: UpdatesToNetwork, item) => {
-      const networkName = item.labels.Network;
-      const feedId = item.labels.FeedId;
-      const value = item.value;
-
-      if (!acc[networkName]) {
-        acc[networkName] = {};
-      }
-
-      acc[networkName][feedId] = value;
-
-      return acc;
-    }, {} as UpdatesToNetwork);
-  });
 }

--- a/apps/e2e-tests/src/process-compose/types.ts
+++ b/apps/e2e-tests/src/process-compose/types.ts
@@ -1,4 +1,4 @@
-import { Context, Data, Effect, Layer } from 'effect';
+import { Context, Data, Effect, Layer, Schema as S } from 'effect';
 import { execa } from 'execa';
 
 import { fetchAndDecodeJSON } from '@blocksense/base-utils/http';
@@ -128,3 +128,20 @@ export const RGLogCheckerLive = Layer.succeed(
 // class ExampleError extends Data.TaggedError('@e2e-tests/ExampleError')<{
 //   readonly message: string;
 // }> {}
+
+// --- Schema Definition ---
+export const UpdatesToNetworkMetric = S.Struct({
+  name: S.Literal('updates_to_networks'),
+  type: S.Literal('COUNTER'),
+  metrics: S.Array(
+    S.Struct({
+      value: S.Number,
+      labels: S.Struct({
+        Network: S.String,
+        FeedId: S.String,
+      }),
+    }),
+  ),
+});
+
+export type UpdatesToNetwork = Record<string, Record<string, number>>;

--- a/apps/e2e-tests/src/utils/metrics/types.ts
+++ b/apps/e2e-tests/src/utils/metrics/types.ts
@@ -6,10 +6,12 @@ const Labels = S.Record({
   value: S.String,
 });
 
-const MetricSchema = S.Struct({
+export const MetricSchema = S.Struct({
   value: S.NumberFromString,
   labels: S.optional(Labels),
 });
+
+export type Metric = typeof MetricSchema.Type;
 
 const MetricType = S.Literal('COUNTER', 'GAUGE', 'HISTOGRAM', 'SUMMARY');
 


### PR DESCRIPTION
[BSN-3296: Tests rely on updates_to_networks  metric instead of waiting  of unspecified to happen](https://coda.io/d/_d6vM0kjfQP6#_tuk5j/r3296&view=full) 