### PR TITLE
[config-types]: Use strict imports from `config-types`

### DIFF
--- a/libs/ts/config-types/package.json
+++ b/libs/ts/config-types/package.json
@@ -32,6 +32,11 @@
       "require": "./dist/cjs/dfcg/artifacts/index.cjs",
       "import": "./dist/esm/dfcg/artifacts/index.mjs",
       "types": "./src/dfcg/artifacts/index.ts"
+    },
+    "./read-write-config": {
+      "require": "./dist/cjs/read-write-config.cjs",
+      "import": "./dist/esm/read-write-config.mjs",
+      "types": "./src/read-write-config.ts"
     }
   },
   "scripts": {

--- a/libs/ts/contracts/tasks/add-signer-to-multisig.ts
+++ b/libs/ts/contracts/tasks/add-signer-to-multisig.ts
@@ -7,7 +7,7 @@ import {
   EthereumAddress,
   parseEthereumAddress,
 } from '@blocksense/base-utils';
-import { readEvmDeployment } from '@blocksense/config-types';
+import { readEvmDeployment } from '@blocksense/config-types/read-write-config';
 
 import { initChain } from './deployment-utils/init-chain';
 import { executeMultisigTransaction } from './deployment-utils/multisig-tx-exec';

--- a/libs/ts/contracts/tasks/ms-change-sequencer.ts
+++ b/libs/ts/contracts/tasks/ms-change-sequencer.ts
@@ -7,7 +7,7 @@ import {
   OperationType,
   SafeTransactionDataPartial,
 } from '@safe-global/safe-core-sdk-types';
-import { readEvmDeployment } from '@blocksense/config-types';
+import { readEvmDeployment } from '@blocksense/config-types/read-write-config';
 import { initChain } from './deployment-utils/init-chain';
 import { solidityPacked, toBeArray } from 'ethers';
 import { adjustVInSignature } from './utils';

--- a/libs/ts/contracts/tasks/multichain-deploy.ts
+++ b/libs/ts/contracts/tasks/multichain-deploy.ts
@@ -17,7 +17,10 @@ import { padNumber } from '@blocksense/base-utils/string';
 import { readline } from '@blocksense/base-utils/tty';
 
 import { DeploymentConfigV2 } from '@blocksense/config-types/evm-contracts-deployment';
-import { readConfig, writeEvmDeployment } from '@blocksense/config-types';
+import {
+  readConfig,
+  writeEvmDeployment,
+} from '@blocksense/config-types/read-write-config';
 
 import { NetworkConfig, ContractNames, DeployContract } from './types';
 import { predictAddress } from './utils';

--- a/libs/ts/contracts/tasks/test-multichain-deploy.ts
+++ b/libs/ts/contracts/tasks/test-multichain-deploy.ts
@@ -6,7 +6,10 @@ import { OperationType } from '@safe-global/safe-core-sdk-types';
 
 import { ContractNames } from './types';
 
-import { readEvmDeployment, readConfig } from '@blocksense/config-types';
+import {
+  readEvmDeployment,
+  readConfig,
+} from '@blocksense/config-types/read-write-config';
 import { encodeDataAndTimestamp } from '../test/utils/helpers/common';
 import { Feed, WriteOp } from '../test/utils/wrappers/types';
 

--- a/libs/ts/contracts/tasks/verify.ts
+++ b/libs/ts/contracts/tasks/verify.ts
@@ -7,7 +7,7 @@ import {
   sleep,
 } from '@blocksense/base-utils';
 
-import { readEvmDeployment } from '@blocksense/config-types';
+import { readEvmDeployment } from '@blocksense/config-types/read-write-config';
 import { ZeroAddress } from 'ethers';
 
 import { binarySearch, getApiKeys, getCustomChainConfig } from './utils';


### PR DESCRIPTION
### Description
Fixing an issue where hardhat is incompatible with the new modules introduced in the following [commit](https://github.com/blocksense-network/blocksense/commit/121b85838c42ab514cafc2ee9038c6302fddb379).

**Note: We should use full path for imports.**

### Testing
On root level:
```
just clean
yarn
cd libs/ts/contracts
yarn hardhat run ./scripts/chainlink-event-fetcher.ts
```

### Error
<img width="828" height="212" alt="Screenshot 2025-08-19 at 18 11 17" src="https://github.com/user-attachments/assets/f126cef6-e1a3-4339-9d5f-fb0a9efcd094" />

### Fix - result
<img width="1000" height="28" alt="Screenshot 2025-08-20 at 8 38 46" src="https://github.com/user-attachments/assets/5c322225-89b4-4faf-aadc-e2afbfff2136" />
