### PR TITLE
[e2e-tests]: Use `getSingleDataAtIndex` at the e2e tests

### DIFF
--- a/apps/e2e-tests/src/process-compose/types.ts
+++ b/apps/e2e-tests/src/process-compose/types.ts
@@ -98,12 +98,13 @@ export class Sequencer extends Context.Tag('@e2e-tests/Sequencer')<
               metric => metric.name === 'updates_to_networks',
             )[0];
 
-            if (!updatesToNetworks)
+            if (!updatesToNetworks) {
               return yield* Effect.fail(
                 new ParseMetricsError({
-                  message: 'No updates_to_networks metric found',
+                  message: `No 'updates_to_networks' metric found in the response from ${metricsUrl}`,
                 }),
               );
+            }
 
             const decoded = S.decodeUnknownSync(UpdatesToNetworkMetric)(
               updatesToNetworks,


### PR DESCRIPTION
[BSN-3326: Use getSingleDataAtIndex at the e2e tests](https://coda.io/d/_d6vM0kjfQP6#_tuk5j/r3326&view=full)