### PR TITLE
[e2e-tests]: Compare network values to the values from `get_history` endpoint

### DIFF
--- a/apps/e2e-tests/src/process-compose/e2e.spec.ts
+++ b/apps/e2e-tests/src/process-compose/e2e.spec.ts
@@ -194,6 +194,8 @@ describe.sequential('E2E Tests with process-compose', () => {
         ),
       );
 
+      const historyData = yield* sequencer.fetchHistory();
+
       // Make sure that the feeds info is updated
       for (const [id, data] of entriesOf(currentFeedsInfo)) {
         const { round, value } = data;
@@ -205,6 +207,14 @@ describe.sequential('E2E Tests with process-compose', () => {
           continue;
         }
         expect(value).not.toEqual(initialFeedsInfo[id].value);
+
+        const actualData = historyData.aggregate_history[id].find(
+          feed => feed.update_number === round - initialFeedsInfo[id].round - 1,
+        );
+        const decimals = feedsConfig.feeds.find(f => f.id.toString() === id)!
+          .additional_feed_info.decimals;
+
+        expect(value / 10 ** decimals).toBeCloseTo(actualData!.value.Numerical);
       }
     }),
   );


### PR DESCRIPTION
## Description

Add `fetchHistory` method to the `Sequencer` service and enhance E2E tests to validate feed values against data from the `/get_history` endpoint.

### Changes
- **Sequencer Service**
  - Added `fetchHistory` method for retrieving aggregated feed history.
  - Introduced `FeedAggregateHistorySchema` for type-safe parsing of history data.
  - Integrated `fetchAndDecodeJSONEffect` for history data fetching.

- **E2E Tests**
  - Updated tests to compare current feed values with corresponding historical values.
  - Applied proper decimal handling during value comparison.
  
[BSN-3328: Compare network values to the result of get_history endpoint](https://coda.io/d/_d6vM0kjfQP6#_tu4Kik5j/r3328&view=full)