### PR TITLE
fix(nix): Do not set `LD_LIBRARY_PATH` in the rust `devShell`

### DIFF
--- a/nix/modules/blocksense/backends/process-compose.nix
+++ b/nix/modules/blocksense/backends/process-compose.nix
@@ -90,6 +90,7 @@ let
           environment = [
             "RUST_LOG=${log-level}"
             "SPIN_DATA_DIR=$GIT_ROOT/target/spin-artifacts"
+            "LD_LIBRARY_PATH=${lib.makeLibraryPath self'.legacyPackages.commonLibDeps}"
           ];
           depends_on = {
             blocksense-sequencer.condition = "process_healthy";
@@ -121,6 +122,7 @@ let
       environment = [
         "SEQUENCER_CONFIG_DIR=${cfg.config-dir}"
         "SEQUENCER_LOG_LEVEL=${lib.toUpper cfg.sequencer.log-level}"
+        "LD_LIBRARY_PATH=${lib.makeLibraryPath self'.legacyPackages.commonLibDeps}"
       ];
       shutdown.signal = 9;
       depends_on = lib.mapAttrs' (name: value: {

--- a/nix/shells/pkg-sets/rust.nix
+++ b/nix/shells/pkg-sets/rust.nix
@@ -1,15 +1,10 @@
 {
   pkgs,
   self',
-  lib,
   inputs',
   ...
 }:
 {
-  env = {
-    LD_LIBRARY_PATH = lib.makeLibraryPath self'.legacyPackages.commonLibDeps;
-  };
-
   enterShell =
     # bash
     ''


### PR DESCRIPTION
- Leads to the breakage of all in-shell applications which originally
  link to (usually) older versions of the libraries in `LD_LIBRARY_PATH`
  (biggest offender being `nix` itself with `libcurl`)
- Set `LD_LIBRARY_PATH` for the sequencer and reporters manually in the
  `process-compose` configuration
  (they were previously inheriting it from the shell)
