### PR TITLE
[e2e-tests]: Add support for `UndefinedError` report result

### DIFF
--- a/apps/e2e-tests/src/process-compose/e2e.spec.ts
+++ b/apps/e2e-tests/src/process-compose/e2e.spec.ts
@@ -273,12 +273,16 @@ describe.sequential('E2E Tests with process-compose', () => {
         const apiErrorResult: FeedResult = {
           Err: { APIError: 'Rate limit exceeded' },
         }; // Err → APIError
+        const undefinedErrorResult: FeedResult = {
+          Err: { UndefinedError: {} },
+        }; // Err → UndefinedError
 
         const reports: Array<ReportData> = [
           { feed_id, value: numericalResult },
           { feed_id, value: textResult },
           { feed_id, value: bytesResult },
           { feed_id, value: apiErrorResult },
+          { feed_id, value: undefinedErrorResult },
         ];
 
         const baselineUpdates = yield* sequencer


### PR DESCRIPTION
### [BSN-3418: Handle UndefinedError as report result during postReportsBatch request](https://coda.io/d/_d6vM0kjfQP6#_tu4Kik5j/r3418&view=full)
****
This pull request improves error handling for feed results by introducing support for the `UndefinedError` variant across both backend Rust code and frontend TypeScript tests. The main focus is on ensuring that the system can properly serialize and deserialize the new error type, and that end-to-end tests cover this scenario.

**Error handling improvements:**

* Added support for `UndefinedError` in the `FeedError` enum and implemented custom deserialization logic in `libs/feed_registry/src/types.rs` to handle both object and string representations of this error.
* Removed the unnecessary `Deserialize` derive from the `FeedError` enum and replaced it with a manual implementation to accommodate the new error variant.

**Testing enhancements:**

* Updated the E2E test suite in `apps/e2e-tests/src/process-compose/e2e.spec.ts` to include a test case for `UndefinedError`, ensuring that the frontend can handle this error type correctly.
****