### PR TITLE
[oracles/commodities_price_feeds]: Oracle for Commodities

### DIFF
--- a/apps/oracles/Cargo.lock
+++ b/apps/oracles/Cargo.lock
@@ -1119,6 +1119,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "commodities-price-feeds"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "blocksense-data-providers-sdk",
+ "blocksense-sdk",
+ "futures",
+ "itertools 0.14.0",
+ "prettytable-rs",
+ "serde",
+ "serde-this-or-that",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "wit-bindgen",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/apps/oracles/Cargo.toml
+++ b/apps/oracles/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "stock-price-feeds",
   "forex-price-feeds",
   "spout-rwa",
+  "commodities-price-feeds",
 ]
 
 resolver = "2"

--- a/apps/oracles/commodities-price-feeds/Cargo.toml
+++ b/apps/oracles/commodities-price-feeds/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "commodities-price-feeds"
+authors = ["Mila Genova", "Emil Ivanichkov"]
+description = ""
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { workspace = true }
+blocksense-sdk = { workspace = true }
+blocksense-data-providers-sdk = { workspace = true }
+anyhow = { workspace = true }
+serde_json = { workspace = true }
+url = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde-this-or-that = { workspace = true }
+prettytable-rs = { workspace = true }
+futures = { workspace = true }
+itertools = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/apps/oracles/commodities-price-feeds/spin.toml
+++ b/apps/oracles/commodities-price-feeds/spin.toml
@@ -1,0 +1,28 @@
+spin_manifest_version = 2
+
+[application]
+authors = ["Mila Genova", "Emil Ivanichkov"]
+name = "Commodities Price Fetcher Oracle"
+version = "0.1.0"
+
+[application.trigger.settings]
+interval_time_in_seconds = 10
+sequencer = "http://127.0.0.1:9856/post_reports_batch"
+secret_key = "536d1f9d97166eba5ff0efb8cc8dbeb856fb13d2d126ed1efc761e9955014003"
+second_consensus_secret_key = "536d1f9d97166eba5ff0efb8cc8dbeb856fb13d2d126ed1efc761e9955014003"
+kafka_endpoint = "http://127.0.0.1:9092"
+reporter_id = 0
+
+[[trigger.oracle]]
+component = "commodities-price-feeds"
+
+[[trigger.oracle.capabilities]]
+data = "x"
+id = "METALS_API_KEY"
+
+[component.commodities-price-feeds]
+source = "../target/wasm32-wasip1/release/commodities_price_feeds.wasm"
+allowed_outbound_hosts = ["https://metals-api.com"]
+
+[component.commodities-price-feeds.build]
+command = "cargo build --target wasm32-wasip1 --release"

--- a/apps/oracles/commodities-price-feeds/spin.toml
+++ b/apps/oracles/commodities-price-feeds/spin.toml
@@ -16,6 +16,12 @@ reporter_id = 0
 [[trigger.oracle]]
 component = "commodities-price-feeds"
 
+[[trigger.oracle.data_feeds]]
+id = "20000"
+stride = 0
+decimals = 8
+data = '{"pair":{"base":"LME-XCU","quote":"USD"},"decimals":8,"category":"Commodities","market_hours":"Commodities","arguments":{"kind":"commodities-price-feeds","providers":["MetalsAPI"]}}'
+
 [[trigger.oracle.capabilities]]
 data = "x"
 id = "METALS_API_KEY"

--- a/apps/oracles/commodities-price-feeds/src/domain.rs
+++ b/apps/oracles/commodities-price-feeds/src/domain.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use blocksense_data_providers_sdk::price_data::types::{PricePair, ProvidersSymbols};
+use blocksense_sdk::oracle::Settings;
+
+/* Feed configuration data related types */
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProvidersConfig {
+    pub providers: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FeedConfigData {
+    pub pair: PricePair,
+    pub arguments: ProvidersConfig,
+}
+
+/*  Oracle resource data related types */
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ResourcePairData {
+    pub pair: PricePair,
+    pub id: String,
+}
+
+#[derive(Debug)]
+pub struct ResourceData {
+    pub pairs: Vec<ResourcePairData>,
+    pub symbols: ProvidersSymbols,
+}
+
+//TODO: Consider moving this type to blocksense-sdk
+pub type Capabilities = HashMap<String, String>;
+
+pub fn get_capabilities_from_settings(settings: &Settings) -> Capabilities {
+    settings
+        .capabilities
+        .iter()
+        .map(|cap| (cap.id.to_string(), cap.data.to_string()))
+        .collect()
+}
+
+//TODO: Consider moving this function to blocksense-sdk
+pub fn get_api_keys(capabilities: &Capabilities, keys: &[&str]) -> Option<HashMap<String, String>> {
+    keys.iter()
+        .map(|&key| {
+            capabilities
+                .get(key)
+                .map(|value| (key.to_string(), value.clone()))
+        })
+        .collect()
+}
+
+pub fn get_resources_from_settings(settings: &Settings) -> Result<ResourceData> {
+    let mut feeds_data = Vec::new();
+    let mut providers_symbols: ProvidersSymbols = HashMap::new();
+
+    for feed_setting in &settings.data_feeds {
+        let feed_config_data: FeedConfigData =
+            serde_json::from_str(&feed_setting.data).context("Couldn't parse data feed")?;
+
+        let base = &feed_config_data.pair.base;
+        let quote = &feed_config_data.pair.quote;
+        let symbol = format!("{base}:{quote}");
+
+        feeds_data.push(ResourcePairData {
+            pair: feed_config_data.pair.clone(),
+            id: feed_setting.id.clone(),
+        });
+
+        if let Some(providers) = &feed_config_data.arguments.providers {
+            for provider in providers {
+                let symbols = providers_symbols.entry(provider.clone()).or_default();
+
+                if !symbols.contains(&symbol) {
+                    symbols.push(symbol.clone());
+                }
+            }
+        }
+    }
+
+    Ok(ResourceData {
+        pairs: feeds_data,
+        symbols: providers_symbols,
+    })
+}

--- a/apps/oracles/commodities-price-feeds/src/fetch_prices.rs
+++ b/apps/oracles/commodities-price-feeds/src/fetch_prices.rs
@@ -1,0 +1,81 @@
+use anyhow::Result;
+use futures::stream::FuturesUnordered;
+use serde::{Deserialize, Serialize};
+
+use blocksense_data_providers_sdk::price_data::{
+    fetchers::{
+        fetch::fetch_all_prices,
+        metals::metals_api::MetalsApiPriceFetcher,
+    },
+    traits::prices_fetcher::{fetch, TradingPairSymbol},
+    types::{PairsToResults, ProviderPriceData, ProvidersSymbols},
+};
+
+use crate::domain::{get_api_keys, Capabilities, ResourceData, ResourcePairData};
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SymbolsData {
+    pub metals_api: Vec<TradingPairSymbol>,
+}
+
+impl SymbolsData {
+    pub fn from_resources(providers_symbols: &ProvidersSymbols) -> Result<Self> {
+        Ok(Self {
+            metals_api: providers_symbols
+                .get("MetalsAPI")
+                .cloned()
+                .unwrap_or_default(),
+        })
+    }
+}
+
+pub async fn get_prices(
+    resources: &ResourceData,
+    capabilities: &Capabilities,
+    timeout_secs: u64,
+) -> Result<PairsToResults> {
+    let symbols = SymbolsData::from_resources(&resources.symbols)?;
+
+    let futures_set = FuturesUnordered::from_iter([
+        fetch::<MetalsApiPriceFetcher>(
+            &symbols.metals_api,
+            get_api_keys(capabilities, &["METALS_API_KEY"]),
+            timeout_secs,
+        ),
+    ]);
+
+    let fetched_provider_prices = fetch_all_prices(futures_set).await;
+
+    let mut final_results = PairsToResults::new();
+    for price_data_for_exchange in fetched_provider_prices {
+        fill_results(
+            &resources.pairs,
+            price_data_for_exchange,
+            &mut final_results,
+        );
+    }
+    Ok(final_results)
+}
+
+fn fill_results(
+    resources: &[ResourcePairData],
+    prices_per_provider: ProviderPriceData,
+    results: &mut PairsToResults,
+) {
+    let provider_name = &prices_per_provider.name.clone();
+    for resource in resources {
+        let pair = format!("{}{}", resource.pair.base, resource.pair.quote);
+
+        let res = results.entry(resource.id.clone()).or_default();
+        res.symbol = pair.clone();
+
+        if let Some(price_point) = prices_per_provider.data.get(&pair) {
+            res.providers_data
+                .insert(provider_name.clone(), price_point.clone());
+        }
+        if res.providers_data.is_empty() {
+            results.remove(&resource.id);
+        }
+    }
+}

--- a/apps/oracles/commodities-price-feeds/src/lib.rs
+++ b/apps/oracles/commodities-price-feeds/src/lib.rs
@@ -1,0 +1,56 @@
+mod domain;
+mod fetch_prices;
+mod logging;
+
+use anyhow::Result;
+
+use blocksense_data_providers_sdk::price_data::{types::PairsToResults, wap::vwap::compute_vwap};
+use tracing::info;
+
+use blocksense_sdk::{
+    oracle::{DataFeedResult, DataFeedResultValue, Payload, Settings},
+    oracle_component,
+};
+
+use crate::{
+    domain::{get_capabilities_from_settings, get_resources_from_settings},
+    fetch_prices::get_prices,
+    logging::print_results,
+};
+
+#[oracle_component]
+async fn oracle_request(settings: Settings) -> Result<Payload> {
+    tracing_subscriber::fmt::init();
+
+    info!("Starting oracle component - Commodities Price Fetcher");
+
+    let resources = get_resources_from_settings(&settings)?;
+    let capabilities = get_capabilities_from_settings(&settings);
+    let timeout_secs = settings.interval_time_in_seconds - 1;
+
+    let results = get_prices(&resources, &capabilities, timeout_secs).await?;
+    let payload = process_results(&results)?;
+
+    print_results(&resources.pairs, &results, &payload);
+    Ok(payload)
+}
+
+fn process_results(results: &PairsToResults) -> Result<Payload> {
+    let mut payload = Payload::new();
+    for (feed_id, results) in results.iter() {
+        let price_points = results.providers_data.values();
+
+        payload.values.push(match compute_vwap(price_points) {
+            Ok(price) => DataFeedResult {
+                id: feed_id.to_string(),
+                value: DataFeedResultValue::Numerical(price),
+            },
+            Err(err) => DataFeedResult {
+                id: feed_id.to_string(),
+                value: DataFeedResultValue::Error(err.to_string()),
+            },
+        });
+    }
+
+    Ok(payload)
+}

--- a/apps/oracles/commodities-price-feeds/src/logging.rs
+++ b/apps/oracles/commodities-price-feeds/src/logging.rs
@@ -1,0 +1,105 @@
+use std::fmt::Write;
+
+use blocksense_data_providers_sdk::price_data::types::PairsToResults;
+use blocksense_sdk::oracle::{DataFeedResultValue, Payload};
+use itertools::Itertools;
+use prettytable::{format, Cell, Row, Table};
+use tracing::{info, warn};
+
+use crate::domain::ResourcePairData;
+
+struct ResultInfo {
+    pub id: i64,
+    pub name: String,
+    pub value: String,
+    pub providers: Vec<String>,
+}
+
+pub fn print_results(resources: &[ResourcePairData], results: &PairsToResults, payload: &Payload) {
+    let mut results_info: Vec<ResultInfo> = Vec::new();
+    let mut pairs_with_missing_provider_data: String = String::new();
+    let mut pairs_with_missing_provider_data_count = 0;
+    let mut missing_prices: String = String::new();
+    let mut missing_prices_count = 0;
+
+    for resource in resources.iter() {
+        if results.get(&resource.id).is_some() {
+            let providers = results
+                .get(&resource.id)
+                .map(|res| {
+                    res.providers_data
+                        .keys()
+                        .map(|x| x.split(' ').next().unwrap().to_string())
+                        .unique()
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let value = match payload
+                .values
+                .iter()
+                .find(|x| x.id == resource.id)
+                .unwrap()
+                .value
+                .clone()
+            {
+                DataFeedResultValue::Numerical(num) => format!("{num:.8}"),
+                _ => {
+                    missing_prices_count += 1;
+                    write!(
+                        missing_prices,
+                        "{{ {}: {} / {}, providers: {:?} }},",
+                        resource.id, resource.pair.base, resource.pair.quote, providers
+                    )
+                    .unwrap();
+                    "-".to_string()
+                }
+            };
+
+            results_info.push(ResultInfo {
+                id: resource.id.parse().unwrap(),
+                name: format!("{} / {}", resource.pair.base, resource.pair.quote),
+                value,
+                providers,
+            });
+        } else {
+            pairs_with_missing_provider_data_count += 1;
+            write!(
+                pairs_with_missing_provider_data,
+                "{{ {}: {} / {} }},",
+                resource.id, resource.pair.base, resource.pair.quote
+            )
+            .unwrap();
+        }
+    }
+
+    results_info.sort_by(|a, b| a.id.cmp(&b.id));
+
+    let mut table = Table::new();
+    table.set_format(*format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
+
+    table.set_titles(Row::new(vec![
+        Cell::new("ID").style_spec("bc"),
+        Cell::new("Name").style_spec("bc"),
+        Cell::new("Value").style_spec("bc"),
+        Cell::new("Providers").style_spec("bc"),
+    ]));
+
+    for data in results_info {
+        table.add_row(Row::new(vec![
+            Cell::new(&data.id.to_string()).style_spec("r"),
+            Cell::new(&data.name).style_spec("r"),
+            Cell::new(&data.value).style_spec("r"),
+            Cell::new(&data.providers.len().to_string()).style_spec("r"),
+        ]));
+    }
+
+    warn!("{pairs_with_missing_provider_data_count} Pairs with no provider data:");
+    warn!("[{pairs_with_missing_provider_data}]");
+
+    warn!("{missing_prices_count} Pairs with missing price / volume data from provider:");
+    warn!("[{missing_prices}]");
+
+    info!("Results:");
+    table.printstd();
+}

--- a/apps/oracles/forex-price-feeds/spin.toml
+++ b/apps/oracles/forex-price-feeds/spin.toml
@@ -832,12 +832,6 @@ stride = 0
 decimals = 8
 data = '{"pair":{"base":"ZAC","quote":"USD"},"decimals":8,"category":"Forex","market_hours":"Forex","arguments":{"kind":"forex-price-feeds","providers":["twelvedata","YahooFinance","AlphaVantage","FMP"]}}'
 
-[[trigger.oracle.data_feeds]]
-id = "20000"
-stride = 0
-decimals = 8
-data = '{"pair":{"base":"LME-XCU","quote":"USD"},"decimals":8,"category":"Forex","market_hours":"Forex","arguments":{"kind":"forex-price-feeds","providers":["MetalsAPI"]}}'
-
 [[trigger.oracle.capabilities]]
 data = "x"
 id = "ALPHAVANTAGE_API_KEY"
@@ -854,9 +848,6 @@ id = "YAHOO_FINANCE_API_KEY"
 data = "x"
 id = "FMP_API_KEY"
 
-[[trigger.oracle.capabilities]]
-data = "x"
-id = "METALS_API_KEY"
 
 [component.forex-price-feeds]
 source = "../target/wasm32-wasip1/release/forex_price_feeds.wasm"
@@ -865,7 +856,6 @@ allowed_outbound_hosts = [
   "https://www.alphavantage.co",
   "https://api.twelvedata.com",
   "https://financialmodelingprep.com",
-  "https://metals-api.com"
 ]
 
 [component.forex-price-feeds.build]

--- a/apps/oracles/forex-price-feeds/src/fetch_prices.rs
+++ b/apps/oracles/forex-price-feeds/src/fetch_prices.rs
@@ -6,10 +6,9 @@ use blocksense_data_providers_sdk::price_data::{
     fetchers::{
         fetch::fetch_all_prices,
         forex::{
-            alpha_vantage::AlphaVantagePriceFetcher, twelvedata::TwelveDataPriceFetcher,
-            yahoo_finance::YFPriceFetcher, fmp::FMPPriceFetcher
+            alpha_vantage::AlphaVantagePriceFetcher, fmp::FMPPriceFetcher,
+            twelvedata::TwelveDataPriceFetcher, yahoo_finance::YFPriceFetcher,
         },
-        metals::metals_api::MetalsApiPriceFetcher
     },
     traits::prices_fetcher::{fetch, TradingPairSymbol},
     types::{PairsToResults, ProviderPriceData, ProvidersSymbols},
@@ -24,7 +23,6 @@ pub struct SymbolsData {
     pub twelvedata: Vec<TradingPairSymbol>,
     pub yahoo_finance: Vec<TradingPairSymbol>,
     pub fmp: Vec<TradingPairSymbol>,
-    pub metals_api: Vec<TradingPairSymbol>,
 }
 
 impl SymbolsData {
@@ -42,14 +40,7 @@ impl SymbolsData {
                 .get("YahooFinance")
                 .cloned()
                 .unwrap_or_default(),
-            fmp: providers_symbols
-                .get("FMP")
-                .cloned()
-                .unwrap_or_default(),
-            metals_api: providers_symbols
-                .get("MetalsAPI")
-                .cloned()
-                .unwrap_or_default(),
+            fmp: providers_symbols.get("FMP").cloned().unwrap_or_default(),
         })
     }
 }
@@ -80,11 +71,6 @@ pub async fn get_prices(
         fetch::<FMPPriceFetcher>(
             &symbols.fmp,
             get_api_keys(capabilities, &["FMP_API_KEY"]),
-            timeout_secs,
-        ),
-        fetch::<MetalsApiPriceFetcher>(
-            &symbols.metals_api,
-            get_api_keys(capabilities, &["METALS_API_KEY"]),
             timeout_secs,
         ),
     ]);

--- a/config/feeds_config_v2.json
+++ b/config/feeds_config_v2.json
@@ -46169,7 +46169,7 @@
       "full_name": "LME-XCU price in USD per troy ounce",
       "description": "Price of LME Copper in US Dollar per troy ounce",
       "type": "price-feed",
-      "oracle_id": "forex-price-feeds",
+      "oracle_id": "commodities-price-feeds",
       "value_type": "numerical",
       "stride": 0,
       "quorum": {
@@ -46188,10 +46188,10 @@
           "quote": "USD"
         },
         "decimals": 8,
-        "category": "Forex",
-        "market_hours": "Forex",
+        "category": "Commodities",
+        "market_hours": "Commodities",
         "arguments": {
-          "kind": "forex-price-feeds",
+          "kind": "commodities-price-feeds",
           "providers": ["MetalsAPI"]
         }
       }

--- a/config/feeds_config_v2.json
+++ b/config/feeds_config_v2.json
@@ -46177,7 +46177,7 @@
         "aggregation": "median"
       },
       "schedule": {
-        "interval_ms": 60000,
+        "interval_ms": 600000,
         "heartbeat_ms": 7200000,
         "deviation_percentage": 0.1,
         "first_report_start_unix_time_ms": 0

--- a/libs/ts/config-types/src/data-feeds-config/oracles.ts
+++ b/libs/ts/config-types/src/data-feeds-config/oracles.ts
@@ -54,6 +54,14 @@ export const forexPriceFeedsArgsSchema = S.mutable(
   }),
 );
 
+// `commodities-price-feeds` Oracle related Types
+export const commoditiesPriceFeedsArgsSchema = S.mutable(
+  S.Struct({
+    kind: S.Literal('commodities-price-feeds'),
+    providers: S.Array(S.String),
+  }),
+);
+
 // `eth-rpc` Oracle related Types
 // Schema for a single URL string
 const UrlSchema = S.String.pipe(

--- a/libs/ts/config-types/src/data-feeds-config/types.ts
+++ b/libs/ts/config-types/src/data-feeds-config/types.ts
@@ -9,6 +9,7 @@ import {
   stockPriceFeedsArgsSchema,
   hyperBorrowRatesArgsSchema,
   forexPriceFeedsArgsSchema,
+  commoditiesPriceFeedsArgsSchema,
 } from './oracles';
 /**
  * Schema for the data feed category ( Chainlink compatible ).
@@ -143,6 +144,7 @@ export const MarketHoursSchema = S.Union(
   S.Literal(''),
   S.Literal('Crypto'),
   S.Literal('Forex'),
+  S.Literal('Commodities'),
   S.Literal('FX'),
   S.Literal('NYSE'),
   S.Literal('WTI'),
@@ -202,6 +204,7 @@ export const NewFeedSchema = S.mutable(
         arguments: S.Union(
           stockPriceFeedsArgsSchema,
           forexPriceFeedsArgsSchema,
+          commoditiesPriceFeedsArgsSchema,
           cexPriceFeedsArgsSchema,
           geckoTerminalArgsSchema,
           ethRpcArgsSchema,

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -73,6 +73,7 @@
           eth-rpc = mkOracleScript "eth-rpc";
           stock-price-feeds = mkOracleScript "stock-price-feeds";
           forex-price-feeds = mkOracleScript "forex-price-feeds";
+          commodities-price-feeds = mkOracleScript "commodities-price-feeds";
           spout-rwa = mkOracleScript "spout-rwa";
         };
 

--- a/nix/test-environments/example-setup-01.nix
+++ b/nix/test-environments/example-setup-01.nix
@@ -287,13 +287,20 @@ in
           "https://yfapi.net"
           "https://api.twelvedata.com"
           "https://financialmodelingprep.com"
-          "https://metals-api.com"
         ];
         api-keys = [
           "ALPHAVANTAGE_API_KEY"
           "YAHOO_FINANCE_API_KEY"
           "TWELVEDATA_API_KEY"
           "FMP_API_KEY"
+        ];
+      };
+      commodities-price-feeds = {
+        exec-interval = 60;
+        allowed-outbound-hosts = [
+          "https://metals-api.com"
+        ];
+        api-keys = [
           "METALS_API_KEY"
         ];
       };


### PR DESCRIPTION
This pull request introduces a new dedicated oracle component for fetching metal prices, specifically moving the LME Copper (LME-XCU) price feed from the existing `forex-price-feeds` oracle to a new `commodities_price_feeds` oracle. The changes include setting up the new component, updating configuration and build files, and cleaning up the `forex-price-feeds` logic to remove commodities-related code.

[BSN-3417: Write custom oracle for Tellura ](https://coda.io/d/_d6vM0kjfQP6#_tu4Kik5j/r3417&view=full)