### PR TITLE
[dev/read-adfs]: CLI tool for reading ADFS data

### DIFF
--- a/apps/dev/src/Cli.ts
+++ b/apps/dev/src/Cli.ts
@@ -4,9 +4,10 @@ import packageJson from '../package.json';
 
 import { listFeeds } from './commands/list-feeds';
 import { readClAdapter } from './commands/read-cl-adapter';
+import { readAdfs } from './commands/read-adfs';
 
 const command = Command.make('dev').pipe(
-  Command.withSubcommands([listFeeds, readClAdapter]),
+  Command.withSubcommands([listFeeds, readClAdapter, readAdfs]),
 );
 
 export const run = Command.run(command, {

--- a/apps/dev/src/commands/read-adfs.ts
+++ b/apps/dev/src/commands/read-adfs.ts
@@ -1,0 +1,141 @@
+import { Command, Options } from '@effect/cli';
+import { Effect, Option } from 'effect';
+
+import {
+  getAddressExplorerUrl,
+  parseEthereumAddress,
+  type EthereumAddress,
+} from '@blocksense/base-utils/evm';
+import { renderTui, drawTable } from '@blocksense/base-utils/tty';
+import { listEvmNetworks, readEvmDeployment } from '@blocksense/config-types';
+import { AggregatedDataFeedStoreConsumer } from '@blocksense/contracts/viem';
+
+const availableNetworks = await listEvmNetworks();
+
+export const readAdfs = Command.make(
+  'read-adfs',
+  {
+    network: Options.choice('network', availableNetworks),
+    address: Options.optional(Options.text('address')),
+    rpcUrl: Options.optional(Options.text('rpc-url')),
+    feedId: Options.integer('feed-id'),
+    index: Options.optional(Options.integer('index')),
+    startSlot: Options.optional(Options.integer('start-slot')),
+    slots: Options.optional(Options.integer('slots')),
+    multi: Options.boolean('multi').pipe(Options.withDefault(false)),
+  },
+  ({ address, feedId, index, multi, network, rpcUrl, slots, startSlot }) =>
+    Effect.gen(function* () {
+      let resolvedAddress: EthereumAddress;
+      if (Option.isSome(address)) {
+        resolvedAddress = yield* Effect.try({
+          try: () => parseEthereumAddress(address.value),
+          catch: e =>
+            new Error(
+              `Invalid Ethereum address ${address.value}: ${(e as Error)?.message}`,
+            ),
+        });
+      } else {
+        const deployment = yield* Effect.tryPromise(() =>
+          readEvmDeployment(network, true),
+        );
+        const addr = deployment.contracts?.coreContracts?.UpgradeableProxyADFS
+          ?.address as string | undefined;
+        if (!addr)
+          return yield* Effect.fail(
+            new Error(
+              `UpgradeableProxyADFS address not found in deployment for network ${network}`,
+            ),
+          );
+        resolvedAddress = yield* Effect.try({
+          try: () => parseEthereumAddress(addr),
+          catch: e =>
+            new Error(
+              `Invalid Ethereum address from deployment ${addr}: ${(e as Error)?.message}`,
+            ),
+        });
+      }
+
+      const consumer = Option.isSome(rpcUrl)
+        ? AggregatedDataFeedStoreConsumer.createConsumerByRpcUrl(
+            resolvedAddress,
+            rpcUrl.value,
+          )
+        : AggregatedDataFeedStoreConsumer.createConsumerByNetworkName(
+            resolvedAddress,
+            network,
+          );
+
+      const feed = BigInt(feedId);
+
+      const hasSlice = Option.isSome(startSlot) || Option.isSome(slots);
+      const start = Option.isSome(startSlot) ? startSlot.value : 0;
+      const len = Option.isSome(slots) ? slots.value : 0;
+
+      type DataRow = Array<[string, string]>;
+      const rows: DataRow = [];
+
+      if (Option.isSome(index)) {
+        rows.push(['Mode', 'Index']);
+        rows.push(['Feed Id', feed.toString()]);
+        rows.push(['Index', index.value.toString()]);
+
+        if (hasSlice) {
+          const data = yield* Effect.tryPromise(() =>
+            consumer.getDataSliceAtIndex(feed, index.value, start, len),
+          );
+          data.forEach((word, i) => rows.push([`Data[${i}]`, word]));
+        } else if (multi) {
+          const data = yield* Effect.tryPromise(() =>
+            consumer.getDataAtIndex(feed, index.value),
+          );
+          data.forEach((word, i) => rows.push([`Data[${i}]`, word]));
+        } else {
+          const data = yield* Effect.tryPromise(() =>
+            consumer.getSingleDataAtIndex(feed, index.value),
+          );
+          rows.push(['Data', data]);
+        }
+      } else {
+        rows.push(['Mode', 'Latest']);
+        rows.push(['Feed Id', feed.toString()]);
+
+        if (hasSlice) {
+          const { data, index } = yield* Effect.tryPromise(() =>
+            consumer.getLatestDataSliceAndIndex(feed, start, len),
+          );
+          rows.push(['Index', index.toString()]);
+          (data as Array<string>).forEach((word, i) =>
+            rows.push([`Data[${i}]`, word]),
+          );
+        } else if (multi) {
+          const { data, index } = yield* Effect.tryPromise(() =>
+            consumer.getLatestDataAndIndex(feed),
+          );
+          rows.push(['Index', index.toString()]);
+          (data as Array<string>).forEach((word, i) =>
+            rows.push([`Data[${i}]`, word]),
+          );
+        } else {
+          const { data, index } = yield* Effect.tryPromise(() =>
+            consumer.getLatestSingleDataAndIndex(feed),
+          );
+          rows.push(['Index', index.toString()]);
+          rows.push(['Data', data as string]);
+        }
+      }
+
+      rows.unshift([
+        'Explorer',
+        getAddressExplorerUrl(network, resolvedAddress),
+      ]);
+      rows.unshift(['Address', resolvedAddress]);
+      rows.unshift(['Network', network]);
+
+      renderTui(
+        drawTable(rows, {
+          headers: ['Field', 'Value'],
+        }),
+      );
+    }),
+);


### PR DESCRIPTION
### This CLI command:
1. Takes network, feed ID, and optional parameters.
2. Resolves the contract address (via option or deployment).
3. Creates a blockchain consumer (via RPC or network name).
4. Fetches data from a feed (at a specific index or the latest).
5. Supports slice/multi/single modes.
6. Renders results in a nice terminal table.

### **How to test:**

**# Latest single word + index**
```
yarn start read-adfs --network ink-sepolia --feed-id 0
```
**# Latest full data (all 32-byte words) + index**
```
yarn start read-adfs --network ink-sepolia --feed-id 0 --multi
```
**# Read a specific round/index (single word)**
```
yarn start read-adfs --network ink-sepolia --feed-id 0 --index 12
```
**# Read a slice (from latest): start at slot 0, read 4 slots**
```
yarn start read-adfs --network ink-sepolia --feed-id 0 --start-slot 0 --slots 4
```
**# Optional: override RPC (network is still required for explorer link)**
```
yarn start read-adfs --network ink-sepolia --feed-id 0 --rpc-url https://ink-sepolia.g.alchemy.com/v2/<alchemy-key>
```
￼
<img width="908" height="288" alt="Screenshot 2025-09-10 at 14 14 52" src="https://github.com/user-attachments/assets/bfa87c88-b1f0-4941-bb62-a76efaade9aa" />

[BSN-3412: Implement CLI tool for reading AggregatedDataFeedStore contract data](https://coda.io/d/_d6vM0kjfQP6#_tu4Kik5j/r3412&view=full)