### PR TITLE
chore(.envrc): source the direnv flake-overrides plugin

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -6,6 +6,11 @@ if ! has nix_direnv_version || ! nix_direnv_version 3.1.0; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.0/direnvrc" "sha256-yMJ2OVMzrFaDPn7q8nCBZFRYpL/f0RcHzhmw/i6btJM="
 fi
 
+# See https://direnv-flake-overrides.blocksense.network
+# Allows flake inputs to be easily overridden from your local .env file
+source_url "https://direnv-flake-overrides.blocksense.network/plugin" \
+  "sha256-BTxlsheP/7/FQw9IBPGFc6zYTl5S2qdAAt3EUqfkbjI="
+
 dotenv_if_exists
 
 mkdir -p "$PWD/.devenv"


### PR DESCRIPTION
Sources the [`direnv-nix-flake-overrides`](https://github.com/blocksense-network/direnv-nix-flake-overrides) plugin in `.envrc`, so flake inputs can be overridden from a local `.env` (`NIX_FLAKE_OVERRIDE_INPUTS` / `_SIBLINGS` / `_AUTO`).

Pinned to the current `stable` plugin version:
```
sha256-BTxlsheP/7/FQw9IBPGFc6zYTl5S2qdAAt3EUqfkbjI=
```
(verified against what `direnv-flake-overrides.blocksense.network/plugin` serves).

### Notes
- **Rebased onto current `main`.** The `.envrc` here evolved (nix-direnv 3.1.0, devenv-root) since this change was first drafted, so I ported just the plugin block rather than the old diff.
- **Scope:** this only *sources* the plugin, making its helpers + the `with-local-flake-overrides` leader script available. It does **not** wire overrides into the default `use flake` line. To auto-apply `.env` overrides on every `direnv reload`, line 19 would need `$(flake-override-args-quoted)` appended (via `eval`). Left out as a separate decision — say the word if you want that too.