### PR TITLE
[nix/process-compose]: Add `failure_threshold` to anvil instances

### DIFF
--- a/nix/modules/blocksense/backends/process-compose.nix
+++ b/nix/modules/blocksense/backends/process-compose.nix
@@ -53,6 +53,7 @@ let
           initial_delay_seconds = 0;
           period_seconds = 1;
           timeout_seconds = 30;
+          failure_threshold = 10;
         };
         log_configuration = logsConfig;
         log_location = "${cfg.logsDir}/anvil-${name}.log";


### PR DESCRIPTION
### [BSN-3414: Set failure_threshold to anvil instances](https://coda.io/d/_d6vM0kjfQP6#_tu4Kik5j/r3414&view=full)
****
After updating the RPC URLs used for forking in the example environments, we started seeing failures when launching Anvil instances. Investigation showed the fix was to adjust the readiness probes for Anvil by setting the `failure_threshold`. Since applying this change, the failures have not reoccurred.