### PR TITLE
[e2e-tests]: Refactor `getMetrics` function to have `HttpClient` as third Effect parameter

### DIFF
--- a/apps/e2e-tests/src/process-compose/types.ts
+++ b/apps/e2e-tests/src/process-compose/types.ts
@@ -13,6 +13,7 @@ import type { NewFeedsConfig } from '@blocksense/config-types';
 import { NewFeedsConfigSchema } from '@blocksense/config-types';
 import type { HttpClientError } from '@effect/platform/HttpClientError';
 import { ParseMetricsError, getMetrics } from '../utils/metrics';
+import { FetchHttpClient } from '@effect/platform';
 
 export class ProcessCompose extends Context.Tag('@e2e-tests/ProcessCompose')<
   ProcessCompose,
@@ -93,7 +94,9 @@ export class Sequencer extends Context.Tag('@e2e-tests/Sequencer')<
           }),
         fetchUpdatesToNetworksMetric: () => {
           return Effect.gen(function* () {
-            const metrics = yield* getMetrics(metricsUrl);
+            const metrics = yield* getMetrics(metricsUrl).pipe(
+              Effect.provide(FetchHttpClient.layer),
+            );
             const updatesToNetworks = metrics.filter(
               metric => metric.name === 'updates_to_networks',
             )[0];

--- a/apps/e2e-tests/src/utils/metrics/metrics-fetcher.spec.ts
+++ b/apps/e2e-tests/src/utils/metrics/metrics-fetcher.spec.ts
@@ -1,11 +1,11 @@
 import { Effect } from 'effect';
-import { afterAll, describe, expect, it, vi } from '@effect/vitest';
-import { HttpClientError } from '@effect/platform';
+import { afterAll, expect, it, vi } from '@effect/vitest';
+import { FetchHttpClient, HttpClientError } from '@effect/platform';
 
 import { getMetrics } from './metrics-fetcher';
 import { ParseMetricsError } from './types';
 
-describe('Metrics fetcher tests', () => {
+it.layer(FetchHttpClient.layer)('Metrics fetcher tests', it => {
   const test_url = 'http://localhost:8080/metrics';
 
   afterAll(() => {

--- a/apps/e2e-tests/src/utils/metrics/metrics-fetcher.ts
+++ b/apps/e2e-tests/src/utils/metrics/metrics-fetcher.ts
@@ -1,7 +1,7 @@
 import { Effect, Schema as S } from 'effect';
 import type { ParseError } from 'effect/ParseResult';
 import type { HttpClientError } from '@effect/platform';
-import { FetchHttpClient, HttpClientRequest } from '@effect/platform';
+import { HttpClientRequest } from '@effect/platform';
 import { HttpClient } from '@effect/platform/HttpClient';
 import parsePrometheusTextFormat from 'parse-prometheus-text-format';
 
@@ -12,7 +12,8 @@ export const getMetrics = (
   url: string,
 ): Effect.Effect<
   PrometheusMetrics,
-  ParseMetricsError | HttpClientError.HttpClientError | ParseError
+  ParseMetricsError | HttpClientError.HttpClientError | ParseError,
+  HttpClient
 > => {
   return Effect.gen(function* () {
     const client = yield* HttpClient;
@@ -32,5 +33,5 @@ export const getMetrics = (
     );
 
     return decodedMetrics;
-  }).pipe(Effect.provide(FetchHttpClient.layer));
+  });
 };


### PR DESCRIPTION
## [BSN-3345: Refactor getMetrics function to have HttpClient as third effect  parameter](https://coda.io/d/_d6vM0kjfQP6#_tuk5j/r3345&view=full)
## Summary

Refactored the `getMetrics` function in **e2e-tests** to accept `HttpClient` as its third `Effect` parameter instead of directly providing `FetchHttpClient.layer` internally.

### Changes
- Updated `getMetrics` signature to require `HttpClient` via dependency injection.
- Removed internal `FetchHttpClient.layer` provisioning from `metrics-fetcher.ts`.
- Adjusted `ProcessCompose` and related tests to explicitly provide `FetchHttpClient.layer` when calling `getMetrics`.
- Updated imports to include `FetchHttpClient` where needed.

### Motivation
This change improves testability and flexibility by allowing different `HttpClient` implementations to be injected into `getMetrics` without modifying the function itself which preserves the dependency injection mechanism.
