### PR TITLE
[e2e-tests]: Kill `process-compose` when `SIGINT` is caught during tests execution

### DIFF
--- a/apps/e2e-tests/src/process-compose/e2e.spec.ts
+++ b/apps/e2e-tests/src/process-compose/e2e.spec.ts
@@ -61,6 +61,22 @@ describe.sequential('E2E Tests with process-compose', () => {
         yield* processCompose.start(testEnvironment);
         hasProcessComposeStarted = true;
 
+        if (!process.listenerCount('SIGINT')) {
+          process.once('SIGINT', () => {
+            if (hasProcessComposeStarted) {
+              Effect.runPromise(
+                processCompose
+                  .stop()
+                  .pipe(Effect.catchAll(() => Effect.succeed(undefined))),
+              ).finally(() => {
+                process.exit(130);
+              });
+            } else {
+              process.exit(130);
+            }
+          });
+        }
+
         sequencer = yield* Sequencer;
 
         // Get feeds information from the original network. No affection of the work of the


### PR DESCRIPTION
### [BSN-3364: Make sure we kill process-compose when we Ctr + C  tests run](https://coda.io/d/_d6vM0kjfQP6#_tu4Kik5j/r3364&view=full)

This pull request improves the robustness of the E2E testing process by adding handling for the `SIGINT` signal (typically triggered by Ctrl+C) in the `process-compose` test suite. The main change ensures that if the tests are interrupted, the `processCompose` service is properly stopped before the process exits, preventing potential resource leaks or inconsistent states.

**Process termination handling:**

* Added a listener for the `SIGINT` signal to gracefully stop the `processCompose` service if it has started, ensuring cleanup before exiting the process. If `processCompose` hasn't started, the process simply exits. (`apps/e2e-tests/src/process-compose/e2e.spec.ts`)tests execution