### PR TITLE
[just]: Fix `list-environments` command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -23,7 +23,7 @@ list-devshells:
 list-environments:
   #!/usr/bin/env bash
   nix eval -L --json --apply builtins.attrNames \
-    .#legacyPackages.${system}.process-compose-environments \
+    .#legacyPackages.${system}.process-compose-environments.with-local-cargo-artifacts \
     2>/dev/null \
     | jq -r '.[]'
 


### PR DESCRIPTION
## [BSN-3452: Fix just list-environments command](https://coda.io/d/_d6vM0kjfQP6#_tu4Kik5j/r3452&view=full)
Minor fix of `list-environments` command.

### After the fix:
<img width="612" height="74" alt="Screenshot 2025-10-06 at 15 32 32" src="https://github.com/user-attachments/assets/203bd9ef-8b71-4426-aa33-b345a3d52f56" />

### Before the fix:
<img width="612" height="44" alt="Screenshot 2025-10-06 at 15 32 49" src="https://github.com/user-attachments/assets/55ccc7cd-7f06-4ec9-8d6f-9896af3acbda" />
