### PR TITLE
fix(just): Fix `just start-oracle` command and add `trigger-oracle-build-type` option

### DIFF
--- a/scripts/install_trigger_oracle_plugin.sh
+++ b/scripts/install_trigger_oracle_plugin.sh
@@ -2,7 +2,20 @@
 
 set -euo pipefail
 
-SPIN_DATA_DIR="$GIT_ROOT/target/spin-artifacts"
+RESET="\033[0m"
+BOLD="\033[1m"
+NOBOLD="\033[22m"
+RED="\033[31m"
+
+if [[ -z "${SPIN:-}" ]] || [[ -z "${SPIN_DATA_DIR:-}" ]]; then
+  echo -e "${RED}${BOLD}SPIN${NOBOLD} and ${BOLD}SPIN_DATA_DIR${NOBOLD} environment variables must be set.${RESET}"
+  echo
+  echo -e "This script is intended to be run from the Justfile:"
+  echo
+  echo -e "    ${BOLD}just start-oracle <oracle-name> --use-local-cargo-artifacts${RESET}"
+  exit 1
+fi
+
 mkdir -p $SPIN_DATA_DIR
 
 IFS='-' read -r ARCH OS <<<$($GIT_ROOT/scripts/get-host-arch-and-os.sh)
@@ -36,4 +49,4 @@ cat >$MANIFEST_PATH <<EOF
 }
 EOF
 
-SPIN_DATA_DIR="$SPIN_DATA_DIR" nix run .#spinUnwrapped -- plugin install --file $MANIFEST_PATH --yes
+"$SPIN" plugin install --file "$MANIFEST_PATH" --yes


### PR DESCRIPTION
Introduce `--use-local-cargo-artifacts` and `--hermetic` options to `just start-oracle` enabling faster local iteration with a minimally wrapped spin binary and locally built trigger-oracle plugin.

### Refactor Nix Flake outputs:
* Replace `spinUnwrapped` with `spin` - a minimally wrapped (with LD_LIBRARY_PATH only) package for local development
* Keep fully wrapped `spinWrapped` with Nix-managed plugin dir (production) but base it on new `spin` package

### Update start-oracle recipe:
* Parameterize build type (default `--use-local-cargo-artifacts`)
* Automatically build blocksense + set `SPIN`/`SPIN_DATA_DIR` when using local artifacts

### Harden trigger oracle plugin install script:
* Require SPIN and SPIN_DATA_DIR env vars to be passed from `just`
* fail fast with guidance if the script is ran manually

### Usage:

    # This command build the node software with Cargo and
    # then runs the oracle script:
    just start-oracle <oracle-name>
    # (
    #   the above command is an alias for:
    #   just start-oracle <oracle-name> --use-local-cargo-artifacts
    # )

    # This command build the node software with Nix and
    # then runs the oracle script:
    just start-oracle <oracle-name> --hermetic
    
### Timings


| build mode | no changes | changes to oracle script | changes to trigger-oracle |
|--------|--------|--------|--------|
| `--hermetic` | 0.41s | ~60sec | ~60sec |
| `--use-local-cargo-artifacts` | 2.56s | 4.5sec | 34.69sec | 
