### PR TITLE
fix(sequencer/feeds_processing): Do not lock providers during results sending to relayers

### DIFF
--- a/apps/sequencer/src/feeds/votes_result_sender.rs
+++ b/apps/sequencer/src/feeds/votes_result_sender.rs
@@ -2,7 +2,9 @@ use crate::providers::eth_send_utils::{
     eth_batch_send_to_all_contracts, get_serialized_updates_for_network,
 };
 use crate::providers::eth_send_utils::{increment_feeds_round_indexes, log_provider_enabled};
-use crate::providers::provider::{GNOSIS_SAFE_CONTRACT_NAME, PRICE_FEED_CONTRACT_NAME};
+use crate::providers::provider::{
+    ProvidersMetrics, GNOSIS_SAFE_CONTRACT_NAME, PRICE_FEED_CONTRACT_NAME,
+};
 use crate::sequencer_state::SequencerState;
 use actix_web::web::Data;
 use alloy::hex::{self, ToHexExt};
@@ -31,6 +33,13 @@ pub async fn votes_result_sender_loop(
         .name("votes_result_sender")
         .spawn(async move {
             let mut batch_count = 0;
+
+            let mut providers_metrics = ProvidersMetrics::new();
+
+            for (net, provider) in sequencer_state.providers.read().await.iter() {
+                providers_metrics.insert(net.clone(), provider.lock().await.provider_metrics.clone());
+            }
+
             loop {
 
                 let send_aggregated_updates_to_publishers = sequencer_state.sequencer_config.read().await.send_aggregated_updates_to_publishers;
@@ -47,7 +56,7 @@ pub async fn votes_result_sender_loop(
                         info!("sending updates to contracts:");
                         let blocksense_block_height = updates.block_height;
                         debug!("Processing eth_batch_send_to_all_contracts{blocksense_block_height}_{batch_count}");
-                        match eth_batch_send_to_all_contracts(&sequencer_state, &updates, Periodic).await {
+                        match eth_batch_send_to_all_contracts(&sequencer_state, &updates, Periodic, Some(&providers_metrics)).await {
                             Ok(()) => info!("Sending updates to relayers complete."),
                             Err(err) => error!("ERROR Sending updates to relayers: {err}"),
                         };
@@ -56,6 +65,7 @@ pub async fn votes_result_sender_loop(
                         try_send_aggregation_consensus_trigger_to_reporters(
                             &sequencer_state,
                             &updates,
+                            Some(&providers_metrics),
                         )
                         .await;
 
@@ -161,6 +171,7 @@ async fn try_send_aggregated_updates_to_publishers(
 async fn try_send_aggregation_consensus_trigger_to_reporters(
     sequencer_state: &Data<SequencerState>,
     updates: &BatchedAggregatesToSend,
+    providers_metrics_opt: Option<&ProvidersMetrics>,
 ) {
     let Some(kafka_endpoint) = &sequencer_state.kafka_endpoint else {
         warn!("No Kafka endpoint set to stream consensus second round data.");
@@ -195,7 +206,13 @@ async fn try_send_aggregation_consensus_trigger_to_reporters(
 
             let is_enabled_value = provider_settings.is_enabled;
 
-            log_provider_enabled(net.as_str(), provider, is_enabled_value).await;
+            if let Some(provider_metrics) =
+                providers_metrics_opt.and_then(|pm| pm.get(net.as_str()))
+            {
+                log_provider_enabled(net.as_str(), provider_metrics, is_enabled_value).await;
+            } else {
+                error!("No metrics found for network {net}");
+            }
 
             if !is_enabled_value {
                 warn!("Network `{net}` is not enabled; skipping it for second round consensus");

--- a/apps/sequencer/src/providers/eth_send_utils.rs
+++ b/apps/sequencer/src/providers/eth_send_utils.rs
@@ -19,8 +19,8 @@ use tokio::{
 
 use crate::{
     providers::provider::{
-        parse_eth_address, ProviderStatus, ProviderType, RpcProvider, SharedRpcProviders,
-        EVENT_FEED_CONTRACT_NAME, PRICE_FEED_CONTRACT_NAME,
+        parse_eth_address, ProviderStatus, ProviderType, ProvidersMetrics, RpcProvider,
+        SharedRpcProviders, EVENT_FEED_CONTRACT_NAME, PRICE_FEED_CONTRACT_NAME,
     },
     sequencer_state::SequencerState,
 };
@@ -346,7 +346,7 @@ pub async fn loop_processing_batch_of_updates(
 #[allow(clippy::too_many_arguments)]
 pub async fn eth_batch_send_to_contract(
     net: String,
-    provider: Arc<Mutex<RpcProvider>>,
+    provider_mutex: Arc<Mutex<RpcProvider>>,
     provider_settings: blocksense_config::Provider,
     mut updates: BatchedAggregatesToSend,
     feed_type: Repeatability,
@@ -358,7 +358,7 @@ pub async fn eth_batch_send_to_contract(
     let mut feeds_rounds = HashMap::new();
     let serialized_updates = get_serialized_updates_for_network(
         net.as_str(),
-        &provider,
+        &provider_mutex,
         &mut updates,
         &provider_settings,
         feeds_config,
@@ -382,7 +382,7 @@ pub async fn eth_batch_send_to_contract(
     );
 
     debug!("Acquiring a read/write lock on provider state for network `{net}` block height {block_height}");
-    let mut provider = provider.lock().await;
+    let mut provider = provider_mutex.lock().await;
     debug!("Acquired a read/write lock on provider state for network `{net}` block height {block_height}");
 
     let feeds_to_update_ids: Vec<FeedId> = updates
@@ -956,15 +956,10 @@ pub async fn log_gas_used(
 
 pub async fn log_provider_enabled(
     net: &str,
-    provider: &Arc<Mutex<RpcProvider>>,
+    provider_metrics: &Arc<RwLock<ProviderMetrics>>,
     is_enabled_value: bool,
 ) {
-    debug!("Acquiring a read lock on provider for network {net}");
-    let p = provider.lock().await;
-    debug!("Acquired a read lock on provider for network {net}");
-    let provider_metrics = p.provider_metrics.clone();
     set_metric!(provider_metrics, net, is_enabled, is_enabled_value);
-    debug!("Released a read lock on provider for network {net}");
 }
 
 pub struct Eip1559GasFees {
@@ -1058,6 +1053,7 @@ pub async fn eth_batch_send_to_all_contracts(
     sequencer_state: &Data<SequencerState>,
     updates: &BatchedAggregatesToSend,
     feed_type: Repeatability,
+    providers_metrics_opt: Option<&ProvidersMetrics>,
 ) -> Result<()> {
     let span = info_span!("eth_batch_send_to_all_contracts");
     let _guard = span.enter();
@@ -1077,25 +1073,10 @@ pub async fn eth_batch_send_to_all_contracts(
         debug!("Acquired a read lock on sequencer_state.sequencer_config");
         let providers_config = &providers_config_guard.providers;
 
-        // No lock, we propagete the shared objects to the created futures
+        // No lock, we propagate the shared objects to the created futures
         let feeds_config = sequencer_state.active_feeds.clone();
 
         for (net, provider) in providers.iter() {
-            let (
-                transaction_retries_count_limit,
-                transaction_retry_timeout_secs,
-                retry_fee_increment_fraction,
-            ) = {
-                debug!("Acquiring a read lock on provider for network {net}");
-                let p = provider.lock().await;
-                debug!("Acquired and releasing a read lock on provider for network {net}");
-                (
-                    p.transaction_retries_count_limit as u64,
-                    p.transaction_retry_timeout_secs as u64,
-                    p.retry_fee_increment_fraction,
-                )
-            };
-
             let net = net.clone();
 
             if let Some(provider_settings) = providers_config.get(&net) {
@@ -1107,7 +1088,13 @@ pub async fn eth_batch_send_to_all_contracts(
                 }
                 let is_enabled_value = provider_settings.is_enabled;
 
-                log_provider_enabled(net.as_str(), provider, is_enabled_value).await;
+                if let Some(provider_metrics) =
+                    providers_metrics_opt.and_then(|pm| pm.get(net.as_str()))
+                {
+                    log_provider_enabled(net.as_str(), provider_metrics, is_enabled_value).await;
+                } else {
+                    error!("No metrics found for network {net}");
+                }
 
                 if !is_enabled_value {
                     warn!("Network `{net}` is not enabled; skipping it during reporting");
@@ -1115,6 +1102,18 @@ pub async fn eth_batch_send_to_all_contracts(
                 } else {
                     info!("Network `{net}` is enabled; reporting...");
                 }
+
+                let (
+                    transaction_retries_count_limit,
+                    transaction_retry_timeout_secs,
+                    retry_fee_increment_fraction,
+                ) = {
+                    (
+                        provider_settings.transaction_retries_count_limit as u64,
+                        provider_settings.transaction_retry_timeout_secs as u64,
+                        provider_settings.retry_fee_increment_fraction,
+                    )
+                };
 
                 let updates = updates.clone();
                 let provider = provider.clone();
@@ -1600,7 +1599,8 @@ mod tests {
         };
 
         let result =
-            eth_batch_send_to_all_contracts(&sequencer_state, &updates_oneshot, Oneshot).await;
+            eth_batch_send_to_all_contracts(&sequencer_state, &updates_oneshot, Oneshot, None)
+                .await;
         // TODO: This is actually not a good assertion since the eth_batch_send_to_all_contracts
         // will always return ok even if some or all of the sends we unsuccessful. Will be fixed in
         // followups
@@ -1717,13 +1717,16 @@ mod tests {
                 updates: vec![v3],
             };
 
-            let p1 = eth_batch_send_to_all_contracts(&sequencer_state, &updates1, Periodic).await;
+            let p1 =
+                eth_batch_send_to_all_contracts(&sequencer_state, &updates1, Periodic, None).await;
             assert!(p1.is_ok());
 
-            let p2 = eth_batch_send_to_all_contracts(&sequencer_state, &updates2, Periodic).await;
+            let p2 =
+                eth_batch_send_to_all_contracts(&sequencer_state, &updates2, Periodic, None).await;
             assert!(p2.is_ok());
 
-            let p3 = eth_batch_send_to_all_contracts(&sequencer_state, &updates3, Periodic).await;
+            let p3 =
+                eth_batch_send_to_all_contracts(&sequencer_state, &updates3, Periodic, None).await;
             assert!(p3.is_ok());
         }
 

--- a/apps/sequencer/src/providers/provider.rs
+++ b/apps/sequencer/src/providers/provider.rs
@@ -92,6 +92,7 @@ pub enum ProviderStatus {
 }
 
 pub type SharedRpcProviders = Arc<RwLock<HashMap<String, Arc<Mutex<RpcProvider>>>>>;
+pub type ProvidersMetrics = HashMap<String, Arc<RwLock<ProviderMetrics>>>;
 
 pub async fn init_shared_rpc_providers(
     conf: &SequencerConfig,


### PR DESCRIPTION
In the flow of distributing the updates per network relayer we had a locking of the provider mutex-es, which was causing an unnecessary sync point with transaction sending, causing bottle neck in the case a given network relayer enters transaction retry mechanism.