### PR TITLE
Fix oracle scripts

### DIFF
--- a/apps/oracles/eth-rpc/src/lib.rs
+++ b/apps/oracles/eth-rpc/src/lib.rs
@@ -200,7 +200,7 @@ impl Contract {
                     None => break,
                 };
                 if let Ok(mut value) =
-                    http_post_json::<RequestEthCall, ResponseEthCall>(rpc_url.as_str(), eth_call, timeout_secs)
+                    http_post_json::<RequestEthCall, ResponseEthCall>(rpc_url.as_str(), eth_call, Some(timeout_secs))
                         .await
                 {
                     value.rpc_url = Some(rpc_url_candidate.clone());

--- a/apps/oracles/gecko-terminal/src/lib.rs
+++ b/apps/oracles/gecko-terminal/src/lib.rs
@@ -114,7 +114,7 @@ async fn fetch_pools_data_for_network(
         .join(",");
     let url = format!("https://api.geckoterminal.com/api/v2/networks/{network}/pools/multi/{r}");
 
-    let mut value = http_get_json::<GeckoTerminalMultipleResponce>(&url, None, None, timeout_secs).await?;
+    let mut value = http_get_json::<GeckoTerminalMultipleResponce>(&url, None, None, Some(timeout_secs)).await?;
     for v in value.data.iter_mut() {
         if let Some(p) = pools
             .iter()

--- a/apps/oracles/spout-rwa/src/lib.rs
+++ b/apps/oracles/spout-rwa/src/lib.rs
@@ -27,7 +27,7 @@ async fn oracle_request(settings: Settings) -> Result<Payload> {
         url.as_str(),
         None,
         Some(&[("X-API-Key", api_key.as_str())]),
-        timeout_secs,
+        Some(timeout_secs),
     ).await?;
 
     if resources.arguments.endpoint == "reserve" {
@@ -73,4 +73,3 @@ fn get_resources_from_settings(settings: &Settings) -> Result<ResourceData> {
         .and_then(|feed| serde_json::from_str::<ResourceData>(&feed.data).ok())
         .ok_or_else(|| anyhow::anyhow!("Couldn't parse resource data from settings"))
 }
-

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/binance.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/binance.rs
@@ -45,7 +45,7 @@ impl<'a> PricesFetcher<'a> for BinancePriceFetcher<'a> {
                 "https://api1.binance.com/api/v3/ticker/24hr",
                 Some(&[("symbols", req_symbols.as_str())]),
                 None,
-                timeout_secs,
+                Some(timeout_secs),
             )
             .await?;
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/binance_us.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/binance_us.rs
@@ -45,7 +45,7 @@ impl<'a> PricesFetcher<'a> for BinanceUsPriceFetcher<'a> {
                 "https://api.binance.us/api/v3/ticker/24hr",
                 Some(&[("symbols", req_symbols.as_str())]),
                 None,
-                timeout_secs,
+                Some(timeout_secs),
             )
             .await?;
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/bitfinex.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/bitfinex.rs
@@ -62,7 +62,7 @@ impl<'a> PricesFetcher<'a> for BitfinexPriceFetcher<'a> {
                 "https://api-pub.bitfinex.com/v2/tickers",
                 Some(&[("symbols", all_symbols.as_str())]),
                 None,
-                timeout_secs,
+                Some(timeout_secs),
             )
             .await?;
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/bitget.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/bitget.rs
@@ -40,7 +40,7 @@ impl PricesFetcher<'_> for BitgetPriceFetcher {
                 "https://api.bitget.com/api/spot/v1/market/tickers",
                 None,
                 None,
-                timeout_secs,
+                Some(timeout_secs),
             )
             .await?;
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/bybit.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/bybit.rs
@@ -48,7 +48,7 @@ impl PricesFetcher<'_> for BybitPriceFetcher {
                 "https://api.bybit.com/v5/market/tickers",
                 Some(&[("category", "spot"), ("symbols", "")]),
                 None,
-                timeout_secs,
+                Some(timeout_secs),
             )
             .await?;
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/coinbase.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/coinbase.rs
@@ -51,9 +51,13 @@ impl<'a> PricesFetcher<'a> for CoinbasePriceFetcher<'a> {
                         prices.insert(symbol, price_pint);
                     }
                     Err(err) => {
-                        anyhow::bail!("Error processing future in CoinbasePriceFetcher {err:?}")
+                        eprintln!("Error processing future in CoinbasePriceFetcher {err:?}")
                     }
                 }
+            }
+
+            if prices.is_empty() {
+                anyhow::bail!("No prices fetched from Coinbase");
             }
 
             Ok(prices)

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/coinbase.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/coinbase.rs
@@ -70,7 +70,8 @@ pub async fn fetch_price_for_symbol(
     timeout_secs: u64,
 ) -> Result<(String, PricePoint)> {
     let url = format!("https://api.exchange.coinbase.com/products/{symbol}/ticker");
-    let response = http_get_json::<CoinbasePriceResponse>(&url, None, None, timeout_secs).await?;
+    let response =
+        http_get_json::<CoinbasePriceResponse>(&url, None, None, Some(timeout_secs)).await?;
 
     Ok((
         symbol.to_string().replace("-", ""),

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/crypto_com_exchange.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/crypto_com_exchange.rs
@@ -45,7 +45,7 @@ impl PricesFetcher<'_> for CryptoComPriceFetcher {
                 "https://api.crypto.com/exchange/v1/public/get-tickers",
                 None,
                 None,
-                timeout_secs,
+                Some(timeout_secs),
             )
             .await?;
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/gate_io.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/gate_io.rs
@@ -36,7 +36,7 @@ impl PricesFetcher<'_> for GateIoPriceFetcher {
                 "https://api.gateio.ws/api/v4/spot/tickers",
                 None,
                 None,
-                timeout_secs,
+                Some(timeout_secs),
             )
             .await?;
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/gemini.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/gemini.rs
@@ -70,7 +70,8 @@ pub async fn fetch_price_for_symbol(
     timeout_secs: u64,
 ) -> Result<(String, PricePoint)> {
     let url = format!("https://api.gemini.com/v1/pubticker/{symbol}");
-    let response = http_get_json::<GeminiPriceResponse>(&url, None, None, timeout_secs).await?;
+    let response =
+        http_get_json::<GeminiPriceResponse>(&url, None, None, Some(timeout_secs)).await?;
 
     let volume_data = response
         .volume

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/gemini.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/gemini.rs
@@ -50,9 +50,13 @@ impl<'a> PricesFetcher<'a> for GeminiPriceFetcher<'a> {
                         prices.insert(symbol, price_pint);
                     }
                     Err(err) => {
-                        anyhow::bail!("Error processing future in GeminiPriceFetcher {err:?}")
+                        eprintln!("Error processing future in GeminiPriceFetcher {err:?}")
                     }
                 }
+            }
+
+            if prices.is_empty() {
+                anyhow::bail!("No prices fetched from Gemini");
             }
 
             Ok(prices)

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/kraken.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/kraken.rs
@@ -50,7 +50,7 @@ impl PricesFetcher<'_> for KrakenPriceFetcher {
                 "https://api.kraken.com/0/public/Ticker",
                 None,
                 None,
-                timeout_secs,
+                Some(timeout_secs),
             )
             .await?;
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/kucoin.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/kucoin.rs
@@ -59,7 +59,7 @@ impl PricesFetcher<'_> for KuCoinPriceFetcher {
                 "https://api.kucoin.com/api/v1/market/allTickers",
                 None,
                 None,
-                timeout_secs,
+                Some(timeout_secs),
             )
             .await?;
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/mexc.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/mexc.rs
@@ -37,7 +37,7 @@ impl PricesFetcher<'_> for MEXCPriceFetcher {
                 "https://api.mexc.com/api/v3/ticker/24hr",
                 None,
                 None,
-                timeout_secs,
+                Some(timeout_secs),
             )
             .await?;
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/okx.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/okx.rs
@@ -41,7 +41,7 @@ impl PricesFetcher<'_> for OKXPriceFetcher {
                 "https://www.okx.com/api/v5/market/tickers",
                 Some(&[("instType", "SPOT")]),
                 None,
-                timeout_secs,
+                Some(timeout_secs),
             )
             .await?;
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/exchanges/upbit.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/exchanges/upbit.rs
@@ -36,7 +36,7 @@ impl<'a> PricesFetcher<'a> for UpBitPriceFetcher<'a> {
                 "https://api.upbit.com/v1/ticker",
                 Some(&[("markets", all_markets.as_str())]),
                 None,
-                timeout_secs,
+                Some(timeout_secs),
             )
             .await?;
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/stock_markets/alpaca_markets.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/stock_markets/alpaca_markets.rs
@@ -71,7 +71,7 @@ impl<'a> PricesFetcher<'a> for AlpacaMarketsPriceFetcher<'a> {
                     ("APCA-API-KEY-ID", api_key_id),
                     ("APCA-API-SECRET-KEY", api_secret_key),
                 ]),
-                timeout_secs,
+                Some(timeout_secs),
             )
             .await?;
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/stock_markets/alpha_vantage.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/stock_markets/alpha_vantage.rs
@@ -53,7 +53,7 @@ impl<'a> PricesFetcher<'a> for AlphaVantagePriceFetcher<'a> {
                 "https://www.alphavantage.co/query?function=REALTIME_BULK_QUOTES",
                 Some(&[("symbol", &all_symbols), ("apikey", api_key)]),
                 None,
-                timeout_secs,
+                Some(timeout_secs),
             )
             .await?;
             let results = response

--- a/libs/data_providers_sdk/src/price_data/fetchers/stock_markets/fmp.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/stock_markets/fmp.rs
@@ -50,7 +50,7 @@ impl<'a> PricesFetcher<'a> for FMPPriceFetcher<'a> {
                 format!("https://financialmodelingprep.com/api/v3/quote/{all_symbols}").as_str(),
                 Some(&[("apikey", api_key)]),
                 None,
-                timeout_secs,
+                Some(timeout_secs),
             )
             .await?;
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/stock_markets/twelvedata.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/stock_markets/twelvedata.rs
@@ -46,7 +46,7 @@ impl<'a> PricesFetcher<'a> for TwelveDataPriceFetcher<'a> {
                 "https://api.twelvedata.com/quote",
                 Some(&[("symbol", &all_symbols)]),
                 Some(&[("Authorization", format!("apikey {api_key}").as_str())]),
-                timeout_secs,
+                Some(timeout_secs),
             )
             .await?;
 

--- a/libs/data_providers_sdk/src/price_data/fetchers/stock_markets/yahoo_finance.rs
+++ b/libs/data_providers_sdk/src/price_data/fetchers/stock_markets/yahoo_finance.rs
@@ -58,7 +58,7 @@ impl<'a> PricesFetcher<'a> for YFPriceFetcher<'a> {
                 "https://yfapi.net/v6/finance/quote",
                 Some(&[("symbols", all_symbols.as_str())]),
                 Some(&[("x-api-key", api_key)]),
-                timeout_secs,
+                Some(timeout_secs),
             )
             .await?;
 

--- a/libs/sdk/src/http.rs
+++ b/libs/sdk/src/http.rs
@@ -8,6 +8,8 @@ use url::Url;
 pub type QueryParam<'a, 'b> = (&'a str, &'b str);
 pub type HeaderParam<'a, 'b> = (&'a str, &'b str);
 
+const HTTP_USER_AGENT: &str = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
 #[derive(Debug, Serialize)]
 struct Params {
     seconds: u64,
@@ -20,32 +22,42 @@ pub fn prepare_get_request(
     forward_url: &str,
     params: Option<&[QueryParam<'_, '_>]>,
     headers: Option<&[HeaderParam<'_, '_>]>,
-    timeout_secs: u64,
+    timeout_secs: Option<u64>,
 ) -> Result<Request> {
-    let base_url = "http://127.0.0.1:3000";
+    let mut req = Request::builder();
+
     let forward_url_and_params = match params {
         Some(p) => Url::parse_with_params(forward_url, p)?,
         None => Url::parse(forward_url)?,
     };
-
-    let mut req = Request::builder();
-    req.method(Method::Post);
-    req.uri(base_url);
 
     if let Some(hdrs) = headers {
         for (key, value) in hdrs {
             req.header(*key, *value);
         }
     }
+    req.header("Accepts", "application/json");
+    req.header("User-Agent", HTTP_USER_AGENT);
 
-    let payload = Params {
-        endpoint_url: forward_url_and_params.to_string(),
-        seconds: timeout_secs,
-        request_method: "GET".to_string(),
-        request_body: None,
+    match timeout_secs {
+        Some(timeout_secs) => {
+            req.method(Method::Post);
+            req.uri("http://127.0.0.1:3000");
+
+            let payload = Params {
+                endpoint_url: forward_url_and_params.to_string(),
+                seconds: timeout_secs,
+                request_method: "GET".to_string(),
+                request_body: None,
+            };
+
+            req.body(serde_json::to_string(&payload).unwrap());
+        }
+        None => {
+            req.method(Method::Get);
+            req.uri(forward_url_and_params.as_str());
+        }
     };
-
-    req.body(serde_json::to_string(&payload).unwrap());
 
     Ok(req.build())
 }
@@ -54,7 +66,7 @@ pub async fn http_get_json<T>(
     url: &str,
     params: Option<&[QueryParam<'_, '_>]>,
     headers: Option<&[HeaderParam<'_, '_>]>,
-    timeout_secs: u64,
+    timeout_secs: Option<u64>,
 ) -> Result<T>
 where
     T: DeserializeOwned,
@@ -76,32 +88,46 @@ where
 pub fn prepare_post_request<U>(
     forward_url: &str,
     request_json: U,
-    timeout_secs: u64,
+    timeout_secs: Option<u64>,
 ) -> Result<Request>
 where
     U: Serialize,
 {
     let request_body = serde_json::to_string(&request_json)?;
 
-    let base_url = "http://127.0.0.1:3000";
-
     let mut req = Request::builder();
     req.method(Method::Post);
-    req.uri(base_url);
 
-    let payload = Params {
-        endpoint_url: forward_url.to_string(),
-        seconds: timeout_secs,
-        request_method: "POST".to_string(),
-        request_body: Some(request_body),
+    req.header("Content-Type", "application/json");
+    req.header("User-Agent", HTTP_USER_AGENT);
+
+    match timeout_secs {
+        Some(timeout_secs) => {
+            req.uri("http://127.0.0.1:3000");
+
+            let payload = Params {
+                endpoint_url: forward_url.to_string(),
+                seconds: timeout_secs,
+                request_method: "POST".to_string(),
+                request_body: Some(request_body),
+            };
+
+            req.body(serde_json::to_string(&payload).unwrap());
+        }
+        None => {
+            req.uri(Url::parse(forward_url)?.as_str());
+            req.body(request_body);
+        }
     };
-
-    req.body(serde_json::to_string(&payload).unwrap());
 
     Ok(req.build())
 }
 
-pub async fn http_post_json<U, T>(url: &str, request_json: U, timeout_secs: u64) -> Result<T>
+pub async fn http_post_json<U, T>(
+    url: &str,
+    request_json: U,
+    timeout_secs: Option<u64>,
+) -> Result<T>
 where
     T: DeserializeOwned,
     U: Serialize,


### PR DESCRIPTION
* Make error handling in Coinbase and Gemini better: `bail!` if no prices fetched, log otherwise
* Don't log `payload.endpoint_url` in trigger oracle timing out proxy, but only the scheme and host of the url
* Optional use proxy for http_get_json & http_post_json in `sdk/http.rs`