### PR TITLE
build(nix/shells): Drop `spin` from `rust` (and `default`) shells

### DIFF
--- a/nix/shells/pkg-sets/rust.nix
+++ b/nix/shells/pkg-sets/rust.nix
@@ -15,7 +15,6 @@
 
   packages = self'.packages.blocksense-rs.buildInputs ++ [
     self'.legacyPackages.cargoWrapped
-    self'.legacyPackages.spinWrapped
     self'.legacyPackages.rustToolchain
     pkgs.cargo-tarpaulin
   ];


### PR DESCRIPTION
Remove `spinWrapped` from `rust.nix` to slim the dev environment. Inject
its `PATH` only for reporter processes (when not using local cargo
result) in process-compose.nix. Also drop unused blama inherit.

Benefits:

* Smaller closure / faster nix develop
* Fewer implicit tools in base shell
* Keeps reporter workflow working via conditional PATH injection


## Testing

* `direnv reload`
* `just start-environment example-setup-01`
* `just start-oracle cex-price-feeds --hermetic`
* `just start-oracle cex-price-feeds --use-local-cargo-artifacts`

## If for some reason you need to use `spin` directly

```
nix run $GIT_ROOT#spinWrapped
```
