### PR TITLE
build(nix/pkgs/blocksense-rs): Remove deprecated macOS frameworks that are now provided by stdenv

### DIFF
--- a/nix/pkgs/blocksense-rs/default.nix
+++ b/nix/pkgs/blocksense-rs/default.nix
@@ -40,13 +40,6 @@ let
     ]
     ++ lib.optionals stdenv.isDarwin [
       iconv
-
-      darwin.apple_sdk.frameworks.Security
-      darwin.apple_sdk.frameworks.AppKit
-
-      # Used by ggml / llama.cpp
-      darwin.apple_sdk.frameworks.Accelerate
-
       curl
     ];
 


### PR DESCRIPTION
Fixes the following warnings:

```
evaluation warning: darwin.apple_sdk_11_0.Security: these stubs do
nothing and will be removed in Nixpkgs 25.11; see
<https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation
and migration instructions.

evaluation warning: darwin.apple_sdk_11_0.AppKit: these stubs do nothing
and will be removed in Nixpkgs 25.11; see
<https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation
and migration instructions.

evaluation warning: darwin.apple_sdk_11_0.Accelerate: these stubs do
nothing and will be removed in Nixpkgs 25.11; see
<https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation
and migration instructions.
```

How to test:

```
just build-environment example-setup-01
```