### PR TITLE
[docs.ws/gh-actions]: Test deployed networks icons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,9 @@ jobs:
           - project: docs.blocksense.network
             path: apps/docs.blocksense.network/dist
             project_name: blocksense-docs
-            build_command: yarn workspace @blocksense/docs.blocksense.network build:with-deps
+            build_command: |
+              yarn workspace @blocksense/docs.blocksense.network build:with-deps &&
+              yarn workspace @blocksense/docs.blocksense.network test:network-icons
           - project: docs-ui.blocksense.network
             path: libs/ts/docs-ui/storybook-static
             project_name: blocksense-docs-ui

--- a/apps/docs.blocksense.network/components/DataFeeds/Cards/NetworkAccessCard.tsx
+++ b/apps/docs.blocksense.network/components/DataFeeds/Cards/NetworkAccessCard.tsx
@@ -16,7 +16,7 @@ import { Button } from '@blocksense/docs-ui/Button';
 import { Card, CardHeader, CardTitle } from '@blocksense/docs-ui/Card';
 import { DataFeedCardContentItem } from '../DataFeedCardContentItem';
 import { ContractAddress } from '@/components/sol-contracts/ContractAddress';
-import { capitalizeWords } from '@/src/utils';
+import { capitalizeWords, networkNameToIconName } from '@/src/utils';
 import { DataFeedCardContent } from '../DataFeedCardContent';
 import { Icon } from '@blocksense/docs-ui/Icon';
 import { Separator } from '@blocksense/docs-ui/Separator';
@@ -24,7 +24,7 @@ import { ImageWrapper } from '@blocksense/docs-ui';
 import { valuesOf } from '@blocksense/base-utils/array-iter';
 
 const NetworkIcon = ({ network }: { network: NetworkName }) => {
-  const path = `/images/network-icons/${network.split('-')[0]}.png`;
+  const path = `/images/network-icons/${networkNameToIconName(network)}.png`;
   return (
     <div className="flex items-center gap-2">
       <ImageWrapper src={path} alt={network} className="relative w-5 h-5" />

--- a/apps/docs.blocksense.network/components/DeployedContracts/NetworkIcon.tsx
+++ b/apps/docs.blocksense.network/components/DeployedContracts/NetworkIcon.tsx
@@ -2,10 +2,11 @@ import * as React from 'react';
 import { Button } from 'nextra/components';
 
 import { ImageWrapper } from '@blocksense/docs-ui/ImageWrapper';
-import { capitalizeWords } from '@/src/utils';
+import { capitalizeWords, networkNameToIconName } from '@/src/utils';
+import { NetworkName } from '@blocksense/base-utils/evm/networks';
 
 type NetworkIconProps = {
-  network: string;
+  network: NetworkName;
   isSelected: boolean;
   onClick: () => void;
 };
@@ -15,7 +16,7 @@ export const NetworkIcon = ({
   isSelected,
   onClick,
 }: NetworkIconProps) => {
-  const iconPath = `/images/network-icons/${network.split('-')[0]}.png`;
+  const iconPath = `/images/network-icons/${networkNameToIconName(network)}.png`;
 
   return (
     <Button

--- a/apps/docs.blocksense.network/package.json
+++ b/apps/docs.blocksense.network/package.json
@@ -12,6 +12,7 @@
     "ready-dev-go": "yarn build:with-deps && yarn dev",
     "start": "next start",
     "test": "vitest run --typecheck --coverage",
+    "test:network-icons": "vitest run tests/network-icons.spec.ts",
     "ts": "yarn node --import tsx",
     "watch:docs-theme": "nodemon -w ../../libs/docs-theme -e js,jsx,ts,tsx,css --exec 'yarn workspace @blocksense/docs-theme build'"
   },

--- a/apps/docs.blocksense.network/src/utils.ts
+++ b/apps/docs.blocksense.network/src/utils.ts
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/navigation';
 
 import { previewHexString } from '@blocksense/base-utils/buffer-and-hex';
+import { NetworkName } from '@blocksense/base-utils/evm/networks';
 import { VariableDocItem } from '@blocksense/sol-reflector';
 
 export const filterConstants = (
@@ -67,3 +68,7 @@ export const showMsInSeconds = (ms: number): string => {
 export const showPercentage = (value: any): string => {
   return `${value} %`;
 };
+
+export function networkNameToIconName(networkName: NetworkName) {
+  return networkName.split('-')[0];
+}

--- a/apps/docs.blocksense.network/tests/network-icons.spec.ts
+++ b/apps/docs.blocksense.network/tests/network-icons.spec.ts
@@ -1,14 +1,17 @@
 import { describe, test, expect } from 'vitest';
 import path from 'path';
+
 import { listEvmNetworks } from '@blocksense/config-types/read-write-config';
 import { selectDirectory } from '@blocksense/base-utils/fs';
+
+import { networkNameToIconName } from '../src/utils';
 
 describe('Network Icons', () => {
   test('all deployed networks should have corresponding icons in the website', async () => {
     const deployedNetworks = await listEvmNetworks();
 
-    const expectedIconNames = deployedNetworks.map(
-      network => network.split('-')[0],
+    const expectedIconNames = deployedNetworks.map(network =>
+      networkNameToIconName(network),
     );
 
     const uniqueExpectedIconNames = [...new Set(expectedIconNames)];

--- a/apps/docs.blocksense.network/tests/network-icons.spec.ts
+++ b/apps/docs.blocksense.network/tests/network-icons.spec.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from 'vitest';
+import path from 'path';
+import { listEvmNetworks } from '@blocksense/config-types/read-write-config';
+import { selectDirectory } from '@blocksense/base-utils/fs';
+
+describe('Network Icons', () => {
+  test('all deployed networks should have corresponding icons in the website', async () => {
+    const deployedNetworks = await listEvmNetworks();
+
+    const expectedIconNames = deployedNetworks.map(
+      network => network.split('-')[0],
+    );
+
+    const uniqueExpectedIconNames = [...new Set(expectedIconNames)];
+
+    const iconsDir = path.join(__dirname, '../public/images/network-icons');
+    const { readDir } = selectDirectory(iconsDir);
+    const iconFiles = await readDir();
+
+    const availableIconNames = iconFiles
+      .filter(file => file.endsWith('.png'))
+      .map(file => file.replace('.png', ''));
+
+    const missingIcons = uniqueExpectedIconNames.filter(
+      iconName => !availableIconNames.includes(iconName),
+    );
+
+    let errorMessage = '';
+    if (missingIcons.length > 0) {
+      errorMessage += `Missing icons for networks: ${missingIcons.join(', ')}\n`;
+    }
+
+    if (errorMessage) {
+      errorMessage += `\n\nExpected icons: ${uniqueExpectedIconNames.sort().join(', ')}`;
+      errorMessage += `\n\nAvailable icons: ${availableIconNames.sort().join(', ')}`;
+      errorMessage += `\n\nDeployed networks: ${deployedNetworks.sort().join(', ')}`;
+      errorMessage += `\n\nMissing icons: ${missingIcons.join(', ')}`;
+    }
+
+    expect(missingIcons, errorMessage).toEqual([]);
+  });
+});


### PR DESCRIPTION
This pull request improves how network icons are handled and tested in the `docs.blocksense.network` app. It introduces a utility function to consistently map network names to icon filenames, updates components to use this function, and adds automated testing to ensure all deployed networks have corresponding icon images. It also updates the CI workflow to run these new tests.

**Network Icon Handling Improvements:**

* Added a new utility function `networkNameToIconName` in `utils.ts` to standardize mapping from `NetworkName` to icon filenames, replacing previous string splitting logic.
* Updated `NetworkIcon` components in `NetworkAccessCard.tsx` and `NetworkIcon.tsx` to use the new `networkNameToIconName` utility for determining icon image paths.

**Testing and CI Integration:**

* Added a new test `test:network-icons` (with `network-icons.spec.ts`) to verify that all deployed networks have corresponding icon images in the project.
* Updated the CI workflow (`ci.yml`) to run the new network icons test as part of the build process.

**Type Improvements:**

* Updated type signatures to use the `NetworkName` type for better type safety in components and utilities. 