### PR TITLE
[base-utils/tty/getTextWidth]: Fix compatibility with hardhat (ts-node)

### DIFF
--- a/libs/ts/base-utils/package.json
+++ b/libs/ts/base-utils/package.json
@@ -110,7 +110,6 @@
     "@effect/platform": "^0.90.0",
     "@effect/vitest": "^0.25.0",
     "effect": "^3.15.1",
-    "string-width": "^8.0.0",
     "tslib": "^2.8.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2286,7 +2286,6 @@ __metadata:
     "@vitest/coverage-v8": "npm:3.1.3"
     effect: "npm:^3.15.1"
     glob: "npm:^11.0.0"
-    string-width: "npm:^8.0.0"
     tslib: "npm:^2.8.1"
     tsx: "npm:^4.19.2"
     typescript: "npm:5.8.3"
@@ -21343,7 +21342,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-east-asian-width@npm:^1.0.0, get-east-asian-width@npm:^1.3.0":
+"get-east-asian-width@npm:^1.0.0":
   version: 1.3.0
   resolution: "get-east-asian-width@npm:1.3.0"
   checksum: 10c0/1a049ba697e0f9a4d5514c4623781c5246982bdb61082da6b5ae6c33d838e52ce6726407df285cdbb27ec1908b333cf2820989bd3e986e37bb20979437fdf34b
@@ -31890,16 +31889,6 @@ __metadata:
     get-east-asian-width: "npm:^1.0.0"
     strip-ansi: "npm:^7.1.0"
   checksum: 10c0/eb0430dd43f3199c7a46dcbf7a0b34539c76fe3aa62763d0b0655acdcbdf360b3f66f3d58ca25ba0205f42ea3491fa00f09426d3b7d3040e506878fc7664c9b9
-  languageName: node
-  linkType: hard
-
-"string-width@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "string-width@npm:8.0.0"
-  dependencies:
-    get-east-asian-width: "npm:^1.3.0"
-    strip-ansi: "npm:^7.1.0"
-  checksum: 10c0/5f82872aba8c1871b6a066d1d7694585ebb89b252374d077d142234512c02fedde9fbf2532f252bdd0453dba5565d45efc7e6851b9e5c9493d204e159943baa1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Revert "fix(base-utils/tty/getTextWidth): Replace our hand-rolled impl w/ `string-width` npm library"

This reverts commit b378a5d5e47ca72a7a9a494c4bd4d994abf6b9f2 as it broke hardhat.