### PR TITLE
[e2e-tests]: Setup anvil to use alchemy RPCs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ env:
   TWELVEDATA_API_KEY: ${{ secrets.TWELVEDATA_API_KEY }}
   FMP_API_KEY: ${{ secrets.FMP_API_KEY }}
   SPOUT_RWA_API_KEY: ${{ secrets.SPOUT_RWA_API_KEY }}
+  RPC_URL_ETHEREUM_SEPOLIA: ${{ secrets.RPC_URL_ETHEREUM_SEPOLIA }}
+  RPC_URL_INK_SEPOLIA: ${{ secrets.RPC_URL_INK_SEPOLIA }}
 
 jobs:
   lint:

--- a/.github/workflows/on-main.yml
+++ b/.github/workflows/on-main.yml
@@ -7,6 +7,8 @@ on:
 
 env:
   DFCG_ARTIFACTS_ACCESS_TOKEN: ${{ secrets.DFCG_ARTIFACTS_ACCESS_TOKEN }}
+  RPC_URL_ETHEREUM_SEPOLIA: ${{ secrets.RPC_URL_ETHEREUM_SEPOLIA }}
+  RPC_URL_INK_SEPOLIA: ${{ secrets.RPC_URL_INK_SEPOLIA }}
 
 jobs:
   deploy_websites:

--- a/apps/e2e-tests/src/process-compose/e2e.spec.ts
+++ b/apps/e2e-tests/src/process-compose/e2e.spec.ts
@@ -101,7 +101,7 @@ describe.sequential('E2E Tests with process-compose', () => {
           ),
         {
           schedule: Schedule.fixed(1000),
-          times: 30,
+          times: 90,
         },
       );
       // still validate the result

--- a/apps/e2e-tests/vitest.config.js
+++ b/apps/e2e-tests/vitest.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    testTimeout: 300000,
-    hookTimeout: 300000,
+    testTimeout: 500000,
+    hookTimeout: 500000,
   },
 });

--- a/nix/test-environments/example-setup-01.nix
+++ b/nix/test-environments/example-setup-01.nix
@@ -32,12 +32,12 @@ in
       ethereum-sepolia = {
         port = 8546;
         chain-id = 99999999999;
-        fork-url = "wss://ethereum-sepolia-rpc.publicnode.com";
+        fork-url = "$RPC_URL_ETHEREUM_SEPOLIA";
       };
       ink-sepolia = {
         port = 8547;
         chain-id = 99999999999;
-        fork-url = "wss://ws-gel-sepolia.inkonchain.com";
+        fork-url = "$RPC_URL_INK_SEPOLIA";
       };
     };
 

--- a/nix/test-environments/example-setup-03.nix
+++ b/nix/test-environments/example-setup-03.nix
@@ -49,7 +49,7 @@ in
       ink-sepolia = {
         port = anvilInkSepoliaPort;
         chain-id = 99999999999;
-        fork-url = "wss://ws-gel-sepolia.inkonchain.com";
+        fork-url = "$RPC_URL_INK_SEPOLIA";
       };
     };
 


### PR DESCRIPTION
### [BSN-3404: Setup anvil to use alchemy RPCs](https://coda.io/d/_d6vM0kjfQP6#_tu4Kik5j/r3404&view=full)

### Description
We’ve updated Anvil’s RPCs to use alchemy. As a result, the sequencer now takes longer to start—about 60 seconds compared to 20 seconds previously with the old fork-url. This caused the end-to-end tests to time out, so I adjusted the timeouts to account for the slower sequencer startup.

### **_Note: You have to setup local environment variables for RPCs in order to run e2e tests locally._**
****