### PR TITLE
fix(sequencer/adfs): Fix to correctly wrap around the round counters when serializing them + unit test

### DIFF
--- a/apps/sequencer/src/providers/provider.rs
+++ b/apps/sequencer/src/providers/provider.rs
@@ -1835,7 +1835,7 @@ mod tests {
 
             let pending_tx = provider.send_transaction(tx).await.expect("send tx");
             let receipt = pending_tx.get_receipt().await.expect("get receipt");
-            info!("DEBUG: receipt = {receipt:?}");
+            info!("Receipt = {receipt:?}");
             let last_round = p.get_latest_round(&feed_id).await.unwrap();
             assert_eq!(last_round.feed_id, feed_id);
             assert_eq!(last_round.round, round_counter_val);
@@ -1946,10 +1946,11 @@ mod tests {
                 let val = vals[0]
                     .as_ref()
                     .expect("Expected correct value in contract for feed id {feed_id}");
-                assert_eq!(
-                    round.round,
-                    wrapped_val
-                );
+
+                // Assert that the value of the round counter in the contract is as expected.
+                // Note: The sequencer tracks the index of the *next* slot to write,
+                // while the contract stores the index of the *last* written value.
+                assert_eq!(round.round, wrapped_val);
 
                 assert_eq!(val.value, new_update);
 

--- a/apps/sequencer/src/providers/provider.rs
+++ b/apps/sequencer/src/providers/provider.rs
@@ -1732,4 +1732,263 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_recover_after_read_overflowed_rb_index_value() -> Result<()> {
+        let round_counter_val = 9111;
+        let wrapped_val = round_counter_val % MAX_HISTORY_ELEMENTS_PER_FEED as u16 + 1;
+
+        let metrics_prefix = "test_recover_after_read_overflowed_rb_index_value";
+
+        let span = info_span!("test_recover_after_read_overflowed_rb_index_value");
+        let _guard = span.enter();
+
+        let network = "ETH4380";
+        let anvil = Anvil::new().try_spawn()?;
+
+        let key_path = get_test_private_key_path();
+
+        let mut sequencer_config =
+            get_test_config_with_single_provider(network, key_path.as_path(), &anvil.endpoint());
+
+        let feed_id = 31;
+        let stride = 0;
+        let feeds: Vec<FeedConfig> = (16..32)
+            .map(|feed_id| test_feed_config(feed_id, stride))
+            .collect();
+        let feeds_config = AllFeedsConfig { feeds };
+
+        let p_entry = sequencer_config.providers.entry(network.to_string());
+        p_entry.and_modify(|p| {
+            p.should_load_historical_values = true;
+            p.should_load_round_counters = true;
+            if let Some(x) = p
+                .contracts
+                .iter_mut()
+                .find(|x| x.name == MULTICALL_CONTRACT_NAME)
+            {
+                x.address = None;
+                x.creation_byte_code = Some(Multicall::BYTECODE.to_string());
+            }
+        });
+
+        let (sequencer_state, collected_futures) = create_sequencer_state_and_collected_futures(
+            sequencer_config.clone(),
+            metrics_prefix,
+            feeds_config.clone(),
+        )
+        .await;
+        let msg = sequencer_state
+            .deploy_contract(network, ADFS_ACCESS_CONTROL_CONTRACT_NAME)
+            .await
+            .expect("ADFS access control contract deployment failed!");
+        info!("{msg}");
+        let msg = sequencer_state
+            .deploy_contract(network, ADFS_CONTRACT_NAME)
+            .await
+            .expect("Data feed publishing contract deployment failed!");
+        info!("{msg}");
+        let msg = sequencer_state
+            .deploy_contract(network, MULTICALL_CONTRACT_NAME)
+            .await
+            .expect("Error when deploying multicall contract!");
+        info!("{msg}");
+
+        let rpc_provider_mutex = sequencer_state.get_provider(network).await.clone().unwrap();
+        let (adfs_address, multicall_address, adfs_deployed_byte_code) = {
+            let mut rpc_provider = rpc_provider_mutex.lock().await;
+            rpc_provider.history.register_feed(feed_id, 100);
+            let contract_version = rpc_provider.get_latest_contract_version(Periodic);
+            assert_eq!(contract_version, 2);
+
+            let block_number = rpc_provider.provider.get_block_number().await.unwrap();
+            let block_num_at_time_of_writing_this_test = 0_u64;
+            assert!(block_number > block_num_at_time_of_writing_this_test);
+            let last_round = rpc_provider.get_latest_round(&feed_id).await.unwrap();
+            assert_eq!(last_round.feed_id, feed_id);
+            assert_eq!(last_round.round, 0);
+            (
+                rpc_provider
+                    .get_contract(ADFS_CONTRACT_NAME)
+                    .unwrap()
+                    .address
+                    .unwrap(),
+                rpc_provider
+                    .get_contract(MULTICALL_CONTRACT_NAME)
+                    .unwrap()
+                    .address
+                    .unwrap(),
+                blocksense_utils::to_hex_string(
+                    rpc_provider
+                        .get_contract(ADFS_CONTRACT_NAME)
+                        .unwrap()
+                        .deployed_byte_code
+                        .unwrap(),
+                    None,
+                ),
+            )
+        };
+
+        // Write raw calldata to ADFS before any updates are made.
+        {
+            use alloy::hex::FromHex;
+            // Provided calldata to pre-populate counters/values
+            let calldata_hex = "0x01000000000000000100000001000303e3970120000000000000000000000000000015d41642f71aa02900000000003647f7d78101010000000000000000000000000000000000000000000000000000000000002397";
+
+            let pre_data: Bytes = Bytes::from_hex(calldata_hex).expect("Invalid calldata hex");
+
+            let p = rpc_provider_mutex.lock().await;
+            let signer = p.signer.clone();
+            let provider = &p.provider;
+
+            // Get current nonce for the signer
+            let nonce = provider
+                .get_transaction_count(signer.address())
+                .pending()
+                .await
+                .expect("Failed to get nonce");
+
+            let mut tx = TransactionRequest::default()
+                .to(adfs_address)
+                .with_nonce(nonce)
+                .with_from(signer.address())
+                .with_chain_id(anvil.chain_id())
+                .input(TransactionInput::from(pre_data.clone()));
+
+            // Be explicit with gas to avoid missing fillers
+            tx = tx
+                .with_gas_limit(10_000_000)
+                .with_max_fee_per_gas(30_000_000_000)
+                .with_max_priority_fee_per_gas(2_000_000_000);
+
+            let pending_tx = provider.send_transaction(tx).await.expect("send tx");
+            let receipt = pending_tx.get_receipt().await.expect("get receipt");
+            info!("DEBUG: receipt = {receipt:?}");
+            let last_round = p.get_latest_round(&feed_id).await.unwrap();
+            assert_eq!(last_round.feed_id, feed_id);
+            assert_eq!(last_round.round, round_counter_val);
+        }
+
+        // Some arbitrary point in time in the past, nothing special about this value
+        let first_report_start_time = UNIX_EPOCH + Duration::from_secs(1524885322);
+        let end_slot_timestamp = first_report_start_time.elapsed().unwrap().as_millis();
+        let interval_ms = (test_feed_config(feed_id, stride).schedule.interval_ms) as u128;
+
+        // Wait for all threads to JOIN
+        for x in collected_futures.iter() {
+            info!("Aborting future = {:?}", x.id());
+            x.abort();
+        }
+        // this simulates a second boot of the sequencer
+        // contracts are already deployed
+        let mut sequencer_config2 = sequencer_config.clone();
+        let p_entry = sequencer_config2.providers.entry(network.to_string());
+        p_entry.and_modify(|p| {
+            if let Some(x) = p
+                .contracts
+                .iter_mut()
+                .find(|x| x.name == MULTICALL_CONTRACT_NAME)
+            {
+                x.address = Some(multicall_address.to_string());
+            }
+            if let Some(x) = p
+                .contracts
+                .iter_mut()
+                .find(|x| x.name == ADFS_CONTRACT_NAME)
+            {
+                x.address = Some(adfs_address.to_string());
+                x.deployed_byte_code = Some(adfs_deployed_byte_code)
+            }
+            p.publishing_criteria.push(PublishCriteria {
+                feed_id,
+                skip_publish_if_less_then_percentage: 0.5,
+                always_publish_heartbeat_ms: Some(864000),
+                peg_to_value: None,
+                peg_tolerance_percentage: 0.5,
+            });
+        });
+
+        let metrics_prefix2 = "test_recover_after_read_overflowed_rb_index_value_2";
+        let new_rpc_providers =
+            init_shared_rpc_providers(&sequencer_config2, Some(metrics_prefix2), &feeds_config)
+                .await;
+        {
+            let new_rpc_provider = new_rpc_providers
+                .read()
+                .await
+                .get(network)
+                .cloned()
+                .unwrap();
+            let provider = new_rpc_provider.lock().await;
+            let counters = &provider.round_counters;
+            assert_eq!(Some(wrapped_val as u64), counters.get(&feed_id).copied());
+
+            let x = provider.get_latest_values(&[feed_id]).await.unwrap();
+            assert_eq!(x.len(), 1);
+            let v = x[0].clone().unwrap();
+            assert_eq!(v.num_updates, round_counter_val.into());
+
+            {
+                let metrics_prefix3 = "test_recover_after_read_overflowed_rb_index_value_3";
+
+                let (sequencer_state, collected_futures) =
+                    create_sequencer_state_and_collected_futures(
+                        sequencer_config2.clone(),
+                        metrics_prefix3,
+                        feeds_config.clone(),
+                    )
+                    .await;
+
+                // publish new update
+                let new_update = FeedType::Numerical(94011.11f64);
+                let v1 = VotedFeedUpdate {
+                    feed_id,
+                    value: new_update.clone(),
+                    end_slot_timestamp: end_slot_timestamp + interval_ms * 4,
+                };
+                let updates1 = BatchedAggregatesToSend {
+                    block_height: 4,
+                    updates: vec![v1],
+                };
+
+                let p1 = eth_batch_send_to_all_contracts(
+                    &sequencer_state,
+                    &updates1,
+                    Repeatability::Periodic,
+                    None,
+                )
+                .await;
+
+                assert!(p1.is_ok());
+                tokio::time::sleep(Duration::from_millis(2000)).await;
+
+                let prov = sequencer_state.providers.read().await;
+                let p = prov.get(network).unwrap();
+                let round = p.lock().await.get_latest_round(&feed_id).await.unwrap();
+                let vals = p
+                    .lock()
+                    .await
+                    .get_latest_values(&[feed_id])
+                    .await
+                    .expect("Could not get latest value");
+                let val = vals[0]
+                    .as_ref()
+                    .expect("Expected correct value in contract for feed id {feed_id}");
+                assert_eq!(
+                    round.round,
+                    wrapped_val
+                );
+
+                assert_eq!(val.value, new_update);
+
+                // Wait for all threads to JOIN
+                for x in collected_futures.iter() {
+                    info!("Aborting future = {:?}", x.id());
+                    x.abort();
+                }
+            }
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
- Fix to correctly wrap around the round counters when serializing them.
- Add unit test that has one Feed ID with update counter larger than the round buffer size to recreate problem.
- Refactor unit test setup to pass as arguments to initialization function the updates, round counters and strides per feed.