### PR TITLE
[config-types/dfcg/artifacts]: Refactor `dfcg/artifacts` downloader

### DIFF
--- a/libs/ts/config-types/tests/config-decoding.spec.ts
+++ b/libs/ts/config-types/tests/config-decoding.spec.ts
@@ -1,9 +1,8 @@
 import { readdir } from 'fs/promises';
-import { Schema as S } from 'effect';
 
 import { describe, expect, it, test } from 'vitest';
 
-import { entriesOf, keysOf } from '@blocksense/base-utils/array-iter';
+import { keysOf } from '@blocksense/base-utils/array-iter';
 import { assertNotNull } from '@blocksense/base-utils/assert';
 import {
   parseNetworkName,
@@ -54,11 +53,8 @@ describe.skipIf(!tokenValid)(
 );
 
 describe('Configuration files decoding', async () => {
-  const configTypesWithoutLegacy = Object.fromEntries(
-    entriesOf(configTypes).filter(([key]) => !(key in legacyConfigTypes)),
-  ) satisfies Record<string, S.Schema<any>>;
-
-  for (const configType of keysOf(configTypesWithoutLegacy)) {
+  for (const configType of keysOf(configTypes)) {
+    if (configType in legacyConfigTypes) continue;
     it(`should decode '${configType}' config file successfully`, async () => {
       const dir =
         configType === 'sequencer_config_v2'


### PR DESCRIPTION
### [BSN-3302: Address PR comments/suggestions](https://coda.io/d/_d6vM0kjfQP6#_tu4Kik5j/r3302&view=full)

This pull request refactors the configuration file downloading logic to improve code clarity and reduce duplication. The main changes include extracting repeated logic into a helper function, simplifying the process of fetching multiple config files, and cleaning up test code to use more idiomatic patterns.

**Refactoring and simplification of config file downloading:**

* Extracted repeated downloading and decoding logic into a helper function `fetchConfigFromDfcgRepo`, reducing code duplication in `downloader.ts`.
* Replaced manual `Promise.all` calls with a single call to `mapValuePromises`, making the fetching of multiple legacy config files more concise and maintainable in `fetchRepoFiles`.
* Switched from manual fetch and parse to using the shared utility `fetchAndDecodeJSON` for improved consistency and error handling.

**Test code improvements:**

* Simplified the filtering of config types in the decoding tests by using a direct loop and conditional continue, removing the need for `entriesOf` and `Object.fromEntries`.
* Removed unnecessary imports from test files for cleaner code.

These changes help make the codebase easier to read, maintain, and extend.