### PR TITLE
[nix/just]: Revert Justfile change of removing `--impure` and handle empty available-ports

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -47,10 +47,9 @@ build-environment environment="all" use-local-cargo-result="0":
   # Collect free ports that process-compose will use
   mkdir -p "$DEST_DIR"
   scripts/utils/collect-available-ports.sh "$DEST_DIR/available-ports"
-  git add --intent-to-add --force "$DEST_DIR/available-ports"
 
   SRC_DIR=$(
-    nix build --no-warn-dirty -L --print-out-paths \
+    nix build --no-warn-dirty --impure -L --print-out-paths \
       .#${FLAKE_ATTR_PATH} \
       2> >(grep -v '^Using saved setting for' >&2)
   )

--- a/nix/test-environments/example-setup-03.nix
+++ b/nix/test-environments/example-setup-03.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   ...
 }:
@@ -20,7 +21,7 @@ let
 
   availablePorts =
     let
-      filePath = lib.path.append root "config/generated/process-compose/available-ports";
+      filePath = "${config.devenv.root}/config/generated/process-compose/example-setup-03/available-ports";
       ports = if builtins.pathExists filePath then readPortsFromFile filePath else [ ];
     in
     if builtins.length ports > 0 then ports else [ 8547 ];

--- a/nix/test-environments/example-setup-03.nix
+++ b/nix/test-environments/example-setup-03.nix
@@ -21,9 +21,9 @@ let
   availablePorts =
     let
       filePath = lib.path.append root "config/generated/process-compose/available-ports";
+      ports = if builtins.pathExists filePath then readPortsFromFile filePath else [ ];
     in
-    if builtins.pathExists filePath then readPortsFromFile filePath else [ 8547 ];
-
+    if builtins.length ports > 0 then ports else [ 8547 ];
   testKeysDir = lib.path.append root "nix/test-environments/test-keys";
   deploymentV2FilePath = lib.path.append root "config/evm_contracts_deployment_v2/ink-sepolia.json";
 


### PR DESCRIPTION
### Summary

This PR reverts a previous change that caused issues with process-compose port handling and adds a safeguard for empty `available-ports` files.

### Changes

1. **Justfile**

   * **Reverts commit `48151c2`** to fix unwanted port file behaviour.
   * Drops unnecessary `git add` of the generated `available-ports` file.
   * Adds `--impure` to `nix eval` and `nix build` so environments resolve correctly.
     * This is a **temporary workaround** until we implement a proper port parsing solution.

2. **example-setup-03.nix**

   * Reads ports from the generated `available-ports` file.
   * Falls back to `[8547]` only when the file is empty, not just missing.
   * Prevents environments from silently failing when the file exists but has no entries.