### PR TITLE
[e2e-tests]:  Utilize sequncer round parsing logic

### DIFF
--- a/apps/e2e-tests/src/process-compose/types.ts
+++ b/apps/e2e-tests/src/process-compose/types.ts
@@ -132,6 +132,8 @@ export class Sequencer extends Context.Tag('@e2e-tests/Sequencer')<
   );
 }
 
+export type SequencerService = Context.Tag.Service<Sequencer>;
+
 export class RGLogCheckerError extends Data.TaggedError(
   '@e2e-tests/RGLogCheckerError',
 )<{

--- a/apps/e2e-tests/src/utils/onchain.spec.ts
+++ b/apps/e2e-tests/src/utils/onchain.spec.ts
@@ -1,0 +1,93 @@
+import { Effect } from 'effect';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from '@effect/vitest';
+
+import { AggregatedDataFeedStoreConsumer } from '@blocksense/contracts/viem';
+
+import type { FeedsValueAndRound } from './onchain';
+import { getDataFeedsInfoFromNetwork } from './onchain';
+
+describe('getDataFeedsInfoFromNetwork', () => {
+  const mockConsumer = {
+    getLatestSingleDataAndIndex: vi.fn(),
+    getSingleDataAtIndex: vi.fn(),
+  };
+
+  const data =
+    '0x0000000000000000000000000000000000000a3549cbad30000001986c265bf0';
+  const value = 11223987629360;
+
+  beforeEach(() => {
+    vi.spyOn(
+      AggregatedDataFeedStoreConsumer,
+      'createConsumerByNetworkName',
+    ).mockReturnValue(mockConsumer as any);
+
+    vi.spyOn(
+      AggregatedDataFeedStoreConsumer,
+      'createConsumerByRpcUrl',
+    ).mockReturnValue(mockConsumer as any);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.effect('fetches latest data when roundsInfo is not provided', () =>
+    Effect.gen(function* () {
+      mockConsumer.getLatestSingleDataAndIndex.mockResolvedValue({
+        data,
+        index: 42n,
+      });
+
+      const feedId = 1n;
+
+      const result: FeedsValueAndRound = yield* getDataFeedsInfoFromNetwork(
+        [feedId],
+        '0xabc123',
+        'mainnet',
+      );
+
+      const expected: FeedsValueAndRound = {
+        '1': { value, round: 42 },
+      };
+
+      expect(result).toEqual(expected);
+      expect(mockConsumer.getLatestSingleDataAndIndex).toHaveBeenCalledWith(
+        feedId,
+      );
+    }),
+  );
+
+  it.effect('fetches specific round data when roundsInfo is provided', () =>
+    Effect.gen(function* () {
+      mockConsumer.getSingleDataAtIndex.mockResolvedValue(data);
+
+      const feedId = 2n;
+      const round = 99;
+
+      const result: FeedsValueAndRound = yield* getDataFeedsInfoFromNetwork(
+        [feedId],
+        '0xabc123',
+        'mainnet',
+        { '2': round },
+      );
+
+      const expected: FeedsValueAndRound = {
+        '2': { value, round: 99 },
+      };
+
+      expect(result).toEqual(expected);
+      expect(mockConsumer.getSingleDataAtIndex).toHaveBeenCalledWith(
+        feedId,
+        round,
+      );
+    }),
+  );
+});

--- a/apps/e2e-tests/src/utils/onchain.ts
+++ b/apps/e2e-tests/src/utils/onchain.ts
@@ -1,0 +1,67 @@
+import { Effect } from 'effect';
+
+import type { NetworkName } from '@blocksense/base-utils/evm';
+import { isNetworkName } from '@blocksense/base-utils/evm';
+import { AggregatedDataFeedStoreConsumer } from '@blocksense/contracts/viem';
+
+export type FeedsValueAndRound = Record<
+  string,
+  { value: number; round: number }
+>;
+
+/**
+ * Fetches data feed values and their corresponding round numbers from the blockchain.
+ *
+ * If `roundsInfo` is provided, it fetches data at the specified round for each feed ID.
+ * Otherwise, it fetches the latest data and round index for each feed.
+ *
+ * @param {Array<bigint>} feedIds - List of feed IDs to query.
+ * @param {`0x${string}`} contractAddress - Address of the AggregatedDataFeedStore contract.
+ * @param {NetworkName | string} provider - Either a known network name or an RPC URL.
+ * @param {Record<string, number>} [roundsInfo] - Optional map of feed IDs to specific round numbers.
+ */
+export function getDataFeedsInfoFromNetwork(
+  feedIds: Array<bigint>,
+  contractAddress: `0x${string}`,
+  provider: NetworkName | string,
+  roundsInfo?: Record<string, number>,
+): Effect.Effect<FeedsValueAndRound, Error, never> {
+  return Effect.gen(function* () {
+    const ADFSConsumer = isNetworkName(provider)
+      ? AggregatedDataFeedStoreConsumer.createConsumerByNetworkName(
+          contractAddress,
+          provider,
+        )
+      : AggregatedDataFeedStoreConsumer.createConsumerByRpcUrl(
+          contractAddress,
+          provider!,
+        );
+
+    const feedsInfo: FeedsValueAndRound = {};
+    for (const feedId of feedIds) {
+      const data = yield* Effect.tryPromise(() =>
+        // If round is provided, fetch data at that specific round
+        // Otherwise, fetch the latest data and index
+        roundsInfo !== undefined
+          ? ADFSConsumer.getSingleDataAtIndex(
+              feedId,
+              roundsInfo[feedId.toString()],
+            ).then(res => ({
+              data: res,
+              index: roundsInfo[feedId.toString()],
+            }))
+          : ADFSConsumer.getLatestSingleDataAndIndex(BigInt(feedId)),
+      ).pipe(
+        Effect.mapError(
+          error =>
+            new Error(`Failed to fetch data for feed ${feedId}: ${error}`),
+        ),
+      );
+      feedsInfo[feedId.toString()] = {
+        value: Number(data.data.slice(0, 50)),
+        round: Number(data.index),
+      };
+    }
+    return feedsInfo;
+  });
+}

--- a/libs/ts/contracts/lib/viem/ContractConsumerBase.ts
+++ b/libs/ts/contracts/lib/viem/ContractConsumerBase.ts
@@ -44,9 +44,12 @@ export abstract class ContractConsumerBase {
     contractAddress: Address,
     networkName: NetworkName,
   ): T {
+    const chain = getViemChain(networkName);
     const client = createPublicClient({
-      chain: getViemChain(networkName),
-      transport: http(getRpcUrl(networkName)),
+      chain: chain,
+      transport: chain
+        ? http(chain.rpcUrls.default.http[0])
+        : http(getRpcUrl(networkName)),
     });
     return new this(contractAddress, client);
   }

--- a/nix/test-environments/example-setup-03.nix
+++ b/nix/test-environments/example-setup-03.nix
@@ -58,7 +58,6 @@ in
           private-key-path = "${testKeysDir}/sequencer-private-key";
           transaction-gas-limit = 20000000;
           impersonated-anvil-account = impersonationAddress;
-          should-load-round-counters = false;
           publishing-criteria = [
             {
               feed-id = 50000; # USDT / USD Pegged


### PR DESCRIPTION
## Reflect Sequencer Round Preservation Logic in E2E Tests

### Summary

This PR improves the E2E test suite to reflect the sequencer’s new round-preserving behavior when publishing feed updates. It also introduces a utility to simplify on-chain data retrieval and includes small refactors and internal improvements.

---

### What's Changed

####  Round-Preserving Feed Update Tests and More

* Updated E2E test to expect feed rounds to increase from the initial round rather than being reset.
* Introduced a check that the original round is *not* overwritten after sequencer restart.
* Removed `should-load-round-counters = false` from the test Nix setup to enable proper round loading.
* Assign `sequencer: SequencerService` in beforeAll
* Fetch initial on-chain feeds info in beforeAll to avoid race with local updates
    
      Move retrieval of initial on-chain feed state into the `beforeAll` phase
      via new helper `getInitialFeedsInfoFromNetwork`.
      
      This ensures that by the time `example-setup-03` starts, we already have a
      snapshot of the original network’s state.
      Without this, there’s a race condition where both the original and local
      (anvil) networks may perform updates simultaneously, causing the
      `expect(initialFeedsInfo).toEqual(initialFeedsInfoLocal)` check to fail.
* Skip missing feeds when validating updates

        In the feed update E2E test, handle scenarios where some feeds do not receive
        updates from the sequencer:
        
        - Identify updated feeds via `updatesToNetworks` keys.
        - Log warnings and list missing feed IDs when updates are incomplete.
        - Filter out missing feeds from `initialRounds` and only use `updatedFeedIds`
          when fetching on-chain data.
        
        This prevents the test from failing unnecessarily due to partial feed updates
        while still validating available feeds.
        
Also:
- Added `getInitialFeedsInfoFromNetwork` helper to centralize this logic.
- Validated contract address and feed IDs from sequencer config match those
  from the pre-fetched snapshot ( taken from local config files ).

####  Utilities

* Added `getDataFeedsInfoFromNetwork`, a helper function to fetch feed values and round indices from the chain.

  * Supports both the latest and specific round queries.
  * Includes corresponding unit tests.
* Replaced direct `ADFSConsumer` usage in E2E tests with this utility for better modularity and clarity.

####  Internal Improvements

* Reused `sequencerConfig` and `feedsConfig` across multiple tests to avoid redundant lookups.
* Improved `createConsumerByNetworkName` to fall back to the default RPC for the given network using `viem-chains`.

---

### Follow-ups

* [x] Fix the sequencer to correctly preserve round counters and prevent overwriting. - done in https://github.com/blocksense-network/blocksense/pull/1465
* [x] Revert `.live.fails` back to `.live` once the bug is resolved.
